### PR TITLE
Adding notebook for Dask computation on Coiled Cluster

### DIFF
--- a/notebooks/DaskComputationCoiled.ipynb
+++ b/notebooks/DaskComputationCoiled.ipynb
@@ -1,0 +1,2319 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "8VnZ6zuBOtp3"
+   },
+   "outputs": [],
+   "source": [
+    "# Install packages\n",
+    "\n",
+    "# Remember to Restart runtime after installation\n",
+    "\n",
+    "\n",
+    "!pip install itk==5.3rc4\n",
+    "!pip install vtk\n",
+    "!pip install itkwidgets\n",
+    "!pip install icon-registration==0.3.4\n",
+    "!pip install tornado==6.1\n",
+    "!pip install coiled\n",
+    "!pip install torch\n",
+    "!pip install jupyter\n",
+    "!pip install git+https://github.com/uncbiag/mermaid.git\n",
+    "!pip install git+https://github.com/uncbiag/easyreg.git\n",
+    "!pip install git+https://github.com/PranjalSahu/OAI_analysis_2.git#egg=oai_package"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install git+https://github.com/PranjalSahu/OAI_analysis_2.git#egg=oai_package"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "id": "0w5y-3zBOxkY"
+   },
+   "outputs": [],
+   "source": [
+    "# All Imports\n",
+    "\n",
+    "#import numpy as np\n",
+    "#import itk\n",
+    "#import vtk\n",
+    "import itkwidgets\n",
+    "#import icon_registration\n",
+    "#import icon_registration.itk_wrapper as itk_wrapper\n",
+    "#import icon_registration.pretrained_models as pretrained_models\n",
+    "from oai_analysis_2 import mesh_processing as mp\n",
+    "from oai_analysis_2 import dask_processing as dp\n",
+    "\n",
+    "import os\n",
+    "os.environ[\"CUDA_VISIBLE_DEVICES\"]=\"\"\n",
+    "\n",
+    "#import boto3\n",
+    "#import coiled\n",
+    "#import dask\n",
+    "#from dask import delayed, compute, visualize\n",
+    "#from dask.distributed import Client, progress, LocalCluster"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "D-E-5gV6KX8E"
+   },
+   "outputs": [],
+   "source": [
+    "# Create the environment\n",
+    "\n",
+    "if False:\n",
+    "  coiled.create_software_environment(\n",
+    "    name=\"oai6\",\n",
+    "    pip=\"coiled_requirements.txt\",\n",
+    "  )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 69
+    },
+    "id": "O-pxKPFD2Ld9",
+    "outputId": "4b8d4dcc-2b5b-491d-d531-bfedad3ee87b"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating new software environment\n",
+      "Creating container-only software environment\n",
+      "Successfully saved software environment build\n"
+     ]
+    }
+   ],
+   "source": [
+    "# To create a software environment using docker with open gl installed\n",
+    "# coiled.create_software_environment(\n",
+    "#     name=\"oai6\",\n",
+    "#     container=\"pranjalsahu/pranjal-sahu-oai6:latest\",\n",
+    "# )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 33,
+     "referenced_widgets": [
+      "0fdf3ebec30d4459a90be4314731236d",
+      "c511b4eef0e74cd98b84c8c4e9b2cda5"
+     ]
+    },
+    "id": "2wQIfgkLSMRy",
+    "outputId": "f0063135-18b1-4eaa-f1ba-f5b54eddc6b5"
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0fdf3ebec30d4459a90be4314731236d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Using existing cluster: <span style=\"color: #008000; text-decoration-color: #008000\">'oai-processing'</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "Using existing cluster: \u001b[32m'oai-processing'\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Create Dask Client. This will also spawn dask worker and scheduler\n",
+    "\n",
+    "use_coiled = True\n",
+    "\n",
+    "if use_coiled:\n",
+    "  name = 'oai-processing'\n",
+    "  cluster = coiled.Cluster(n_workers=2,\n",
+    "                         worker_cpu=8,\n",
+    "                         worker_memory='31G',\n",
+    "                         name=name,\n",
+    "                         software='pranjal-sahu/oai6')\n",
+    "  client = dask.distributed.Client(cluster, \n",
+    "                                   serializers=['pickle', 'dask'],\n",
+    "                                   deserializers=['pickle', 'dask'])\n",
+    "  client\n",
+    "else:\n",
+    "  cluster = LocalCluster(processes=False)\n",
+    "  client = Client(cluster)\n",
+    "  client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 161
+    },
+    "id": "YRutouN1Nu-t",
+    "outputId": "36783f91-97bc-4d87-acba-c38fdc03053d"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "    <div style=\"width: 24px; height: 24px; background-color: #e1e1e1; border: 3px solid #9D9D9D; border-radius: 5px; position: absolute;\"> </div>\n",
+       "    <div style=\"margin-left: 48px;\">\n",
+       "        <h3 style=\"margin-bottom: 0px;\">Client</h3>\n",
+       "        <p style=\"color: #9D9D9D; margin-bottom: 0px;\">Client-0cccf874-cc98-11ec-852c-0242ac1c0002</p>\n",
+       "        <table style=\"width: 100%; text-align: left;\">\n",
+       "\n",
+       "        <tr>\n",
+       "        \n",
+       "            <td style=\"text-align: left;\"><strong>Connection method:</strong> Cluster object</td>\n",
+       "            <td style=\"text-align: left;\"><strong>Cluster type:</strong> coiled.Cluster</td>\n",
+       "        \n",
+       "        </tr>\n",
+       "\n",
+       "        \n",
+       "            <tr>\n",
+       "                <td style=\"text-align: left;\">\n",
+       "                    <strong>Dashboard: </strong> <a href=\"http://3.80.217.99:8787\" target=\"_blank\">http://3.80.217.99:8787</a>\n",
+       "                </td>\n",
+       "                <td style=\"text-align: left;\"></td>\n",
+       "            </tr>\n",
+       "        \n",
+       "\n",
+       "        </table>\n",
+       "\n",
+       "        \n",
+       "            <details>\n",
+       "            <summary style=\"margin-bottom: 20px;\"><h3 style=\"display: inline;\">Cluster Info</h3></summary>\n",
+       "            <div class=\"jp-RenderedHTMLCommon jp-RenderedHTML jp-mod-trusted jp-OutputArea-output\">\n",
+       "    <div style=\"width: 24px; height: 24px; background-color: #e1e1e1; border: 3px solid #9D9D9D; border-radius: 5px; position: absolute;\">\n",
+       "    </div>\n",
+       "    <div style=\"margin-left: 48px;\">\n",
+       "        <h3 style=\"margin-bottom: 0px; margin-top: 0px;\">Cluster</h3>\n",
+       "        <p style=\"color: #9D9D9D; margin-bottom: 0px;\">oai-processing</p>\n",
+       "        <table style=\"width: 100%; text-align: left;\">\n",
+       "            <tr>\n",
+       "                <td style=\"text-align: left;\">\n",
+       "                    <strong>Dashboard:</strong> <a href=\"http://3.80.217.99:8787\" target=\"_blank\">http://3.80.217.99:8787</a>\n",
+       "                </td>\n",
+       "                <td style=\"text-align: left;\">\n",
+       "                    <strong>Workers:</strong> 2\n",
+       "                </td>\n",
+       "            </tr>\n",
+       "            <tr>\n",
+       "                <td style=\"text-align: left;\">\n",
+       "                    <strong>Total threads:</strong> 16\n",
+       "                </td>\n",
+       "                <td style=\"text-align: left;\">\n",
+       "                    <strong>Total memory:</strong> 61.48 GiB\n",
+       "                </td>\n",
+       "            </tr>\n",
+       "            \n",
+       "        </table>\n",
+       "\n",
+       "        <details>\n",
+       "            <summary style=\"margin-bottom: 20px;\">\n",
+       "                <h3 style=\"display: inline;\">Scheduler Info</h3>\n",
+       "            </summary>\n",
+       "\n",
+       "            <div style=\"\">\n",
+       "    <div>\n",
+       "        <div style=\"width: 24px; height: 24px; background-color: #FFF7E5; border: 3px solid #FF6132; border-radius: 5px; position: absolute;\"> </div>\n",
+       "        <div style=\"margin-left: 48px;\">\n",
+       "            <h3 style=\"margin-bottom: 0px;\">Scheduler</h3>\n",
+       "            <p style=\"color: #9D9D9D; margin-bottom: 0px;\">Scheduler-0760b654-375f-4759-af1f-7ce3779130c3</p>\n",
+       "            <table style=\"width: 100%; text-align: left;\">\n",
+       "                <tr>\n",
+       "                    <td style=\"text-align: left;\">\n",
+       "                        <strong>Comm:</strong> tls://10.0.0.85:8786\n",
+       "                    </td>\n",
+       "                    <td style=\"text-align: left;\">\n",
+       "                        <strong>Workers:</strong> 2\n",
+       "                    </td>\n",
+       "                </tr>\n",
+       "                <tr>\n",
+       "                    <td style=\"text-align: left;\">\n",
+       "                        <strong>Dashboard:</strong> <a href=\"http://10.0.0.85:8787/status\" target=\"_blank\">http://10.0.0.85:8787/status</a>\n",
+       "                    </td>\n",
+       "                    <td style=\"text-align: left;\">\n",
+       "                        <strong>Total threads:</strong> 16\n",
+       "                    </td>\n",
+       "                </tr>\n",
+       "                <tr>\n",
+       "                    <td style=\"text-align: left;\">\n",
+       "                        <strong>Started:</strong> 9 minutes ago\n",
+       "                    </td>\n",
+       "                    <td style=\"text-align: left;\">\n",
+       "                        <strong>Total memory:</strong> 61.48 GiB\n",
+       "                    </td>\n",
+       "                </tr>\n",
+       "            </table>\n",
+       "        </div>\n",
+       "    </div>\n",
+       "\n",
+       "    <details style=\"margin-left: 48px;\">\n",
+       "        <summary style=\"margin-bottom: 20px;\">\n",
+       "            <h3 style=\"display: inline;\">Workers</h3>\n",
+       "        </summary>\n",
+       "\n",
+       "        \n",
+       "        <div style=\"margin-bottom: 20px;\">\n",
+       "            <div style=\"width: 24px; height: 24px; background-color: #DBF5FF; border: 3px solid #4CC9FF; border-radius: 5px; position: absolute;\"> </div>\n",
+       "            <div style=\"margin-left: 48px;\">\n",
+       "            <details>\n",
+       "                <summary>\n",
+       "                    <h4 style=\"margin-bottom: 0px; display: inline;\">Worker: coiled-dask-pranjal09-152383-worker-7fd143b21f</h4>\n",
+       "                </summary>\n",
+       "                <table style=\"width: 100%; text-align: left;\">\n",
+       "                    <tr>\n",
+       "                        <td style=\"text-align: left;\">\n",
+       "                            <strong>Comm: </strong> tls://10.0.0.218:34367\n",
+       "                        </td>\n",
+       "                        <td style=\"text-align: left;\">\n",
+       "                            <strong>Total threads: </strong> 8\n",
+       "                        </td>\n",
+       "                    </tr>\n",
+       "                    <tr>\n",
+       "                        <td style=\"text-align: left;\">\n",
+       "                            <strong>Dashboard: </strong> <a href=\"http://10.0.0.218:44941/status\" target=\"_blank\">http://10.0.0.218:44941/status</a>\n",
+       "                        </td>\n",
+       "                        <td style=\"text-align: left;\">\n",
+       "                            <strong>Memory: </strong> 30.74 GiB\n",
+       "                        </td>\n",
+       "                    </tr>\n",
+       "                    <tr>\n",
+       "                        <td style=\"text-align: left;\">\n",
+       "                            <strong>Nanny: </strong> tls://10.0.0.218:32795\n",
+       "                        </td>\n",
+       "                        <td style=\"text-align: left;\"></td>\n",
+       "                    </tr>\n",
+       "                    <tr>\n",
+       "                        <td colspan=\"2\" style=\"text-align: left;\">\n",
+       "                            <strong>Local directory: </strong> /dask-worker-space/worker-2h63xzwp\n",
+       "                        </td>\n",
+       "                    </tr>\n",
+       "\n",
+       "                    \n",
+       "\n",
+       "                    \n",
+       "\n",
+       "                </table>\n",
+       "            </details>\n",
+       "            </div>\n",
+       "        </div>\n",
+       "        \n",
+       "        <div style=\"margin-bottom: 20px;\">\n",
+       "            <div style=\"width: 24px; height: 24px; background-color: #DBF5FF; border: 3px solid #4CC9FF; border-radius: 5px; position: absolute;\"> </div>\n",
+       "            <div style=\"margin-left: 48px;\">\n",
+       "            <details>\n",
+       "                <summary>\n",
+       "                    <h4 style=\"margin-bottom: 0px; display: inline;\">Worker: coiled-dask-pranjal09-152383-worker-f46a11c2fc</h4>\n",
+       "                </summary>\n",
+       "                <table style=\"width: 100%; text-align: left;\">\n",
+       "                    <tr>\n",
+       "                        <td style=\"text-align: left;\">\n",
+       "                            <strong>Comm: </strong> tls://10.0.4.47:33463\n",
+       "                        </td>\n",
+       "                        <td style=\"text-align: left;\">\n",
+       "                            <strong>Total threads: </strong> 8\n",
+       "                        </td>\n",
+       "                    </tr>\n",
+       "                    <tr>\n",
+       "                        <td style=\"text-align: left;\">\n",
+       "                            <strong>Dashboard: </strong> <a href=\"http://10.0.4.47:37427/status\" target=\"_blank\">http://10.0.4.47:37427/status</a>\n",
+       "                        </td>\n",
+       "                        <td style=\"text-align: left;\">\n",
+       "                            <strong>Memory: </strong> 30.74 GiB\n",
+       "                        </td>\n",
+       "                    </tr>\n",
+       "                    <tr>\n",
+       "                        <td style=\"text-align: left;\">\n",
+       "                            <strong>Nanny: </strong> tls://10.0.4.47:35227\n",
+       "                        </td>\n",
+       "                        <td style=\"text-align: left;\"></td>\n",
+       "                    </tr>\n",
+       "                    <tr>\n",
+       "                        <td colspan=\"2\" style=\"text-align: left;\">\n",
+       "                            <strong>Local directory: </strong> /dask-worker-space/worker-n62u0x3u\n",
+       "                        </td>\n",
+       "                    </tr>\n",
+       "\n",
+       "                    \n",
+       "\n",
+       "                    \n",
+       "\n",
+       "                </table>\n",
+       "            </details>\n",
+       "            </div>\n",
+       "        </div>\n",
+       "        \n",
+       "\n",
+       "    </details>\n",
+       "</div>\n",
+       "\n",
+       "        </details>\n",
+       "    </div>\n",
+       "</div>\n",
+       "            </details>\n",
+       "        \n",
+       "\n",
+       "    </div>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "<Client: 'tls://10.0.0.85:8786' processes=2 threads=16, memory=61.48 GiB>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 17,
+     "referenced_widgets": [
+      "ef35542d83fd4a6eb38d062367658a23",
+      "7c6a6eaedaf1455e9e4ce6e9bb2fc7b2",
+      "35f0646f5ded451d99e92a7c74e9486e",
+      "04433edc426a4ba99ba1d3a937f42d15",
+      "54ee4db13cab4eebada9fe0ebc9dba3c",
+      "e58a8323c0b64d82a5fa75377cf46e50",
+      "89cfc99bacb3424983f0127b1065c98b",
+      "9e81c59ecf804e56af1c69f30fda8cf9",
+      "641ae4f0ec3a4d78858476edec985aa0",
+      "57cb38340f6f4d3ab264f2d2632dea0c",
+      "41aceabecac9409ca3cd650811e5b81c",
+      "5a2b742a85db450980d791c0d30ec0bd",
+      "95f476e89c704ea2b99117c533506201",
+      "67040281464e48f29e7bb370c7994cc3",
+      "1756413d3140403a8b76e05a0e866375",
+      "5af73d4418724958af448bb859c5104f",
+      "4b8ceab0cbf144be98d10b01fb4c6401",
+      "3fbd04438ff14c56b54242a5270f7abb",
+      "e8b95ef0e41c47a4a1144699015e17fd",
+      "bf2ddee8d91e41698fda46f6fea7de6b",
+      "82eade6e25264c058e9a3e00e8a291a0",
+      "c9d8794770314d9f9477af9179f02cee",
+      "6d320e968b5a41dcb994108cc4d95e50",
+      "06f88296a85a4161b62436df3bdbe371",
+      "524f7dc765484bc1bde0936c51a13fcf",
+      "5c3a8f89501747de8a2d87347077af33",
+      "8230507bb71d4e8fb7f1a79cf5e31036"
+     ]
+    },
+    "id": "qE__24JAckLS",
+    "outputId": "11f6162e-37b5-47ec-dd7f-76f26a0b3bb2"
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ef35542d83fd4a6eb38d062367658a23",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Tab(children=(HTML(value='<div class=\"jp-RenderedHTMLCommon jp-RenderedHTML jp-mod-trusted jp-OutputArea-outpu…"
+      ]
+     },
+     "metadata": {
+      "application/vnd.jupyter.widget-view+json": {
+       "colab": {
+        "custom_widget_manager": {
+         "url": "https://ssl.gstatic.com/colaboratory-static/widgets/colab-cdn-widget-manager/a8874ba6619b6106/manager.min.js"
+        }
+       }
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "cluster"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "code_folding": [
+     0
+    ],
+    "id": "2HbtL8r4TiKb"
+   },
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'delayed' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m/tmp/ipykernel_186247/4048742253.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# All Function Definitions with Dask Delayed Decorator to perform parallel Computing\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 3\u001b[0;31m \u001b[0;34m@\u001b[0m\u001b[0mdelayed\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mnout\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m3\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      4\u001b[0m \u001b[0;32mdef\u001b[0m \u001b[0mregister_images_delayed\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m     \u001b[0;32mimport\u001b[0m \u001b[0mboto3\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'delayed' is not defined"
+     ]
+    }
+   ],
+   "source": [
+    "# All Function Definitions with Dask Delayed Decorator to perform parallel Computing\n",
+    "\n",
+    "@delayed(nout=3)\n",
+    "def register_images_delayed():\n",
+    "    import boto3\n",
+    "    import itk\n",
+    "    import icon_registration\n",
+    "    import icon_registration.itk_wrapper as itk_wrapper\n",
+    "    import icon_registration.pretrained_models as pretrained_models\n",
+    "    from os.path import exists\n",
+    "\n",
+    "    if 1:\n",
+    "        image_A = 'image_preprocessed.nii.gz'\n",
+    "        image_B = 'atlas_image.nii.gz'\n",
+    "        if (exists(image_A) and exists(image_B)) == False:\n",
+    "          s3          = boto3.resource(\"s3\")\n",
+    "          bucket_name = 'oaisample1'\n",
+    "          bucket      = s3.Bucket(bucket_name)\n",
+    "\n",
+    "          s3.Bucket(bucket_name).download_file(image_A, image_A)\n",
+    "          s3.Bucket(bucket_name).download_file(image_B, image_B)\n",
+    "    else:\n",
+    "        image_A = './OAIData/image_preprocessed.nii.gz'\n",
+    "        image_B = './OAIData/atlas_image.nii.gz'\n",
+    "\n",
+    "    image_A = itk.imread(image_A, itk.D)\n",
+    "    image_B = itk.imread(image_B, itk.D)\n",
+    "\n",
+    "    model = pretrained_models.OAI_knees_gradICON_model()\n",
+    "    model.to('cpu')\n",
+    "\n",
+    "    # Register the images\n",
+    "    phi_AB, phi_BA = itk_wrapper.register_pair(model, image_A, image_B)\n",
+    "    return itk.dict_from_transform(phi_AB), itk.dict_from_image(image_A), itk.dict_from_image(image_B)\n",
+    "\n",
+    "@delayed(nout=1)\n",
+    "def deform_probmap_FC_delayed(phi_AB, image_A, image_B):\n",
+    "    import itk\n",
+    "    import boto3\n",
+    "\n",
+    "    if 1:\n",
+    "        s3          = boto3.resource(\"s3\")\n",
+    "        bucket_name = 'oaisample1'\n",
+    "        bucket      = s3.Bucket(bucket_name)\n",
+    "        fc_prob_file = 'FC_probmap.nii.gz'\n",
+    "        s3.Bucket(bucket_name).download_file(fc_prob_file, fc_prob_file)\n",
+    "\n",
+    "    phi_AB1  = itk.transform_from_dict(phi_AB)\n",
+    "    \n",
+    "    def set_parameters(phi_AB, phi_AB1):\n",
+    "        for i in range(len(phi_AB)-1):\n",
+    "            transform1 = phi_AB1.GetNthTransform(i)\n",
+    "\n",
+    "            fp = phi_AB[i+1]['fixedParameters']\n",
+    "            o1 = transform1.GetFixedParameters()\n",
+    "            o1.SetSize(fp.shape[0])\n",
+    "            for j, v in enumerate(fp):\n",
+    "                o1.SetElement(j, v)\n",
+    "            transform1.SetFixedParameters(o1)\n",
+    "\n",
+    "            p = phi_AB[i+1]['parameters']\n",
+    "            o2 = transform1.GetParameters()\n",
+    "            o2.SetSize(p.shape[0])\n",
+    "            for j, v in enumerate(p):\n",
+    "                o2.SetElement(j, v)\n",
+    "            transform1.SetParameters(o2)\n",
+    "\n",
+    "    set_parameters(phi_AB, phi_AB1)\n",
+    "    image_A = itk.image_from_dict(image_A)\n",
+    "    image_B = itk.image_from_dict(image_B)\n",
+    "\n",
+    "    interpolator = itk.LinearInterpolateImageFunction.New(image_A)\n",
+    "    \n",
+    "    prob_file = 'FC_probmap.nii.gz'\n",
+    "    prob = itk.imread(prob_file, itk.D)\n",
+    "\n",
+    "    warped_image = itk.resample_image_filter(prob, \n",
+    "       transform=phi_AB1, \n",
+    "       interpolator=interpolator,\n",
+    "       size=itk.size(image_B),\n",
+    "       output_spacing=itk.spacing(image_B),\n",
+    "       output_direction=image_B.GetDirection(),\n",
+    "       output_origin=image_B.GetOrigin()\n",
+    "    )\n",
+    "\n",
+    "    output_dict = itk.dict_from_image(warped_image)\n",
+    "    return output_dict\n",
+    "  \n",
+    "@delayed\n",
+    "def deform_probmap_delayed(phi_AB, image_A, image_B, image_type ='FC'):\n",
+    "    import itk\n",
+    "    import boto3\n",
+    "\n",
+    "    if 1:\n",
+    "        s3          = boto3.resource(\"s3\")\n",
+    "        bucket_name = 'oaisample1'\n",
+    "        bucket      = s3.Bucket(bucket_name)\n",
+    "        fc_prob_file = str(image_type)+'_probmap.nii.gz'\n",
+    "        s3.Bucket(bucket_name).download_file(fc_prob_file, fc_prob_file)\n",
+    "\n",
+    "    phi_AB1  = itk.transform_from_dict(phi_AB)\n",
+    "    \n",
+    "    def set_parameters(phi_AB, phi_AB1):\n",
+    "        for i in range(len(phi_AB)-1):\n",
+    "            transform1 = phi_AB1.GetNthTransform(i)\n",
+    "\n",
+    "            fp = phi_AB[i+1]['fixedParameters']\n",
+    "            o1 = transform1.GetFixedParameters()\n",
+    "            o1.SetSize(fp.shape[0])\n",
+    "            for j, v in enumerate(fp):\n",
+    "                o1.SetElement(j, v)\n",
+    "            transform1.SetFixedParameters(o1)\n",
+    "\n",
+    "            p = phi_AB[i+1]['parameters']\n",
+    "            o2 = transform1.GetParameters()\n",
+    "            o2.SetSize(p.shape[0])\n",
+    "            for j, v in enumerate(p):\n",
+    "                o2.SetElement(j, v)\n",
+    "            transform1.SetParameters(o2)\n",
+    "\n",
+    "    set_parameters(phi_AB, phi_AB1)\n",
+    "    image_A = itk.image_from_dict(image_A)\n",
+    "    image_B = itk.image_from_dict(image_B)\n",
+    "\n",
+    "    interpolator = itk.LinearInterpolateImageFunction.New(image_A)\n",
+    "    \n",
+    "    prob_file = str(image_type)+'_probmap.nii.gz'\n",
+    "    prob = itk.imread(prob_file, itk.D)\n",
+    "\n",
+    "    warped_image = itk.resample_image_filter(prob, \n",
+    "       transform=phi_AB1, \n",
+    "       interpolator=interpolator,\n",
+    "       size=itk.size(image_B),\n",
+    "       output_spacing=itk.spacing(image_B),\n",
+    "       output_direction=image_B.GetDirection(),\n",
+    "       output_origin=image_B.GetOrigin()\n",
+    "    )\n",
+    "\n",
+    "    output_dict = itk.dict_from_image(warped_image)\n",
+    "    return output_dict\n",
+    "    \n",
+    "\n",
+    "@delayed(nout=1)\n",
+    "def get_thickness(warped_image, mesh_type):\n",
+    "    import itk\n",
+    "    import vtk\n",
+    "    import numpy as np\n",
+    "    from oai_analysis_2 import mesh_processing as mp\n",
+    "\n",
+    "    def get_itk_mesh(vtk_mesh):\n",
+    "        Dimension = 3\n",
+    "        PixelType = itk.D\n",
+    "        \n",
+    "        # Get points array from VTK mesh\n",
+    "        points = vtk_mesh.GetPoints().GetData()\n",
+    "        points_numpy = np.array(points).flatten()#.astype('float32')\n",
+    "            \n",
+    "        polys = vtk_mesh.GetPolys().GetData()\n",
+    "        polys_numpy = np.array(polys).flatten()\n",
+    "\n",
+    "        # Triangle Mesh\n",
+    "        vtk_cells_count = vtk_mesh.GetNumberOfPolys()\n",
+    "        polys_numpy = np.reshape(polys_numpy, [vtk_cells_count, Dimension+1])\n",
+    "\n",
+    "        # Extracting only the points by removing first column that denotes the VTK cell type\n",
+    "        polys_numpy = polys_numpy[:, 1:]\n",
+    "        polys_numpy = polys_numpy.flatten().astype(np.uint64)\n",
+    "\n",
+    "        # Get point data from VTK mesh to insert in ITK Mesh\n",
+    "        point_data_numpy = np.array(vtk_mesh.GetPointData().GetScalars())#.astype('float64')\n",
+    "        \n",
+    "        # Get cell data from VTK mesh to insert in ITK Mesh\n",
+    "        cell_data_numpy = np.array(vtk_mesh.GetCellData().GetScalars())#.astype('float64')\n",
+    "        \n",
+    "        MeshType = itk.Mesh[PixelType, Dimension]\n",
+    "        itk_mesh = MeshType.New()\n",
+    "        \n",
+    "        itk_mesh.SetPoints(itk.vector_container_from_array(points_numpy))\n",
+    "        itk_mesh.SetCellsArray(itk.vector_container_from_array(polys_numpy), itk.CommonEnums.CellGeometry_TRIANGLE_CELL)\n",
+    "        itk_mesh.SetPointData(itk.vector_container_from_array(point_data_numpy))\n",
+    "        itk_mesh.SetCellData(itk.vector_container_from_array(cell_data_numpy))    \n",
+    "        return itk_mesh\n",
+    "\n",
+    "    warped_image = itk.image_from_dict(warped_image)\n",
+    "    distance_inner, distance_outer = mp.get_thickness_mesh(warped_image, mesh_type=mesh_type)\n",
+    "    \n",
+    "    polys = distance_inner.GetPolys().GetData()\n",
+    "    polys_numpy = np.array(polys).flatten()\n",
+    "\n",
+    "    distance_inner_itk = get_itk_mesh(distance_inner)\n",
+    "    distance_inner_itk_dict = itk.dict_from_mesh(distance_inner_itk)\n",
+    "\n",
+    "    return distance_inner_itk_dict"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "t6irlumR7ctq",
+    "outputId": "9e1f17df-3050-4462-b196-3569b8abaf4b"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "('0.18.3',)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# For checking if vtk import works properly\n",
+    "\n",
+    "@delayed\n",
+    "def check_vtk():\n",
+    "  import vtk\n",
+    "  return vtk.__version__\n",
+    "\n",
+    "@delayed\n",
+    "def check_skimage():\n",
+    "  import skimage\n",
+    "  return skimage.__version__\n",
+    "\n",
+    "t1 = check_skimage()\n",
+    "output_result = compute(t1)\n",
+    "print(output_result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dask import compute, visualize"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "snuntUuOBLqV",
+    "outputId": "663f29ae-b412-495d-bc20-cd6f64eaf95c"
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "marching_cubes_lewiner is deprecated in favor of marching_cubes. marching_cubes_lewiner will be removed in version 0.19\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Main execution block\n",
+    "\n",
+    "phi_AB, image_A, image_B = dp.register_images_delayed()\n",
+    "deformed_fc = dp.deform_probmap_delayed(phi_AB, image_A, image_B, 'FC')\n",
+    "deformed_tc = dp.deform_probmap_delayed(phi_AB, image_A, image_B, 'TC')\n",
+    "\n",
+    "thickness_fc = dp.get_thickness(deformed_fc, 'FC')\n",
+    "thickness_tc = dp.get_thickness(deformed_tc, 'TC')\n",
+    "\n",
+    "result = [thickness_fc, thickness_tc]\n",
+    "output_result = compute(*result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phi_AB, image_A, image_B = dp.register_images_delayed()\n",
+    "deformed_fc = dp.deform_probmap_delayed(phi_AB, image_A, image_B, 'FC')\n",
+    "deformed_tc = dp.deform_probmap_delayed(phi_AB, image_A, image_B, 'TC')\n",
+    "\n",
+    "thickness_fc = dp.get_thickness(deformed_fc, 'FC')\n",
+    "thickness_tc = dp.get_thickness(deformed_tc, 'TC')\n",
+    "\n",
+    "result = [thickness_fc, thickness_tc]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 1000
+    },
+    "id": "qI8mWKz8RTAx",
+    "outputId": "a370a6e5-b3de-4fab-e253-6491d7d022cd"
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAs0AAAXxCAIAAADtMjKOAAAABmJLR0QA/wD/AP+gvaeTAAAgAElEQVR4nOzdd1xT5+IG8BP2EBAZ1rpApYpMKyBLVGSqFa2Cq45Wxd5q6+1Vq7W12p92WK1aR1sVtUxlKSojFtlbQWSJoEBQQWSIbEhI8vsjvdarFhcn70nyfP/oR5LA+6TAy3PWe1hCoZACAAAAoIEc6QAAAAAgtdAzAAAAgC7oGQAAAEAXBdIB4AWuXr1aVVVFOgUthgwZMnnyZNIpAKRfXV1damoq6RR0ef/99xUU8LeMufC9Ybrffvvt1KlTpFPQwt3dnc1mk04BIP2uX7++YMEC0ino0tLSoqmpSToF/CMcN5EA7u7uQqnz4Ycfkv7/CiBbWlpaSP/e97O4uDjS/1PhxdAzAAAAgC7oGQAAAEAX9AwAAACgC3oGAAAA0AU9AwAAAOiCngEAAAB0Qc8AAAAAuqBnAAAAAF3QMwAAAIAu6BkAAABAF/QMAAAAoAt6BgAAANAFPQMAAADogp4BAAAAdEHPAAAAALqgZwAAAABd0DMAAACALugZAAAAQBf0DAAAAKALegYAAADQBT0DAAAA6IKeAQAAAHRBzwAAAAC6oGcAAAAAXdAzAAAAgC7oGQAAAEAX9AwAAACgC3oGAAAA0AU9AwAAAOiCngEAAAB0Qc8AAAAAuqBnAAAAAF3QMwAAAIAu6BkAAABAF/QMAAAAoAt6BgAAANAFPQMAAADogp4BAAAAdEHPAAAAALqgZwAAAABd0DMAAACALugZAAAAQBf0DAAAAKALegYAAADQBT0D/odQKCQdAQAkG6YReJIC6QDwYnV1dWFhYWIYqLa29tGjR+PHjxfDWBwOR0lJSQwDAYDIuXPnVFVVxTBQfHy8q6urGAYqKCgQwyjwhtAzJEBBQcGCBQtIp+h/7u7upCMAyJAVK1aIbSw/Pz+xjQUMx8IOLnhs1KhRTU1NDQ0N2NMAAK9n27Ztu3btio2N9fT0JJ0FGAHnZ8Bf8vLyqqqqWltbL126RDoLAEgkoVAYEBBAUVRISAjpLMAU6Bnwl5CQECUlJQUFheDgYNJZAEAi5eTk3Llzh6KoiIiIjo4O0nGAEdAzgKIoSiAQBAcHc7nc3t7eqKio9vZ20okAQPKcPn1adNS1p6cnJiaGdBxgBPQMoCiKSk1NffDggejfPB7vwoULZPMAgMQRCAQhISFcLpeiKHl5+aCgINKJgBHQM4CiKCokJERRUVH0bxaLFRgYSDYPAEicxMTExsZG0b97e3vj4uIePnxINhIwAXoGUDweLzQ0lMfjiT7k8/nx8fFNTU1kUwGAZBGd4/X4Q6FQGBUVRTAPMAR6BlBsNru1tfWpByMiIoiEAQBJ1NPTEx4eLjpoIiIUCrFnFCj0DKAoKjg4+PFBE5HHF6cBALyM2NjYpy4wEQgEKSkpNTU1pCIBQ6BnyLrOzs7z588/PmgiIhAIsrKy7t27RyoVAEiW4OBgBYWnF5iWl5fHnlFAz5B1UVFRPT09zz6uoKAQGhoq/jwAIHHa2touXrz41OYKRVF8Pt/f359IJGAO9AxZFxQUJCf3nB+D3t5eTBAA8DLOnTvX29v77ONCoTA/P//WrVvijwTMgZ4h0x4+fBgfH8/n8599SigUFhUVlZWViT8VAEiWoKCgf7pVFovFwp5RGYeeIdNiY2PV1NQG/JeKioqysvLjDzU1NbFgFwD0rbm5OT8/X11dXTRvqKmpKSoqDngCm80mnRFIwv1a4W8rV66sra2Ni4sjHQQAJBWbzfb09GxpadHU1CSdBRgB+zMAAACALugZAAAAQBf0DAAAAKALegYAAADQBT0DAAAA6IKeAQAAAHRBzwAAAAC6oGcAAAAAXdAzAAAAgC7oGQAAAEAX9AwAAACgC3oGAAAA0AU9AwAAAOiCngEAAAB0Qc8AAAAAuqBnAAAAAF3QMwAAAIAu6BkAAABAF/QMAAAAoAt6BgAAANAFPQMAAADogp4BAAAAdEHPAAAAALqgZwAAAABd0DMAAACALugZAAAAQBf0DAAAAKALegYAAADQBT0DAAAA6IKeAQAAAHRBzwAAAAC6oGfA37hcLo/HEwqFpIMAgKTq7u6mKKqnp4d0EGAKFv6oSD2BQHD//v2qqioOh8PhcGpraxsbGxsbG5uampqamjo7Ozs6Orhc7lOfpaCgoKGhoaKioqOjo6Ojo6urq6urO2TIEENDQwMDAwMDg6FDh8rLy5N4QwBAQHNzs2gOqa6u5nA4Tf/V2NjY3NzM4/Ha29uf/ayBAwcqKCjoPEFfX180h4wcOdLQ0FBVVVX87wXECT1DCtXV1RUWFhYUFBQWFhYVFZWWlopqhJKS0ogRI4YNG6ajo6Onp6erq6ujo6OmpjZgwABFRUWKorS0tOTk5JqbmymK4vP5ra2tXV1dj6eShoaG2tpaDocj2lJRVFQ0MjIyMzOzsLAwNzc3NzcfPnw42TcOAP2lo6OjuLj48TRSVFQkmhkoihoyZIiBgYFoAhFtgWhraysrK6upqVEUpaampqys/HjrpbW1lcvlPp5Gmpqa6urqOBzO4682bNgwU1NT0TRiZmZmbGysoKBA6l0DHdAzpAGfzy8pKUlPT8/MzMzIyOBwOBRFDR061MzMzNzc3MTEZNSoUQYGBm+//bac3JseKRMKhffv3xdt1hQXF4smoOrqatGIDg4O9vb2Dg4OlpaWmCwAJEtNTU1GRkZGRkZmZub169d7e3s1NDRMTU1FM8no0aNF+yFUVFTefKyWlhbRNFJWVvZ4i4jH46mrq0+aNEk0k9jZ2Wlpab35WEAWeoYEq6urY7PZbDY7Pj7+4cOHmpqadnZ29vb29vb2EyZM0NHREVuSlpaWgoICUcvJzMx8+PChhoaGi4uLh4eHh4fHiBEjxJYEAF5JV1dXampqXFxcXFxceXm5goKChYWF6M+8tbW1oaEhi8USTxIej1daWnrlyhXRJtOtW7fk5eWtra09PT09PDysrKzefDMJiEDPkDxlZWWhoaFRUVHXr19XVlZ2cnLy8PCYPn26iYkJE06YEAqFpaWlycnJcXFxSUlJHR0dJiYmXl5ePj4+FhYWpNMBAEVRVHNzc1RUVERERFJSUldXl7m5uYeHh5ub26RJkwYMGEA6HUVRVH19fVpa2qVLl+Li4u7du6enp+fp6ent7e3m5qakpEQ6HbwC9AyJUVFRERoaGhYWVlBQ8NZbb82dO3fmzJnTpk0THRNlpp6enrS0tNjY2LNnz1ZXV48dO9bHx2fhwoXjx48nHQ1AFrW1tUVFRYWGhsbHx8vJybm7u8+aNcvT03Po0KGko/WlqKiIzWZHRUVlZWUNHDhwzpw5Pj4+Li4uODgrEdAzmI7L5Z4/f/7YsWMJCQna2tozZ8709vb29PSUuF+wkpKS8PDwwMDAysrKiRMn+vr6Ll68mCFbTgBSLy8v79ixYyEhIV1dXba2tsuWLVuwYIHEnf1w7969yMjI8PDwzMzMt956a9myZb6+vqNGjSKdC/qCnsFcFRUVR44cCQwMfPTo0cyZM1evXu3h4cGEIyNvQiAQJCcn+/n5nT17VllZefHixWvXrjU1NSWdC0A6tbe3+/v7Hzt2rLCw0MzMbPXq1R988IG2tjbpXG+qsrLyxIkTp06devDggaur65o1a7y8vHACB0MJgXkyMjLmzZsnJydnYGCwa9eumpoa0on6X2Nj4759+8aNG8disTw8POLj40knApAqtbW1X375pba2tpqa2kcffZSVlUU6Uf/j8XhRUVEzZsyQk5MbM2bMkSNHOjo6SIeCp6FnMIhAIDh//rydnR1FUTY2NqGhob29vaRD0UsgEMTExDg7O1MUZWFhERwczOfzSYcCkGxlZWXLly9XUlIaPHjwzp07GxsbSSeiXVlZ2Zo1a1RVVXV0dLZt29bU1EQ6EfwNPYMp4uLirK2tWSzW7NmzU1NTSccRt7y8vEWLFsnLy5uYmISHhwsEAtKJACRPRUXF8uXLFRQUxo0b5+fn193dTTqRWNXX1+/YsUNHR0dLS2vHjh2PHj0inQiEQvQMJkhOTnZwcKAoaubMmXl5eaTjkFRaWrpgwQI5OTlLS8uLFy+SjgMgMe7du+fr66uoqDhmzJiAgACp3xXah9bW1v/7v/8bOHDgoEGDvv/+exxJIQ49g6SKior333+foihXV1epPHr6egoLC+fOnctisVxdXYuLi0nHAWC0zs7OnTt3qqurjxw58sSJE6JbIUJzc/PXX3+toaExYsSI06dPYxcpQegZZLS3t2/fvl1FReWdd97Bhvtz5eTk2NraKigo+Pr61tfXk44DwEQXLlwwNDRUU1Pbvn17V1cX6TiM09DQ8Nlnn8nLy9vY2GRmZpKOI6PQMwiIiooaOnSotrb2/v37uVwu6TjMxefz/fz8Bg8erKurGxAQQDoOAINUVFRMnz6dxWItX75cKi9J60dXr151cHCQk5Nbt25da2sr6TgyBz1DrO7fv+/t7U1R1NKlSxsaGkjHkQwtLS3r1q0TrV1YVVVFOg4AYb29vXv37lVTUzM1NcXx1pckEAj8/f11dXWHDx8eHR1NOo5swaom4hMQEDB+/PirV6+y2eyAgABdXV3SiSSDpqbmoUOH0tLS7t69a2pqevDgQSEWlwNZVVxcbGtr+9VXX23ZsiUvL8/W1pZ0IsnAYrGWLVt248YNJyenWbNmLV68uKmpiXQoWYGeIQ7Nzc0+Pj4ffvjhsmXLiouL3d3dSSeSPPb29vn5+Zs2bdq4caOHh8f9+/dJJwIQK6FQePDgQWtrayUlpfz8/G3btuF2Yq9KT08vKCgoNjY2PT3dwsIiISGBdCKZgJ5Bu6SkJHNz89TU1Ojo6AMHDqirq5NOJKmUlJS2b9+emZnJ4XDMzc2joqJIJwIQk/r6+tmzZ2/YsGH9+vXJycnGxsakE0kwT0/PoqKiqVOnurq6rl+/vqenh3QiKYeeQSM+n//111+7uLjY2NiUlJR4enqSTiQNrKys8vLyvLy85s6du3btWi6XSzoRAL3i4+NNTU1LS0vT0tJ+/PFHRUVF0okknpaWVlBQ0MmTJ0+dOmVnZ1dZWUk6kTRDz6BLU1PTjBkzfv75599++y0yMlJHR4d0IukxYMAAPz+/sLCwwMDAKVOm1NTUkE4EQAuhUPjDDz94enq6uLjk5+fjbIz+tWLFivz8fIqirKys4uLiSMeRWugZtLh+/bq1tfWNGzeSk5N9fX1Jx5FO3t7eubm5bW1tlpaWOM4K0qetrc3Hx+ebb7757rvvQkJCNDQ0SCeSQqNHj87MzHz//fdnzpy5ZcsWgUBAOpEUQs/of2FhYXZ2dqNGjbp27dqkSZNIx5Fm77zzTlZW1pQpUzw8PH7//XfScQD6TWVl5aRJk9LS0hISEjZv3kw6jjRTUVHx8/M7dOjQ/v3758+f39nZSTqRtEHP6Ge7d+9euHChr6/vpUuX9PT0SMeRfhoaGuHh4d98880nn3zyxRdfYHMEpEBOTo6dnZ2KikpeXp6TkxPpODJh7dq1CQkJqamp06ZNe/DgAek4UoWFpQj6C5/P/+yzz44ePfrdd99h+0P8wsPDly1bNmPGjKCgIFVVVdJxAF7TuXPnPvjgA0dHx/DwcE1NTdJxZEtlZeWMGTN6enpiY2NxUU9/wf6M/tHV1eXl5eXv7x8ZGYmSQYS3tzebzU5KSnJzc2tpaSEdB+B1/Prrr/Pnz1+xYkVsbCxKhviNGjUqPT196NChDg4OWVlZpONICfSMftDR0TFr1qysrKzExEQvLy/ScWTXlClTMjIyqqqqpk+f3tjYSDoOwKvZu3fvunXrdu7ceeTIEXl5edJxZJSuru7ly5cnT57s5uaWmJhIOo40QM94Uy0tLW5ubsXFxYmJiTY2NqTjyDpjY+P09PRHjx45OTnheleQILt37/7iiy/27du3detW0llknYqKytmzZ99///0ZM2ZgPcA3h/Mz3khzc7Orq2tdXd3ly5fHjRtHOg785d69ey4uLnw+Pzk5eejQoaTjALzAli1b9uzZc/To0VWrVpHOAn/h8/m+vr5BQUFnzpyZO3cu6TgSDD3j9bW1tbm5udXU1CQnJ48aNYp0HPgfDx48cHZ2FggEKSkp+vr6pOMA/KMdO3bs3LnT39//gw8+IJ0F/odQKFy7du2JEyeioqKwoPNrQ894TV1dXTNmzBCtxIXTkpnpwYMHU6ZMUVZWTkpKGjRoEOk4AM9x4MCB//znP7/99tuaNWtIZ4HnEAqFvr6+wcHBsbGxU6dOJR1HIqFnvA4ulzt79uzc3Nzk5GRTU1PSceAfVVdXT548+e23346Pj8dyisA0v/7667p16w4cOPDZZ5+RzgL/iM/nL1q0iM1mx8fHY+nF14Ce8cqEQuGyZcsuXLiQmJg4ceJE0nHgBcrLy52cnCZMmHDx4kUFBQXScQD+cvbsWW9v7127dn355Zeks8AL8Hi8uXPn5uTkZGVljRkzhnQcCYOe8cq++eabH3/8MTo62s3NjXQWeCl5eXlTpkxZuHChn58f6SwAFEVRubm5U6dOXbx48bFjx0hngZfS1dXl7OxcX1+flZWFU75eCXrGqzl9+vSSJUt+/fXXjz/+mHQWeAUxMTFeXl5YqhWYgMPh2NravvvuuxcuXMA+NgnS0NBgb28/aNCgpKQkNTU10nEkBnrGK0hJSXF1dd20adN3331HOgu8skOHDq1fvz48PHzevHmks4Dsam1ttbW1VVFRSU1NHTBgAOk48GpKS0sdHBw8PDxCQkJIZ5EY6Bkv6969e1ZWVqKbDrBYLNJx4HWsXbs2MDAwJycHlwgBEUKhcN68eVlZWbm5uVjZRUJdvnzZw8Njz549n3/+OekskgE946XweLxp06Y1NjZeuXIFNx2QXDweb/r06Q8ePLhy5YqWlhbpOCBzvv/+++3bt1++fHnKlCmks8Dr271799dff43v40tCz3gpH3/8cXBwcE5Ozvjx40lngTdSV1c3ceJEa2vrc+fOYb8UiFNCQoK7u/u+fftwFaukEwqFCxYsSE1Nzc3NHTZsGOk4TIee8WJnzpxZvHhxRETE+++/TzoL9IOUlBQXF5e9e/euX7+edBaQFXV1debm5i4uLjiuLx3a2tpsbGz09fUTExNx07u+oWe8wL179ywsLBYvXnzo0CHSWaDf7Ny587vvvsvJybGwsCCdBaSfUCh87733SktL8/PzceBVahQXF1tbW2/btg23vusbekZfBAKBi4vLgwcPcnNzVVVVSceBfiMQCKZPn15fX4/vLIjBgQMHNm3alJqaamdnRzoL9Kd9+/Zt3rw5PT0d64T2AT2jLz/88MO3336bnZ1taWlJOgv0Mw6HY2lpuWLFigMHDpDOAtKsqKjIxsbmyy+//Oabb0hngX4mFAo9PDyqqqry8/PV1dVJx2Eo9Ix/VFJS8u6773733XcbN24knQVoERwcvHTp0pSUlMmTJ5POAtKpt7fX1tZWWVk5NTUVR/Gl0v37983MzJYsWfLLL7+QzsJQ6BnPJxAInJycuFxuVlYWZgcp5uXldfPmzYKCAhUVFdJZQArt2bNn27Zt165dw6VqUszf3/+jjz5KS0uzt7cnnYWJ0DOe75dfftm4ceOVK1cmTJhAOgvQqLa2dvz48Z9++unOnTtJZwFpw+FwTE1Nt2zZ8vXXX5POAvRyd3evra3Ny8tTUlIinYVx0DOeo7q62tTU9N///jf+9siCw4cP/+c//8nNzTU3NyedBaSHUCh0dXWtr6/Py8tTVFQkHQfoVVlZaWZmtmXLlm3btpHOwjjoGc/h7e1dWFhYWFiorKxMOgvQTiAQ2NvbKysrp6SkkM4C0iM0NHTx4sWZmZm4EkFG7NmzZ/v27Tdu3DAwMCCdhVnQM56Wnp7u5OQUHR09Y8YM0llATPLy8mxsbM6cOePt7U06C0iDrq4uY2NjZ2fnkydPks4CYsLlcs3Nzc3NzcPCwkhnYRb0jP8hEAhsbGy0tbXj4+NJZwGxWr58eVJS0s2bN3G7Z3hz//d//7dnz57y8vIhQ4aQzgLiEx0d/d577yUnJ+O+J0+SIx2AWU6cOFFYWHjw4EHSQUDcfvjhh+bm5v3795MOAhLv3r17P/3009atW1EyZM2sWbPc3Nw+//xzgUBAOguDYH/G37q6ukaPHj1//nz0DNm0a9euPXv2VFZW6ujokM4CEszX1zc+Pr60tBQXS8ugkpISCwuLgICAxYsXk87CFNif8bdff/21tbX1q6++Ih0EyPj8889VVFT27NlDOghIMA6H4+/v/80336BkyCYTE5PFixfv2LGjt7eXdBamQM/4S0dHx08//bR27drBgweTzgJkqKurb9q06fDhww8ePCCdBSTV9u3bR4wYsXTpUtJBgJjt27dzOJygoCDSQZgCPeMvBw8e7Ozs3LBhA+kgQNK6desGDhy4e/du0kFAIt26dSskJGTHjh0KCgqkswAxo0ePXrZs2Y4dO7hcLuksjICeQVEU1dnZuW/fvvXr1+vr65POAiSpqKh88cUXv//+e0NDA+ksIHl27dplZGS0cOFC0kGAsG3btt2/fz84OJh0EEZAz6Aoivrjjz/a29s//fRT0kGAvFWrVqmrqx85coR0EJAwtbW1Z86c2bRpE+6IBCNHjly0aNFPP/2EKy0o9AyKogQCwaFDh5YvX44zM4CiKDU1tU8++eTw4cMdHR2ks4AkOXjwoLa29qJFi0gHAUbYuHFjWVkZm80mHYQ89AzqwoULZWVl69evJx0EmGLt2rWdnZ2BgYGkg4DE6Ojo8PPz++yzz3CZCYiYmpq6ubn9/PPPpIOQh/UzqKlTp2pqal64cIF0EGCQNWvWpKSklJaWslgs0llAAhw+fHjLli137twZNGgQ6SzAFPHx8W5ubtevX7ewsCCdhSRZ359RVlaWmpq6bt060kGAWdatWyf62SAdBCSDn5/f4sWLUTLgSa6ursbGxsePHycdhDBZ7xnHjh0zMDBwcXEhHQSYxczMzMbGBhMEvIzs7OyCgoLVq1eTDgKM8+GHHwYFBXV2dpIOQpJM9wwulxsYGLhy5Uo5OZn+/wDPtWrVqsjIyIcPH5IOAkx3/Phxc3Nza2tr0kGAcT788MPu7u6IiAjSQUiS6b+v586da25u/vDDD0kHASZauHChgoICFvWDvrW2toaGhvr6+pIOAkykq6s7e/ZsPz8/0kFIkumeERQU5O7u/vbbb5MOAkykoaHh7e2NlXagb+fOnevt7V2yZAnpIMBQH374YXp6OofDIR2EGNntGY8ePfrzzz+xch/0YcGCBVeuXKmoqCAdBJgrNDTU3d194MCBpIMAQ7m4uAwaNCgsLIx0EGJkt2ecPXuWxWK99957pIMAc02fPl1fX1/Gj61CH5qbmxMSEnx8fEgHAeZSVFScO3cueoYsCgsL8/T01NLSIh0EmEtBQWHOnDmhoaGkgwBDnT17Vk5ODpsr0DcfH5+8vLxbt26RDkKGjPaMR48eJSYment7kw4CTOfj45Ofn49DJ/BckZGRHh4empqapIMAo02bNk1PT+/s2bOkg5Ahoz0jPj5eIBB4eHiQDgJMN2XKFC0trbi4ONJBgHG6urpSUlJmz55NOggwnYKCgqenp8xOIzLaM+Li4uzs7LB4H7yQgoLC9OnTcTMkeFZycnJXV5e7uzvpICABPDw8MjIyWlpaSAchQBZ7hlAovHTpEnZmwEvy8PBITEzs6uoiHQSYJS4uzsLCAhfGw8twd3cXCoUJCQmkgxAgiz2joKCgtrbW09OTdBCQDJ6ent3d3WlpaaSDALPExcVhcwVe0qBBg6ytrWXz0Iks9oykpCQ9Pb0JEyaQDgKSYdiwYcbGxomJiaSDAIPcvXv39u3bbm5upIOAxHB3d5fNaUQWe0Z6erq9vT3u9w0vz9HRMT09nXQKYJCMjAxFRcVJkyaRDgISw9HRsbKysqamhnQQcZPFnpGVleXg4EA6BUgSBweH3Nzc7u5u0kGAKTIyMiwtLdXU1EgHAYlha2uroKCQlZVFOoi4yVzPqKiouH//PnoGvBIHB4eenp68vDzSQYApMjIyMI3AKxkwYIC5uXlGRgbpIOImcz0jMzNTWVl54sSJpIOAJBk9evSQIUMyMzNJBwFGaG9vLyoqsre3Jx0EJIyDgwN6hvS7du2aubm5srIy6SAgYaysrPLz80mnAEYoKCjo7e21trYmHQQkjJWVVWFhYW9vL+kgYiVzPaOwsNDc3Jx0CpA8ZmZmhYWFpFMAIxQWFmpqao4cOZJ0EJAw5ubmPT095eXlpIOIlcz1jKKiIjMzM9IpQPKYmZmVlZX19PSQDgLkFRUVmZub45o1eFXGxsaKiopFRUWkg4iVbPWM2trahoYG7M+A12Bubt7b21taWko6CJCH3aLwepSVlY2MjNAzpFlJSQlFUaampqSDgOR55513lJWVi4uLSQcB8oqLizGNwOsxMzNDz5BmFRUVWlpaenp6pIOA5FFQUBg5cmRlZSXpIEBYU1NTS0vLmDFjSAcBiTRmzBhZm0Zkq2dwOBxDQ0PSKUBSGRgYVFVVkU4BhHE4HIqiDAwMCOcAySSD04jM9QzMDvDaDA0NRX9jQJZVVVXJycmNGDGCdBCQSIaGhh0dHQ0NDaSDiA96BsDLksENEXgWh8MZMmQI1uCB1yP6GyRTWyyy1TPu3r2LrRB4bQYGBvfu3ePz+aSDAEl3797Fyhnw2kaMGCEnJ1ddXU06iPjIUM8QCoWNjY2DBw8mHUR82Gw2i8U6cOBAH6/Jzc1lsVg7duzory8oxfT19fl8fnNzM+kgQFJDQ4O+vj7pFOKDaaR/KSoqDhw4EMdNpFNrayuXy9XR0SEd5KWkp6ezWKxdu3bR9Hp4DaIfnqamJtJBgKTGxkZdXV3SKV4KphFm0tXVlalpRIF0APERfV8lZYIQGysrK6FQSDqFZBD98MjUBGuTcbEAACAASURBVAHPampqwo0Yn4Jp5JXIWs+Qof0ZjY2NFHoGvAHRD4/oBwlkVlNTk6TsFgVm0tHRQc+QTo8ePaIoauDAgWIYq7m5+ZNPPnnrrbdUVVWtrKyio6P/+OMPFosVERHx+DVCofDkyZP29vYaGhqqqqoWFhZHjhwRbRPs2rVr8uTJFEVt27aN9V99DPfC12dnZ0+dOlVdXV1HR2f58uUPHz58/NSzB1aFQuEff/zh5OQ0cOBADQ0Na2vr48eP/9MNBouKikaOHPnWW2/l5ORQTxx57WPEvt87RVF8Pv/QoUMTJ07U1tYeOHCglZXVvn37Ojs7X+ZZWikrK6upqeH8DBn36NEjTCOYRt7EoEGDZGsaEcqM8+fPUxTV3d1N90BdXV2WlpZP/k9msVgLFiygKCo8PFz0GoFAsGTJkme/HatXrxYKhTt37nyl79Q/vT4uLo6iqMWLFz91DZ6Tk9Pjz7169SpFUdu3b38cTBT1KfHx8Y+/4P79+0UvjomJ0dDQMDU15XA4okdeZsS+37tQKNy0adOzzx46dOhlnqWbtrb20aNHxTMWMJOysnJgYCDdo2AakeJpxNfX18XFRTxjMYEM9Yzw8HCKovh8Pt0D/fTTTxRFjR07NiEhoa2traqq6tNPPxX9HD+eIAICAiiKMjMzi42NbWpqam9vT0lJsbCwoCgqMzNTKBSmpaVRFLVz586XHPS5rxf9ulIU9fHHH9+6dauzszM9PV10Ze/169dFr3lqgvDz86MoSkdH5/fff79z5057e/vVq1dXrVqVnJws/N8J4pdffpGXl/f09GxtbX2lEV/43o2MjNTV1SMjIx89etTR0XH9+vWNGzeeOnVK9Ol9P0u3t9566+DBg+IZC5iJxWKFhobSPQqmESmeRj799NMnO5PUk6GeERwcrKioKIaBbGxsWCxWcXHxkw+6uro+OUFMmzZNXl6+trb2ydeIbvO2efNmYb9OEG5ubk8+ePjwYYqi/P39RR8+NUGIdpyKNjueJfqCe/bs+de//kVR1Lp163p7e191xBe+92nTphkZGfF4vOdm6PtZuo0YMWLv3r1EhgYm4HK5FEWdO3eO7oEwjUjxNLJhw4ZJkyYRGZoIGbrepKenR0lJSQwDVVRUDB061MTE5MkH3d3d4+PjH39YUlLC5/OHDx9O/XdPpugfFEXduXOnf/NMnTr1yQ9HjRpFUVRbW9tzX3zz5k1tbW0XF5c+vuDOnTtbW1u//PLL77///jVGfOF7379//7x588aMGePu7m5hYWFnZzdhwoTHX63vZ+mmrKzc09MjtuGAaUTffTHMJJhGMI1IDRk6D5TP58vLy4tnrGfPtxL+70VfAoFAFInP5wsEgse/JxRFiTaY+pGqquqz2YRvcBHarFmzBg0adPLkyYKCgtcY8YXv3cLC4ubNmwEBAYaGhmlpaR4eHiYmJo/vpNz3s3RTUFDg8XjiGQsYSLQarIKCOLbQMI30MaKkTyP/dEqsVJKhnqGoqCieb+3o0aPv3bt348aNJx98ciuEoqhx48apqak9evTo2V1MopPJ5eTkKIp6+cCv+vp/Mm7cuObm5oSEhD5eY21tnZqaKi8vP2XKlPT09NcYou/3TlGUgoKCk5PTli1bTp8+XVVV1draunLlysdfoe9nacXlcsWzVwyYSVFRkaIoMXRNTCMvHALTiKSQoZ6hpKTU7x3/uebNmycUCufPn5+cnNzR0VFdXf3555//+eefT75m5cqVnZ2dLi4u0dHRDQ0NXC63uro6JiZm3rx5ol/OQYMGURSVlpb2kpdZv+rr/8ny5cspilq0aNHx48fv3bvX0dGRl5fn6+ubkpLy5MtMTEwyMjL09PTc3NxiY2NfaYgXvnd7e/vff//9xo0bXV1dLS0tbDa7qampsrJS9Ol9P0s3LpeLG2jJMtGfBzHMJJhG+ibp04hM9QwZOg80MjKSEsv1Jp2dnebm5k/+T2axWN7e3hRFRUVFiV4jEAhWrFjx3O9IXFycUCjs7e0dOnToy3+nnvv6p64fExE9+PgKrqdO4OLz+fPnz3821XMvSKurq7O0tFRUVAwODn7yi/c94gvf+3P/kH/22WeiT+/7Wbrp6+sfPnxYPGMBM8nLy585c4buUTCNSPE0snbt2ilTpohnLCaQrf0ZlFg2RFRVVZOSktasWaOvr6+iojJx4sQLFy6MHz+eoihtbW3Ra1gs1qlTp0JDQ11cXLS1tZWUlEaNGjVnzpxz586JTp6Sl5ePiIhwdHRUV1d/mUFf9fX/RE5OLiws7NixY7a2turq6pqamjY2Nn5+fk+dkyUyePDg5ORkW1vbDz744MiRIy85xAvfe05Oztq1a8ePH6+qqqqrq+vg4ODn57d//37Rp/f9LN2wPwPEs2cU00jfMI1IEJZQZhalT0hIcHFxaWpqEu0bFCeBQGBlZXX9+vWGhgasWCzRVFRU/Pz8PvjgA9JBgBgdHZ3vv/9+zZo1Yh4X04jUWLp0aVtbW1RUFOkgYiJD+zPEebPNDRs2BAUFVVdXd3Z2Xr9+3cfHJz8/f+rUqZgdJFpbW1tPTw9ukSPjBg0ahGkE3kRjY6NMfRNlaP2Mxz3DyMiI7rHKysr27dv35CMDBgx46pFXcv369T4u7/by8pKdakyQ6K+LTE0Q8Cyx3QQL04i0amxsNDMzI51CfGRof4Y4b7a5f//+FStWjBkzRllZWU9Pb/78+VlZWU/drQAkjuiHBz1Dxontpt6YRqSVrN3yV4b2Z6iqqqqqqoqnZxgZGZ06daofv6ClpaXsnEnDWKIfHhw3kXE6OjqYRuBNNDY2ytQ0IkP7MyiKGjx48IMHD0inAElVX1+voqKioaFBOgiQpK+vX1dXRzoFSKrOzs62tjY9PT3SQcRHtnrGyJEjq6urSacASVVVVTVy5MhnV4MGmYJpBN4Eh8OhKMrAwIBwDjGSrZ5hYGAg+h4DvAYOhyNTswM8l4GBQWNj4z/dQgygb1VVVRR6hhQzMDAQfY8BXkNVVZWhoSHpFECY6C8EdmnA6+FwODo6OpqamqSDiI9s9QzRDk+cCQWvp6qqSqa2QuC5RF0TWyzwemRwc0W2eoaRkVFXV9edO3dIBwHJ09nZWVNTI4bFV4Dh1NXVhwwZUlZWRjoISKTy8vIxY8aQTiFWstUzzM3NWSxWYWEh6SAgeYqLi/l8/lO3tgLZZG5uXlRURDoFSKTCwkJZm0Zkq2doamqOHDkSEwS8hqKiInV19VGjRpEOAuSZm5tjcwVeQ0tLy507d2RqMVBK1noGhQ0ReF1FRUUmJiZycjL3KwPPMjMzKy0t5fF4pIOAhCkuLhYKhdifIeXMzMwKCgpIpwDJU1RUJGtbIfBPzM3Ne3p6ysvLSQcBCVNUVKSlpTV8+HDSQcRK5nqGlZVVWVlZc3Mz6SAgSfh8fl5enpWVFekgwAjjx49XU1PLyckhHQQkTHZ2tpWVlayt9SdzPcPR0VEoFGKCgFdSWFjY0tLi6OhIOggwgqKiorW1dUZGBukgIGHS09MdHBxIpxA3mesZurq6Y8aMwQQBryQjI2PgwIHjx48nHQSYwsHBAdMIvJIHDx5UVFSgZ8gETBDwqjIyMuzt7XESKDzm4OBQXl7e0NBAOghIjPT0dHl5+UmTJpEOIm6yOG86OjpeuXKlp6eHdBCQGGlpaTK4FQJ9sLOzY7FY6enppIOAxEhLSzMzM9PS0iIdRNxksWe4ubl1dHRggoCXVFRUVFNT4+rqSjoIMIi2tvbEiRP//PNP0kFAYly6dEk2pxFZ7BnDhw83NjZms9mkg4BkYLPZurq6EydOJB0EmMXT0zMmJoZ0CpAMHA7n5s2bnp6epIMQIIs9g6IoT0/PuLg40ilAMsTFxXl4eODkDHiKh4fH3bt3S0tLSQcBCRAXF6eurm5vb086CAEyOnV6eHiUlJTgzs7wQu3t7ZmZmR4eHqSDAOPY2Njo6OhgiwVeRlxcnIuLi7KyMukgBMhoz3ByctLU1Dx//jzpIMB0MTExfD7f3d2ddBBgHHl5eQ8Pj6ioKNJBgOna29sTEhJmzpxJOggZMtozlJWVZ8+eHRYWRjoIMF1oaKizs7Ouri7pIMBE3t7eGRkZNTU1pIMAo128eJHL5c6ZM4d0EDJktGdQFOXj45OZmXnnzh3SQYC52tra2Gz2ggULSAcBhvLw8NDQ0AgPDycdBBgtNDTUxcVFT0+PdBAyZLdnuLu7a2trR0ZGkg4CzHX+/Pne3l6Z3QqBF1JWVvby8sKeUehDW1vbpUuXZHlzRXZ7hpKS0uzZs8+cOUM6CDBXaGioq6vroEGDSAcB5vLx8cnOzuZwOKSDAEOdO3dOIBB4eXmRDkKM7PYMiqKWLVt25cqV69evkw4CTHT//n02m718+XLSQYDR3N3dhwwZcvLkSdJBgKH8/Pxmz56tra1NOggxMt0zpk6damRkhAkCnuvEiRNaWlqyvBUCL0NBQWHZsmUnT57k8/mkswDjlJeXp6enr1q1inQQkmS6Z7BYrJUrVwYGBnZ2dpLOAswiFAr/+OOP5cuXy+b17vBKVq9eff/+fSykAc86fvz4sGHDXFxcSAchSaZ7BkVRK1as6OjoiIiIIB0EmOXy5csVFRUrV64kHQQkwKhRo6ZNm3bs2DHSQYBZuFxuQEDAqlWr5OXlSWchiSUUCklnIGzhwoW3b9/Ozc0lHQQYZNasWW1tbSkpKaSDgGSIiIhYsGBBWVnZmDFjSGcBpvD391+9enVlZeWwYcNIZyEJPYPKzc21trZOSkqaOnUq6SzACDdv3jQxMYmKinrvvfdIZwHJwOfzx44d6+7ufuTIEdJZgCksLS0tLCz8/f1JByEMPYOiKMrJyUlLS+vixYukgwAjrFy5MiMj48aNG7h3Gry8Q4cObdmypbq6GqvHAkVRcXFxM2bMyM/Pt7S0JJ2FMEyjFEVRGzZsiImJuXHjBukgQN6DBw9CQkI2bNiAkgGvZOXKlaqqqr///jvpIMAIP//8s5ubG0oGhZ4h8t57773zzju7d+8mHQTI27t3r5aW1tKlS0kHAQmjpqa2Zs2agwcPtre3k84ChOXk5CQkJGzYsIF0EEZAz6AoipKTk9u2bVtwcHBpaSnpLEBSXV3dr7/+umXLFhUVFdJZQPL85z//6enpOXToEOkgQNi2bdvs7e3d3NxIB2EEnJ/xF4FAYGlpaWJicvr0adJZgJjPPvssIiKioqJCVVWVdBaQSNu2bTt8+HBVVdXAgQNJZwEyMjIyHB0dExISnJ2dSWdhBPSMv4WHhy9cuPDatWsWFhakswABtbW1Y8aM2bt37yeffEI6C0iqlpYWQ0PD9evXb9++nXQWIGPatGm9vb1paWmkgzAFesbfhELhu+++O2zYMFx4IptWrlyZkJBQXl6upKREOgtIsF27du3Zs6e8vHzw4MGks4C4sdlsT0/PtLQ0R0dH0lmYAj3jfyQmJk6fPj0uLs7Dw4N0FhCr/Px8Kyur4ODghQsXks4Ckq2rq2vcuHFubm7Hjx8nnQXEqre319LScuzYsZGRkaSzMAh6xtPmzJlTXl5eUFCgqKhIOguIz5QpU3g8XkZGBovFIp0FJF5wcPCyZctycnKsrKxIZwHx+eWXX7744ovi4mIjIyPSWRgEPeNplZWV48eP37Nnz6effko6C4jJmTNnlixZkp2dbW1tTToLSAOhUOjk5CQQCNLT09FcZcTDhw/feecdX1/f77//nnQWZkHPeI7NmzcfP368tLQUh1dlQVtbm4mJiYuLy8mTJ0lnAelx5coVOzu7gICAJUuWkM4C4uDr6xsdHV1WVqahoUE6C7OgZzxHZ2enmZmZtbX1mTNnSGcB2n322WchISE3btzQ19cnnQWkyr/+9a+IiIgbN27o6emRzgL0Sk1NnTp16pkzZ3x8fEhnYRz0jOcTnTMcFRXl5eVFOgvQ6MqVK/b29idPnly2bBnpLCBtWltbTUxMnJ2dcSct6dbT0zNhwgRDQ8OYmBjSWZgIPeMfLV26NDExsaSkBOvtSKve3l5ra2ttbe2EhAQcRAc6xMTEzJo1i81mu7u7k84CdPn6668PHjxYUlIyfPhw0lmYCD3jHzU2No4fP3727Nl+fn6kswAtvv766/379xcVFY0aNYp0FpBaPj4+OTk5BQUF2GKRSrm5ufb29vv27Vu3bh3pLAyFntGXqKiouXPnhoaG4pCb9ElPT586derhw4c//vhj0llAmjU2Npqbmzs4OISHh5POAv2so6Nj4sSJw4cPv3TpEu7w/E/QM17A19c3IiLi+vXrI0aMIJ0F+k1LS4ulpaWxsXFMTAyOmADd4uPj3d3d/f39cR9gKbN69erIyMiCggIcMekDesYLdHR0vPvuu8OHD//zzz9RV6XGokWLUlJSCgoKcCEAiMfnn39+8uTJ69evGxoaks4C/ePs2bPz5s07e/bs3LlzSWdhNPSMF8vNzXVwcPjyyy937NhBOgv0g99//33t2rWxsbE4NQ/Epru7e9KkSYqKiunp6SoqKqTjwJu6ffu2tbW1j4/P0aNHSWdhOvSMl/Lbb7+tXbs2MjISvVXSZWdnT5069csvv8TtNEHMOByOlZWVp6dnYGAg6SzwRrq6uhwcHIRCYWZmpqqqKuk4TIee8bJWrlx59uzZq1evjhkzhnQWeE0PHjywsrIyNjaOi4uTl5cnHQdkTnR0tJeX15EjR3D2sURbvnx5dHR0bm4ujoK9DPSMl9XV1eXo6Njb25uRkTFgwADSceCVcblcNze3u3fv5ubmamtrk44DMmr79u27d+9OTEy0t7cnnQVex/79+zdt2hQbG+vm5kY6i2RAz3gFHA5n0qRJVlZW58+fV1BQIB0HXoFQKFyxYsW5c+fS09PNzc1JxwHZJRAI5syZk52dnZWVNXr0aNJx4NWcP39+3rx533///RdffEE6i8RAz3g1ubm5U6dOXbRo0fHjx0lngVewY8eOXbt2nT17dvbs2aSzgKzr7Ox0dnZubGzMysrCFU8SJC8vb8qUKQsXLsTija8EPeOVRUdHz5kz58cff9y4cSPpLPBSTp8+vWTJksOHD3/yySekswBQFEXdv3/fzs5uxIgR8fHxysrKpOPAi3E4HFtb2wkTJly8eBH7s18Jesbr2L9//8aNG0+ePLl8+XLSWeAFoqOj33///f/85z8//vgj6SwAfyspKXFwcHB2dg4LC8PfLYarq6tzcnJSV1dPTU3Fbd9fFXrGa9q6detPP/0UFBS0cOFC0lngHyUmJs6cOXPBggUnT57EMmvANFlZWW5ubh4eHmfOnMEFUIz16NEjZ2fntra21NTUIUOGkI4jedAzXt/GjRsPHjwYGRn53nvvkc4Cz5GTk+Pq6urm5hYaGopJHJgpISFh1qxZixYtOnHiBJbAZ6DW1lYXF5e6urrU1FQDAwPScSQSesbrEwqFq1atCgkJiYqKwsqSTHPlyhV3d3cnJ6eIiAhFRUXScQD+0YULF+bPn79mzZqDBw+iajBKa2vrrFmzbt++nZqaipWTXhv2JL8+Fot17NgxHx8fLy+vqKgo0nHgbykpKS4uLg4ODmFhYSgZwHCzZ88OCQk5evTo6tWr+Xw+6Tjwl4cPH7q4uNy+ffvy5csoGW8CJx+9EXl5+T/++ENbW3v+/PknTpzAaaFMEBcXN2/ePNHhEpzJDxJh/vz5ampq8+fPb29vDwwMRDkm7sGDB+7u7s3NzSkpKUZGRqTjSDbsz3hTLBZr//79n3/++UcfffT777+TjiPrwsPD58yZs2DBgsjISJQMkCAzZsyIjo6OiYmZP39+V1cX6TgyjcPhODk5dXV1paeno2S8OfSMfsBisfbs2fPtt99+8sknX375JU55IWXv3r0LFy7817/+dfLkSZz4CRLH2dn50qVL6enpzs7O9fX1pOPIqKtXr9ra2qqpqaWkpAwfPpx0HGmA80D7U1hY2PLly2fOnBkYGIib+IkTn89fv379r7/++s033+zYsYN0HIDXV1FRMWPGDB6PFxMTY2xsTDqObGGz2T4+Pra2thEREZqamqTjSAnsz+hPPj4+MTExCQkJrq6u2BwRm9bWVi8vr1OnTkVGRqJkgKQbPXp0enr64MGDHR0dk5KSSMeRIQcOHBBdYxwbG4uS0Y/QM/qZs7Nzenr6/fv3J06cmJ2dTTqO9CspKbG2tr527VpiYuLcuXNJxwHoB3p6eomJidOnT3dzc9u7dy/2OtOts7Pzgw8+2Lhx4/fff3/06FEsz9q/0DP6n4mJSX5+vpWV1eTJk3fv3k06jjQ7f/68g4ODnp5ebm7upEmTSMcB6DeqqqphYWFHjhzZunXrnDlzWlpaSCeSWrdv37azs2Oz2TExMbgLKx3QM2ihqakZGRm5devWrVu3Ll++vL29nXQiadPT0/P555/PnTt32bJlSUlJb7/9NulEAP3P19eXzWZnZWXZ29sXFRWRjiOFzp49a21traCgkJubi+UWaYKeQRc5Oblvv/32woULcXFxEyZMyMnJIZ1Iety4cWPSpEknTpwIDAw8ePAgFhsAKebs7JyXl6etrW1jY/PLL7/gGEp/6ejoWL169bx587y9vTMyMrCmOH3QM+g1c+bM4uLisWPHOjo67tixA4v9vbmAgAAbGxtlZeVr164tWbKEdBwA2g0fPjwlJWXHjh2bNm1yc3Orra0lnUji5ebmvvvuuxEREadPnz527JiKigrpRNIMPYN2+vr6Fy9e3LNnz+7dux0dHUtKSkgnklRVVVVubm4fffTRhg0bMjIysBIwyA55efnNmzenpqZWVVVZWFgEBQWRTiSpuru7v/76a3t7+xEjRhQXF+OG22KAniEOLBbr3//+99WrV4VC4bvvvrt9+/aenh7SoSQJn8//+eefTU1Na2tr09PTv/32W5wQDjLI1tY2Pz9/wYIFy5cv9/T05HA4pBNJmNTUVEtLy4MHD/7888+XLl0aOnQo6USyQQhi1Nvbe+DAgQEDBhgbGycnJ5OOIxmuXr06ceJEZWXlb7/9tqenh3QcAPIyMjLGjx+vrq6+b98+LpdLOo4EaGxsXL16NYvFmjlzZnV1Nek4sgX7M8RKXl5+/fr1xcXFo0aNmjp1qre3N7ZI+nD//v2PPvpo0qRJampq+fn533zzjZKSEulQAOTZ29tfu3Zt48aNW7duNTc3j4uLI52IuXg83sGDB42MjC5evBgSEhIdHT1ixAjSoWQM6aIju2JiYsaOHauiorJ169a2tjbScZilq6vrhx9+0NDQGDFixJkzZwQCAelEAExUWVk5b948iqI8PT1LS0tJx2EcNpttbGysrKy8efPm1tZW0nFkFHoGSVwu9+jRo7q6ujo6Oj/++GNHRwfpRORxuVx/f39DQ0M1NbXNmzejgQG8UFJSkqWlpZycnLe3961bt0jHYYTMzMzp06dTFDVr1qzbt2+TjiPT0DPIa2xs/OKLL9TV1YcMGXLw4MHu7m7Sicjg8XgnT540NDRUUlJau3ZtTU0N6UQAEqO3t9ff33/06NGKiopr1qy5c+cO6UTE5OTkiFbcmjJlSmpqKuk4gJ7BGA0NDZs3b1ZVVR08ePD27dubmppIJxKf9vb2o0ePjh07VlFRcenSpdj4AHg9PB5P1DaUlJSWLl1aVFREOpFYpaWlzZo1i8Vi2draXrhwgXQc+At6BrPU1NRs2rRJS0trwIAB//73v6uqqkgnotf9+/e/+uqrQYMGqampffLJJxUVFaQTAUi8np6e48ePGxsbs1gsT0/PhIQE0ono1dPTExAQYG5uTlGUi4sLm80mnQj+B3oGE7W2th44cGDEiBFycnIuLi5hYWFSdukan8+Pj49funSpqqqqnp7e9u3bGxoaSIcCkCoCgSA+Pn7WrFkURY0dO/bHH3+sr68nHaqflZeXb968efDgwfLy8rNmzcrJySGdCJ6DJcRq+UzF4/HOnz9//Pjxy5cvDx48eMWKFUuXLjU2Niad641UVlYGBQWdOnWKw+FMnjx51apVPj4+WPQXgD7Xrl07fvx4SEhIT0/P3LlzV6xYMX36dIle6a6trS0qKurEiROpqanDhw//6KOPVq5cOWzYMNK54PnQMyQAh8M5efLkqVOn7t27Z2Zm5uPjs2DBAiMjI9K5XsGdO3fCwsLCwsKuXr2qr6+/bNmylStXjhs3jnQuAFnR0dERFhbm5+eXmZmpq6s7b948Hx+fKVOmyMvLk472sjo6OqKjo8PCwmJjYwUCwaxZs1atWuXu7i4nh4WgGA09Q2IIBIL09PTQ0NDIyMgHDx5YWFjMmDHDw8PD3t6emZsmAoHg6tWrbDY7Njb26tWrAwcOnDt37oIFC5ydnZkZGEAWVFZWhoWFhYaGXr9+ffDgwaJpxNXVVVtbm3S056uurmaz2Ww2+88//+Ryuc7Ozj4+PnPnzh00aBDpaPBS0DMkD5/PT0lJOXfuHJvNvn37tpaWlqur67Rp0xwdHU1NTclWe6FQePPmzYyMjKSkpD///LOxsXH48OEeHh5eXl6urq5YzROAOcrLyyMiIuLi4rKzs4VCoa2trZub2+TJk21sbNTV1clmq6+vz8zMTE1NvXTp0o0bN9TV1Z2dnWfOnPn+++/r6emRzQavCj1Dst26dUvU9NPT01tbW7W0tOzt7e3s7CZMmGBqampgYCCGDDU1NcXFxfn5+ZmZmZmZmU1NTerq6nZ2du7u7h4eHqampmLIAACvrbm5+fLly2w2OyEhobq6WkFBYcKECfb29tbW1mZmZuPGjRPDFkJbW1txcXFRUVF2dnZmZmZZWZmcnJypqamrq6unp6ejo6OysjLdGYAm6BlSgs/nFxcXp6enZ2ZmZmVlVVVVURSlpaVlZmZmYmJiaGhoaGhoYGBgYGCgr6/fx9fp7e3t46DGw4cPq6qqOBxOVVVVVVXVIwoCuwAAIABJREFUjRs3CgsLHz58SFHUsGHDbG1tHRwcHBwcJkyYgCMjAJKopqYmPT09IyMjMzOzqKiIy+UqKiqOGzfOxMTknXfeEc0hhoaGw4YN6+N3nMfjKSoq/tOz3d3dojlE9N/y8vKioiLRNfwaGhoTJ050dHS0t7e3t7fX0tKi512CWKFnSKeWlhbRxkFBQUFpaWlVVVVNTQ2fz6coSkVFRee/9PX1Rb/JWlpacnJy9fX1HR0dhoaGFEU1NzdTFNXa2tr4X01NTV1dXRRFycnJDRkyxNDQ0NjY2MzMzMzMzNzcHMdKAaQMj8crKysrKioqLCwsLi6urKysqqp6PAmI5hDRbRN0dHQUFBTU1NREex2ys7NtbW0piuro6OByud3d3U1NTU1NTY2NjQ0NDS0tLaKvr62tbWBgYGRk9HgaMTAwYLFYBN8y0AE9Q1bweLy7d++KCkfTfz3+nW9paREIBNXV1Vwu18jIiMViDRw4kKIoDQ0NXV1dPT090VQiqhcjRozAPkwA2VRXV8fhcO7cudPQ0ND0hN7e3q6uru7u7o6OjvLycgsLCzk5uQEDBigqKj65baOrqzt48OCRI0caGhpid4WMQM+AvwgEgrfeeku0A2PAgAGk4wCARPr0008PHz58+vTphQsXks4CjIDLjuEvycnJDQ0NXC43KiqKdBYAkEh8Pj8kJISiqKCgINJZgCnQM+AvISEhioqKcnJymCAA4PUkJCSITgy/dOlSU1MT6TjACOgZQFEUxeVyw8LCeDwen8+/fPlyfX096UQAIHlEmysURQmFwrNnz5KOA4yAngEURVFxcXHt7e2if7NYrMjISLJ5AEDidHd3R0RE8Hg8iqKEQmFAQADpRMAI6BlAURQVHBz8+Gp4gUCACQIAXlVMTExnZ6fo3wKBICMjo6amhmwkYAL0DKA6OjouXrwo2gqhKEogEOTk5HA4HKKhAEDCBAcHP3lXNgUFhbCwMIJ5gCHQM4A6d+4cl8t98hEFBYXw8HBSeQBA4rS2tsbExPT29j5+pLe319/fn2AkYAj0DKCCgoKeuvsaj8fDBAEAL+/s2bNPlgyKooRCYUFBQXl5OalIwBDoGbLu4cOHCQkJT00QFEWVlJSUlJQQiQQAEicwMPDZJcOVlJTOnDlDJA8wB3qGrAsLC3vumrCKioqhoaHizwMAEqehoSElJUV0B6Uncblc7BkF9AxZFxgY+NyewePx/vjjDyxLDwAvdObMmX+6/1llZWV+fr6Y8wCjoGfItHv37mVlZQkEguc+e/fu3dzcXDFHAgCJExgY+OyxVxEWi3X69Gkx5wFGUSAdAEjKysoyNzd/vLfz4cOHfD5fT09P9KGcnNyVK1esra3JBQQApmtqauLz+aampqIPu7u7Gxoahg0b9ngPx61bt8ilA/Jwv1b428qVK2tra+Pi4kgHAQBJxWazPT09W1paNDU1SWcBRsBxEwAAAKALegYAAADQBT0DAAAA6IKeAQAAAHRBzwAAAAC6oGcAAAAAXdAzAAAAgC7oGQAAAEAX9AwAAACgC3oGAAAA0AU9AwAAAOiCngEAAAB0Qc8AAAAAuqBnAAAAAF3QMwAAAIAu6BkAAABAF/QMAAAAoAt6BgAAANAFPQMAAADogp4BAAAAdEHPAAAAALqgZwAAAABd0DMAAACALugZAAAAQBf0DAAAAKALegYAAADQBT0DAAAA6IKeAQAAAHRBzwAAAAC6oGcAAAAAXdAzAAAAgC4KpAPAC1RWVtbX14tnrPr6+kePHmVnZ4tnuIEDB44bN048YwHIspaWltLSUvGMdfPmTYqirl69qq6uLp4Rra2t5eXlxTMWvAaWUCgknQH68tFHH506dYp0Clq4u7uz2WzSKQCkH5vN9vT0JJ2CLi0tLZqamqRTwD/C/gwJMGXKlICAANIp+tmmTZtaWlpIpwCQISUlJQMGDCCdoj+lpKQsW7aMdAp4AfQMCaCiojJixAjSKfqZuro6egaAOA0bNkzKtvv19PRIR4AXw3mgAAAAQBf0DAAAAKALegYAAADQBT0DAAAA6IKeAQAAAHRBzwAAAAC6oGcAAAAAXdAzAAAAgC7oGQAAAEAX9AwAAACgC3oGAAAA0AU9AwAAAOiCngEAAAB0Qc8AAAAAuqBnAAAAAF3QMwAAAIAu6BkAAABAF/QMAAAAoAt6BgAAANAFPQMAAADogp4BAAAAdEHPAAAAALqgZwAAAABd0DMAAACALugZAAAAQBf0DAAAAKALegYAAADQBT0DAAAA6IKeAQAAAHRBzwAAAAC6oGcAAAAAXdAzAAAAgC7oGQAAAEAX9AwAAACgC3oGAAAA0AU9AwAAAOiCngEAAAB0Qc8AAAAAuqBnAAAAAF3QMwAAAIAu6BkAAABAF/QMAAAAoAt6BgAAANAFPQP+1t3d3djYSDoFAEi2e/fukY4ADKJAOgC8WEtLS3Z2thgGSk5ObmxsnD9/vhjGamhoEMMoAPBYbm6umpoa3aNwudyvvvpqz549dA9EUdTNmzfFMAq8IfQMCZCdnW1nZye24X7++WfxDOTu7i6egQCAoqjp06eLbSxxTlnAcCyhUEg6A/Tl4cOH7e3tYhioo6PDwsKit7c3LS1t+PDhYhhRVVVVT09PDAMByLju7u76+nrxjLVy5crLly9/9dVXvr6+4hlx+PDhLBZLPGPBa0DPgL8EBAR8+OGHcnJyO3fu3LJlC+k4ACB5Hj16pK+vz+PxzMzMCgsLSccBRsB5oPCXgIAAFovV29vr7+9POgsASKTIyEiBQEBRVFFR0Y0bN0jHAUZAzwCKoqiGhobk5GQ+n09R1M2bN4uLi0knAgDJExgYKPqHoqJiWFgY2TDAEOgZQFEU9eSMoKSkdObMGYJhAEAS1dXVpaWliTZXeDzeqVOnSCcCRkDPAIqiqICAgMdn6nC53FOnTuHEHQB4JaGhoXJyf/9NuXPnTm5uLsE8wBDoGUDduXPn6tWroqOqIrW1tTk5OQQjAYDECQgIeHIaUVRUPH36NME8wBDoGUCFhITIy8s/+YiSkhImCAB4eRUVFfn5+U/2DB6PFxAQIDqMArIMPQOogICA3t7eJx/hcrmBgYFPPQgA8E9Onz6toPD0wo+NjY2pqalE8gBzoGfIutLS0tLS0mcfb25uTkpKEn8eAJBEAQEBPB7vqQcVFRVDQkKI5AHmQM+QdcHBwYqKis8+jgkCAF5SQUHBrVu3nn2cx+OFhob29PSIPxIwB3qGrAsMDHx2K4SiKB6PFxYW1tXVJf5IACBZTp8+/dzNFYqi2tvb//zzTzHnAUZBz/h/9u47IIprfxv4LCxNQECwIIqAqAjSVKQqUgXU2DHWoCgaNWpiriS58YLX3J8l1mhs2CvVqCggAgqydEWKKEgXsYFK77vvH3tfL0GEBXb3bHk+f8mwc86zwB6/c+bMjFhLTk4uLS2l0+kyn5GSkqqvrw8PDyedEQAEGovFunTpUltb26fRQ1pa+tO/KYrConIxh+e1ijUWi7Vr165PXwYHB1dXV69cufLTFkVFRRK5AEBofPz48bvvvvv0ZV5e3pkzZ7Zv384uMiiKkpeXJxQNBAKeowb/4+npWV5ejjkMAOi1iIgIV1fXqqqq/v37k84CAgHnTQAAAIBXUGcAAAAAr6DOAAAAAF5BnQEAAAC8gjoDAAAAeAV1BgAAAPAK6gwAAADgFdQZAAAAwCuoMwAAAIBXUGcAAAAAr6DOAAAAAF5BnQEAAAC8gjoDAAAAeAV1BgAAAPAK6gwAAADgFdQZAAAAwCuoMwAAAIBXUGcAAAAAr6DOAAAAAF5BnQEAAAC8gjoDAAAAeAV1BgAAAPAK6gwAAADgFdQZAAAAwCuoMwAAAIBXUGcAAAAAr6DOAAAAAF5BnQEAAAC8gjoDAAAAeAV1BgAAAPAK6gwAAADgFTrpAEDAx48fWSxWXV1dc3MzRVEfPnygKKqpqamuro7JZDIYDFlZWYqilJSUJCQk6HS6oqIiRVHKyso0Go1scgAQEOwBpLm5ua6ujqKo2tralpYWFov19OlTdXX1+Pj4wYMHUxQlJyfXfjzp16+fjIwM4ejAXzQWi0U6A3BTS0tLWVlZUVFRaWnpu3fv3r17V/mZtra2XrRMo9FU/05NTU1VVXXw4MHDhg3T0tIaMWKEtLQ0198RAPDfmzdviouLi4uLX79+/Wno+DSeVFRUNDY29q5lBQUFtf+v/XjCHka0tLSUlJS4+16ALNQZQqympiY7OzsvL6+4uLioqIg9KJSVlbHLCDk5uUGDBn36MHf4SNNoNEVFRTqdTqPRlJWVKYqSkpJSUFCgKKq+vr6pqYmiqKqqKiaT2dbWVl1dTVHU+/fvKyoqOpQs7969e/v2LfuARkJCYujQoVpaWtra2uzxYtSoUYaGhuz2AUAAtba25uXl5eTktB9GioqKGhoaKIqi0+kDBw78dFzx6d/sL6WlpWVkZPr160dRlIKCgpSUFEVRKioq7GZramooimpoaGBXJNXV1W1tbfX19exhhF2ytB9S3r17x46koqLSfhgZOXKkgYHBiBEjCP2EoK9QZwiT8vLyhw8f5uTkPHny5OHDh8+ePWMymdLS0sOGDdPR0dHR0VFXVx86dCj731paWhISfFp/8+HDh/Ly8levXhW2k5eXxx5o1NXVDQwM9PX1J0yYYGBgMG7cOEycApDy4cMH9gDCHknS09Pr6+spilJRUdH5jKamJp3Op9Przc3NZWVlnwaQT0NKUVERi8Xq37//qFGjPg0jpqamqqqq/AkGfYQ6Q6C9evWKwWAwGIzExMSsrKz6+npJScmRI0caGxsbGhoaGhoaGRlpa2sL7LKJkpKS7OzszMzMzMzMrKys3Nzc1tZWGRkZAwMDS0tLKysrGxsbTU1N0jEBRFl9fX1KSkp8fHxiYuLDhw/fvHlDUdTgwYONjIyMjIzYI4mBgYHAVv9VVVVZWVlZWVkZGRlZWVnZ2dnV1dU0Gk1bW9vMzMza2tra2trIyIhv9RD0FOoMwcJkMp88eRIfH5+QkMBgMIqKiiQlJY2MjKytrU1NTY2MjAwMDOTk5EjH7KXm5uYnT55kZWU9fvyYPeS1tLQMGzbM2traysrK2tra2NgYgwVA35WXl7MPURISEtLT01tbW4cPH25jY2NmZmZoaGhsbDxw4EDSGXuJxWIVFxezD12SkpISEhI+fPigoKBgbm7OHkksLS379+9POib8D+oMgfDixYuIiIiIiIjo6Oiqqqr+/ftbWFiw/+u1sLBgL5sQPQ0NDampqeyi6tNgYWtr6+rq6uLiMnLkSNIBAYRJXV1dTExMeHh4ZGRkQUEBnU5nH6KwJw6HDRtGOiBPsFisnJychIQE9kiSn58vKSlpYmLi4uLi6upqYWEhKSlJOqO4Q51BTHNzc3x8fERERHh4eHZ2dr9+/ezt7adNmzZ58uRx48aJ22eDPVjEx8dHRkZGRUVVV1ePGjXK1dXV1dXV1tZWeKdwAHgtJycnPDw8IiLiwYMHLS0t48ePd3FxmTp1qrm5uageonThzZs3CQkJUVFRERERhYWFKioqTk5OLi4uLi4u6urqpNOJKdQZ/Pbx48fr169fv349Ojq6trZWT0+P/b/p5MmT2VeZQ0tLS0JCAnvozMjIkJOTs7W1nTVr1rx584R3sheAi9ra2u7fvx8UFBQREVFSUqKqqurs7Mz+33TQoEGk0wmK3Nxc9oFcbGxsU1OTsbHx9OnT3d3djYyMSEcTL6gz+KS6uvrmzZuBgYGRkZEURTk5Obm5ubm6umppaZGOJtDKy8vZBUdYWFhTU5O9vb27u/vcuXMHDBhAOhoAvzGZzAcPHgQEBISEhLx9+9bU1HTmzJmurq5mZmbiNgPaI/X19ffv3w8PD79582Zpaamenp67u/vChQv19fVJRxMLqDN4q6GhISoqKigo6Nq1a42NjRYWFgsWLFiyZImamhrpaEKm05/k4sWLMcMB4uDhw4cXLlwIDg4uLy/X19dfsGDBokWLxowZQzqX8Hny5ElQUNCFCxeKiorYP8mvv/5aT0+PdC5RhjqDVx48eODn5xccHNzS0uLg4ODu7j5nzhz2HWygL2pqakJDQwMCAu7cuUNR1MyZM1evXu3o6Mi3m4UA8E1paenp06fPnj374sULfX39hQsXuru74z/FvmM/YCEwMDA4OPj169cTJkxYtWrV4sWLcaEKL6DO4LJ3795duHDh1KlTz549mzhxoqen54IFC3A/GV6oqqq6fv366dOnHzx4oKWl5enpuWLFCg0NDdK5APqqpaUlNDT01KlTd+7cGTRo0DfffLN06dJx48aRziWC2tra4uLizp8/HxQURKPR3N3dV69ebWlpSTqXSEGdwR0sFovBYFy8ePHixYtSUlJff/31mjVrxo8fTzqXWMjLyztz5szZs2crKirs7e29vLzmzJmD+3CAMHrx4sWVK1f+/PPPly9fsv+YZ8+ezb6fN/BUdXW1v7//iRMnHj16pKen5+Hh4enpiRPc3MGCvqmpqTl06BD7Zg9WVlZnz56tq6sjHUocNTY2+vv7s0+gaGho7Ny58/3796RDAXCEyWRGREQ4OTnRaLRhw4b961//Ki4uJh1KTKWkpHh5eSkqKsrKyq5YsSIrK4t0IqGHOqP3Xr58+dNPP6moqMjLy69bty47O5t0ImCxWKyCgoKtW7cqKysrKChs3LixsLCQdCKAL2psbDxz5gz7nIiTk1NoaGhrayvpUMCqqak5efKkvr4+jUabNm3a3bt3SScSYqgzeiMjI8PLy0tWVnbQoEE+Pj4VFRWkE0FHNTU1J06cGDVqlISExIwZMxgMBulEAH9TVVV18ODBYcOGSUlJLViwICUlhXQi6MSDBw9mzJhBo9GMjIxOnDjR0NBAOpHwQZ3RM9HR0c7OzjQazcDA4PTp042NjaQTQVdaWlquXr06ceJEiqImT54cGhpKOhEAq6SkZMOGDfLy8srKyt7e3mVlZaQTQTcePny4ePFiKSkpDQ2NPXv21NTUkE4kTFBncOrBgwdTp06lKMre3j4sLIzJZJJOBD1w79499kHJpEmTIiIiSMcBMfXy5csNGzbIyMiMGDHiwIED1dXVpBNBD5SWlm7ZskVRUXHgwIF79+6tr68nnUg4oM7oXnJy8owZMyiKsra2jomJIR0Hei8zM3PBggU0Gs3S0jIqKop0HBAj79698/b2lpOTGzZs2MGDBzEVKrwqKip8fHz69+8/cODAXbt24UxKt1BndCUrK4v935KFhcXNmzdJxwHuSEpK+lQ43rt3j3QcEHGVlZXt/1vCQbBo+FQ4Dh8+HIVj11BndC4/P3/+/Pk0Gm3ChAm3b98mHQe4LzY2dsqUKRRFubq64loh4IX6+vodO3b0799fTU1tz549uOJd9JSVla1bt05aWlpHR+fKlSs4n94p1BkdVVdXe3t7y8jIjB079q+//sLfjWiLjIycMGECnU5fv349rhsCbmEymf7+/pqamoqKiv/+97+xDkO0FRcXr1ixQkJCwsrKCtcNfQ51xv8wmczz588PGTJERUVl165dTU1NpBMBP7B/7+rq6vi9A1c8fPhw8uTJNBptwYIFpaWlpOMAnzx69GjKlCns33tJSQnpOAIEdcZ/JScnW1hYSEhILFu27M2bN6TjAL/V1tb6+PjIysqOHj0al79C75SXl3t5eUlKSk6aNCkhIYF0HCDg5s2b2tra8vLyPj4+WCLKhjqD9fLlS3d3dxqN5uTkhPP0Yq6goGDOnDkURbm5uRUUFJCOA0KjpaVl9+7dioqKmpqaV69exflWccZelyMvL6+trX39+nXSccgT6zqDyWSeOHFCSUlp5MiRN27cIB0HBEV0dPS4ceP69ev3+++/t7S0kI4Dgi4tLc3ExERWVtbX1xeLPYGtrKxsyZIlFEXNnz//1atXpOOQJL51Rn5+voODA51O37hxI27uBh00Nzfv2rVLVlbW2Ng4NTWVdBwQUPX19d7e3nQ63cbG5unTp6TjgMC5f//+6NGjlZWVT5w4IbazXBKknhNLUGtr66FDh4yNjd+9e5eQkHDo0CEFBQXSoUCwSElJeXt7Z2VlDRgwwNLSctOmTXV1daRDgWCJi4szNTU9fvz43r17Y2Nj9fT0SCcCgWNra/v48eM1a9asW7fO1tY2NzeXdCICxK7OyMjIsLS0/Omnn3788cfU1FQzMzPSiUBw6erqRkdHnz59+tKlS8bGxtHR0aQTgUD4+PHjmjVrpk6dOmrUqOzs7E2bNklIiN1YChySk5PbtWtXWlpafX29qampr69vS0sL6VB8JUafjdbW1t27d5uZmcnJyaWnp/v6+kpLS5MOBYKORqMtX748OzvbxMTEyclpzZo19fX1pEMBSezlOzdv3jx37lxoaOiwYcNIJwIhYGJikpSUtHPnzr1791pbWz9//px0Iv4RlzqjsLBwypQp27dv379/P2Y4oafU1dWDg4MvXrwYEBBgYWGRnZ1NOhEQ0NTU9MMPPzg5OdnY2OTk5Cxfvpx0IhAmdDp906ZNaWlpbW1t48ePP3v2LOlEfCIWdUZQUNCECROqq6uTkpI2bNhAo9FIJwKhtGTJkszMTBUVFTMzs927dzOZTNKJgH+ePn1qaWl56tSp48eP+/v7q6iokE4EQklPTy85OXnLli2rVq2aN29eZWUl6UQ8J+J1RlVV1dKlSxcuXLh8+fKHDx8aGRmRTgTCTVNTMyYmxtfXd9u2bdOmTSsvLyedCHiOxWKdPHly4sSJUlJSjx498vLyIp0IhBudTvf19Y2KikpJSRk3blxERATpRLwlynXG/fv3DQ0N7927FxkZeejQIRkZGdKJQBRISkp6e3s/ePCgqKjIxMQkNDSUdCLgoTdv3ri5ua1fv37r1q0MBkNXV5d0IhARdnZ2GRkZNjY206dP37p1qwgvDhXNOoPFYv3++++Ojo4TJ07MzMx0dHQknQhEjbm5eXp6+vTp02fNmvXLL7+0tbWRTgTcl5iYOGHChLy8vLi4OB8fHzqdTjoRiJQBAwYEBQX5+fkdO3bMzs5OVOdHRbDOqK2tXbhw4c8///yf//wnJCREVVWVdCIQTYqKimfPnr1w4cKhQ4ccHR3fvHlDOhFw08mTJ6dOnWpsbJyWlmZpaUk6DoislStXpqWlffjwwcTEJCYmhnQc7hO1OiMvL8/S0vLevXsRERHe3t5Y8gm8tnTp0vj4+JKSkokTJyYnJ5OOA1zQ2Ni4atWqtWvXfv/996GhoVjyCbw2ZsyYpKSkKVOmTJs2bffu3aTjcJlI1RmhoaHm5ubS0tJpaWk4VwJ8Y2pqmpqaqq+vb2tre+rUKdJxoE9evHgxZcqUoKCga9eu7dq1CzfgAv5QVFQMCgr67bff/vnPfy5evFiUbkAsIh+htra2n3/+edasWe7u7gkJCSNGjCCdCMSLqqpqWFjY5s2bvby81q5d29zcTDoR9MadO3dMTU2bmpoePXo0e/Zs0nFAvNBoNG9v79u3b0dGRlpZWRUUFJBOxB2iUGfU1dXNmzfv4MGDp06dOnHiBK4rASIkJSV37doVHBx85coVZ2fnDx8+kE4EPXP06NHp06dPmzYtMTFx5MiRpOOAmJo2bVpaWpqkpKS5uTmDwSAdhwuEvs54/fq1nZ3dgwcP7ty5s3LlStJxQNzNnTs3ISGhqKho0qRJYnVrYaHGYrF8fX03bNjw66+/Xr58uV+/fqQTgVjT0tJKSEhwcHBwcHC4cuUK6Th9Jdx1Rk5OjqWl5fv37xMSEqZMmUI6DgBFUdS4ceOSkpKUlJQsLS3j4+NJx4FuNDU1LV68eOfOnRcuXPD19SUdB4CiKEpWVtbf3/+nn35aunSpsP9ZCnGdERMTY21tPWTIkMTExDFjxpCOA/A/6urqsbGxVlZWTk5OAQEBpOPAF1VWVjo6Ot65c+fOnTtLly4lHQfgf2g0mq+v7/Hjx//zn/94enoK7428hLXOOH/+vKurq6OjY0xMzMCBA0nHAehIXl7+r7/+WrVq1aJFi4T9cERU5efnW1lZvXz5MiEhYerUqaTjAHTCy8srNDQ0KCho+vTpVVVVpOP0hlDWGTt37lyxYsUPP/wQGBgoJydHOg5A5yQlJQ8fPrxnz54dO3b88MMPLBaLdCL4n5SUFHNz8wEDBiQlJeEBziDIXFxcYmJisrKy7Ozs3r59SzpOj9GEbuz75z//uWvXrsOHD69bt450FgCOBAQELFu2zMPD4/jx47gfgyCIi4ubMWMG+z4ZOFYBoVBcXOzk5ESn06OiojQ0NEjH6QFhqjNYLNaWLVv++OMPPz+/FStWkI4D0AO3b99esGDBrFmzLly4ICUlRTqOWLt3795XX31lb28fGBiIy+BBiLx+/drZ2bm6ujoqKkqIHuknNIdWTCbTy8vryJEjV69eRZEBQmf69Onh4eG3b9+eO3duY2Mj6Tji69atW25ubl999VVISAiKDBAuQ4YMiY2NHTx48OTJk7Ozs0nH4ZRw1BltbW0rV668ePFiYGDgggULSMcB6A1bW9vo6OiEhAQ3N7fa2lrSccSRv7//3Llzv/nmm4sXL+LhqyCMVFRUIiMjdXR0HBwcHj9+TDoOR4Sgzmhqapo/f35wcPDt27dxJ2AQamZmZpGRkZmZmdOnT6+uriYdR7ycOnVqyZIlGzduPHbsGFbJgPBSUlK6c+eOgYGBvb19SkoK6TjdE/T1GS0tLQsWLLh///7t27etra1JxwHgguzsbCcnJ11d3YiICHl5edJxxMLZs2c9PT23bdu2fft20lkAuKChoWH+/PkMBiM6OnrChAmk43RFoOsMJpO5bNmy69evh4eH43afIEpyc3NtbW3HjRt369YtWVlZ0nFEXEhIyNdff/3TTz/t2LGDdBYArmlubp4zZ05KSsq9e/fGjRuf78ZYAAAgAElEQVRHOs4XCW6dwWKx1q5de+7cuRs3bri4uJCOA8BlGRkZdnZ2kydPDg4OxhUovHPz5s358+d/++23hw4dIp0FgMsaGhpcXV2fPn0aGxsrsLeBEdw648cff/zjjz+uXbs2Y8YM0lkAeCIpKcnZ2dnZ2TkgIEBSUpJ0HBEUHR09Y8aMRYsWnT59mkajkY4DwH3V1dVOTk6vXr2Ki4vT0tIiHacTAlpn/PLLL3v27Ll06dLXX39NOgsAD8XExEyfPn3hwoVnzpzB4kTuSkxMdHZ2nj179vnz5/GzBRH28eNHBweH6urquLg4dXV10nE6EsTP3n/+85/du3efOXMGRQaIPHt7++Dg4KtXr37//feks4iU1NRUFxcXZ2fns2fPosgA0aasrBwWFiYpKens7FxZWUk6TkcCN59x5syZVatWHT16dO3ataSzAPBJUFDQokWLfvvtt59++ol0FlFQUFBgaWk5ceLE69evS0tLk44DwA9lZWWTJ08eOnRodHS0QK0uF6w64/79+9OmTfP29v73v/9NOgsAX504ceLbb7+9cOECnk7eR+/fv7eyspKXl4+NjVVQUCAdB4B/nj17ZmVl5eDgEBAQIDjTeAJUZ+Tk5FhbW0+bNu3q1atYsQVi6Pvvvz969GhERISdnR3pLMKqubnZ1dU1Nzc3KSlp2LBhpOMA8FtcXJyzs/OmTZt2795NOst/CUqd8erVK0tLS01Nzbt37+KhAyCemEzm/Pnz4+LiEhISRo8eTTqO8GGxWN98882NGzcePHhgZGREOg4AGf7+/osXLz58+PD69etJZ6EoAakz6uvr7ezsKisrExMTBw4cSDoOADENDQ329vZv375NTEwcNGgQ6ThC5tdff92zZ8/t27ednJxIZwEgafv27Tt27Lh27dpXX31FOosA1BltbW3z5s1jMBgJCQmjRo0iGwaAuIqKCktLywEDBty7d69fv36k4wiNM2fOeHp6Hjt2DEvIAVgs1sqVK0NCQuLi4kxMTMiGIV9nbNmy5dixYzExMRYWFmSTAAgI9lqlGTNmXLx4kXQW4fDgwQMHB4etW7f+9ttvpLMACAT2WqW8vLyHDx+SnRwlXGf4+/svWrTo7NmzHh4eBGMACJqoqCgXF5eDBw9u2LCBdBZB9/r16wkTJrCvYsUScoBPPnz4YGZmpqmpGRkZSafTScUgWWc8e/Zs0qRJK1aswHMHAD63Y8eOHTt2REdHT548mXQWwdXS0uLg4PDmzZuUlBQlJSXScQAES2ZmpqWl5bp1637//XdSGYjVGTU1Nebm5srKyvfv38eNdAA+x2Kx5s+fn5CQ8PDhw6FDh5KOI6DWr19/4cKFpKQkAwMD0lkABNHly5eXLVvm7+/v7u5OJACZOuPTAJqWlqahocH/AABCAeV414gPoABCYcOGDefPnydVjpOpMzAhDMAh9unFlStXHjx4kHQWwZKRkWFlZbV+/fo9e/aQzgIg0MieXiRQZ0RGRrq6uh46dAgL3AA4cfXq1SVLlly5cgVPFvzk48eP48eP19bWvnPnDsEFbgDCory8fMKECVZWViEhIXzumt91xrt374yMjOzs7K5cucLPfgGE2saNGy9cuPD48WMtLS3SWQTCokWLYmNjHz9+jLuZAXAoNjbWwcHhzz//XLNmDT/75XedMWvWrEePHmVmZqqoqPCzXwCh1tTUNGnSJEVFxdjYWElJSdJxCLtw4YKHh8etW7fc3NxIZwEQJv/85z8PHjz48OFDPT09vnXK1zrj2LFjGzZsiI6Onjp1Kt86BRANT548MTMz+/nnn7dt20Y6C0lFRUUmJiaenp779+8nnQVAyLS2tk6ePLm5uTkxMZFvS8v5V2fk5+ebmppu3rx5x44d/OkRQMQcOnToxx9/jIuLs7S0JJ2FDCaTaW9vX1FRkZqaKicnRzoOgPApKCgwNTVdt27drl27+NMjn+qMlpYWGxubtra2xMREKSkpPvQIIHpYLNbMmTOfPn2anp7ev39/0nEI2L59+86dO1NSUvA4VoBeO336tJeX1927d+3t7fnQHZ/qDG9v7z///PPhw4djxozhQ3cAourt27dGRkZubm5nzpwhnYXfUlNTra2t9+7du3HjRtJZAITb119/HR8fn5GRoaqqyuu++FFnPHjwYOrUqSdPnvT09OR1XwAi79atW1999VVISMicOXNIZ+Gf+vp6Y2NjXV3dsLAwPMQEoI/ev39vbGw8efJkPlz7yfM6o7Gx0dTUVEdH5/bt2zztCEB8eHp6RkREPHnyRFlZmXQWPtm6devJkydzcnJwC3YAroiIiHB1dQ0NDZ0xYwZPO+J5nfHrr78ePHgwKytLW1ubpx0BiI+qqip9ff0ZM2acOHGCdBZ+yMjIMDMzO3LkiJeXF+ksAKJj6dKl9+7dy8nJ4elNQnlbZ2RlZU2YMGHfvn3fffcd73oBEEMBAQGLFi26e/eug4MD6Sy81draam5urqCgcP/+fZwxAeCiyspKfX19d3f3w4cP864XHtYZTCbTxsaGyWQyGAzcWQiA62bPnp2Tk5ORkSHaV3ju2rXL19c3PT197NixpLMAiJqLFy96eHjExsba2NjwqAsJHrVLURT7pmOnT59GkQHAC0ePHn337t1vv/1GOggPPX/+/N///rePjw+KDABeWLZsmZub26pVqxobG3nUBa/mM0pKSsaNG7dlyxZfX19etA8AFEX9+eefmzdvTk5OHj9+POks3MdisZycnN69e5eWlob77gDwCK//v+ZVnTF9+vTi4uJHjx7JyMjwon0AoCiKyWROmTKltbU1MTFR9NYunDt3btWqVUlJSRMnTiSdBUCUHTx40NvbOzMzkxf3uOJJnREWFjZ9+vTIyEgnJyeuNw4A7T158sTExOT06dPLly8nnYWbampqxowZM2fOnD///JN0FgAR19bWNn78+OHDh9+6dYvrjXO/zmhtbTUxMdHT0wsODuZuywDQqbVr116/fj0vL0+Ubkb+008/nTx5Mi8vT01NjXQWANF37949e3v78PBwFxcX7rbM/XWgR44cef78Od8e0AIAO3bsaGpq2rNnD+kgXFNYWHjo0CFfX18UGQD8YWdnN3v27B9++KGlpYW7LXN5PuP9+/ejR4/28vL6v//7Py42CwBd279//z//+c+cnBzRuCHe3Llznz59mpmZieWfAHxTWFior6+/Z88e7j5CiMt1xrp1665duyZi87cAgq+lpcXQ0NDQ0DAoKIh0lr5iz9+GhYW5urqSzgIgXry9vf38/Lh7vpKbdUZOTo6xsbGfn5+Hhwe32gQADt26dWvmzJn379+3tbUlnaX3mEzmpEmTBg8ejCciAfAfe/313Llzjxw5wq02uVlnuLi4VFZWJicnS0jw8PZfAPAlLi4u7LtNCO81rqdPn/72228zMzP19PRIZwEQR2fOnFmzZk1mZia3bo7HtTrjwYMHU6ZMiYmJsbOz40qDANBTmZmZpqamAQEB8+fPJ52lN5qamkaPHj19+vSjR4+SzgIgpphMprGxsb6+fkBAAFca5FqdYWdn19bWFhcXx5XWAKB3Fi5c+OTJk8zMTGGcVjxy5Mg//vGP58+fDxs2jHQWAPEVEhKyYMGC9PR0Y2PjvrfGnTojKirKyckpNjZ2ypQpfW8NAHotLy/PwMDg/PnzixcvJp2lZxobG3V1dRcsWHDgwAHSWQDEGovFMjc319DQ+Ouvv/reGnfqDCsrKyUlpfDw8L43BQB9tHz58qSkpJycHDqdTjpLD+zbt8/Hx6egoGDw4MGkswCIO/a68uTk5EmTJvWxKS7UGbdv354xY0ZSUpK5uXkfmwKAvisoKBg7duzJkyeF6Mqvuro6HR0dDw+P3bt3k84CABRFUZaWlioqKmFhYX1sp691Bnt2RV1d/caNG32MAgDcsmrVqqioqLy8PGlpadJZOLJz587/+7//KygoGDRoEOksAEBRFBUZGTlt2rS4uLjJkyf3pZ2+1hl//fXXvHnzHj16ZGJi0pd2AICLSkpKRo8e/ccff6xZs4Z0lu5VV1dra2uvW7dux44dpLMAwP9MmTJFWlo6KiqqL430tc4wNzcfNmxYSEhIXxoBAK779ttv7969m5ubKykpSTpLN37//ffffvutpKREWVmZdBYA+J+YmBgHB4c+rtLoU50RFxdna2ubkJBgaWnZ60YAgBcKCwtHjx7t7+8v4PfSaGlpGTlypLu7+969e0lnAYCOzM3NtbS0+nIvjT7VGbNmzaqsrIyPj+91CwDAO3Pnzi0rK0tJSSEdpCuXLl1asWJFQUGBpqYm6SwA0NHVq1eXLVuWm5s7cuTI3rXQ+zojLy9v7NixwcHBc+bM6V0LAMBTDAbDxsYmPj7e2tqadJYvGj9+/NixYy9fvkw6CAB0oq2tbfTo0TNnzjx48GDvWuh9nbF27dq7d+/m5eUJ/tlfALFlZWU1ZMiQa9eukQ7SuejoaEdHR65cow8APHLgwIFt27aVlJSoqqr2Yvde3pm4srLy0qVLW7ZsQZEBIMh++OGHGzduPHv2jHSQzu3bt8/Ozg5FBoAgW7VqlZSUlJ+fX+9272WdceTIERkZmW+++aZ3uwMAf8yZM0dHR+fw4cOkg3Ti2bNnERERW7ZsIR0EALqiqKjo5eV1+PDh5ubmXuzemzqjubn52LFj69atk5eX78XuAMA3kpKSmzZtOnfu3IcPH0hn6Wj//v1jxoxxc3MjHQQAurFx48aKioreXXXSmzrj+vXrFRUVXl5evdgXAPjMw8NDUlLy0qVLpIP8TW1trb+///r162k0GuksANANDQ2NWbNmnTx5shf79qbO8PPzc3NzGz58eC/2BQA+U1BQcHd37/W5VR65cuVKa2vrkiVLSAcBAI6sWrUqPj4+Jyenpzv2uM4oKiqKiYlZvXp1T3cEAFJWr16dlZWVnJxMOsj/+Pn5zZ8/X0VFhXQQAOCIk5PTyJEjz5w509Mde1xnnDp1avDgwa6urj3dEQBIMTc3NzExOXXqFOkg/5WZmZmWlobDFQAhQqPRPDw8zp0719TU1KMde1ZntLa2njt3ztPTk06n92hHACBr5cqV/v7+1dXVpINQFEUdP358zJgxNjY2pIMAQA94enpWVVX19PHsPaszbt269erVKw8Pjx7tBQDELVu2jMlk9uUhBdzS0NBw9erV1atXYwUogHBRV1d3dXXt6WKvntUZfn5+zs7Ovb7JOQCQoqysPHfuXEFYDRoQEFBfX79s2TLSQQCgx1avXh0dHZ2fn8/5Lj2oM169enXnzh1PT8+eBwMA8latWpWampqdnU02xrlz52bNmjVo0CCyMQCgF1xdXdXV1S9evMj5Lj2oM4KDg/v16zdjxoyeBwMA8qZMmaKpqRkYGEgww6tXr+Lj43E5K4CQotPp7u7uPToD24M6IzAwcNasWXJycj0PBgDk0Wi0efPmkV2iERgY2K9fv2nTphHMAAB94e7unpubm5GRweHrOa0zysrKEhIS3N3dexsMAMhzd3fPy8t7/PgxqQCBgYGzZ8+WlZUlFQAA+sjCwkJLS4vzmVFO64ygoKD+/fs7Ozv3NhgAkGdubt6jAYK7Xrx4kZiYiMMVAKFGo9Hmz5/v7+/PYrE4eT2ndQb7pImMjEwfsgEAYewBIiAggMMBgrsCAwOVlJScnJz43zUAcJG7u3thYeGjR484eTFHdcaLFy+Sk5NxFAIgAno0QHBXYGDgnDlzcLgCIOzMzMxGjhzJ4cwoR3WGv7+/srKyo6Nj34IBAHlmZma6urr8P3VSWlqampqKwxUA0cD5qROO6ozr16/Pnj1bWlq6z8EAgLx58+Zdu3aNz52GhIQoKys7ODjwuV8A4IUFCxaUlpamp6d3+8ru64wPHz4kJydPnz6dG8EAgDw3N7f8/Pwe3dGv78LDw52dnaWkpPjZKQDwyPjx44cOHRoREdHtK7uvM+7cuUOj0XAUAiAyrKyslJWVw8PD+dZjXV3dgwcP8JxnAJFBo9GcnZ25U2eEh4ezRyVuBAMA8uh0uoODAycDBLfcu3evqakJF8YDiBIXF5eEhIT37993/bJu6gwWi3X37l0chQCIGBcXl3v37jU0NPCnu4iICFNTU3V1df50BwB84OzsTKPRYmJiun5ZN3VGenr6q1evUGcAiBgXF5fGxsa4uDj+dBcREYFhBEDEqKioTJo0qduZ0W7qjPDw8CFDhhgZGXEvGACQN2zYsHHjxvHn1EleXl5BQYGLiwsf+gIAfnJ1dQ0LC+v66tbu6wxXV1cajcbVYABAnqurK3+WgoaHhysrK1tYWPChLwDgJxcXl1evXmVlZXXxmq7qjJqamuTkZByFAIgkFxeX3Nzc0tJSXnd09+5dR0dHOp3O644AgM/Gjx8/aNCgyMjILl7TVZ2RmJjY2to6efJkbgcDAPIsLCykpaXj4+N52guLxUpMTLS1teVpLwBAhISEhI2NTdfDSFd1RkJCwsiRI7FEHEAkycnJmZqaMhgMnvaSk5Pz/v17a2trnvYCAKRYW1szGIwulmh0VWcwGAyMDgAizMbGhtd1BoPBkJeXNzQ05GkvAECKtbV1RUVFXl7el17wxTqjra0tOTnZysqKN8EAgDxra+usrKyqqiredcFgMCwsLLA4A0BUjR8/vl+/fl0csXyxzsjMzKypqcF8BoAIs7a2ZjKZSUlJvOsC06IAok1KSsrMzKw3dQaDwVBWVtbX1+dNMAAgb9CgQaNGjeLdqZM3b94UFBSgzgAQbV2fge2qzrC0tJSQ4OjB8QAgpNhruHjUOIPBkJCQMDc351H7ACAIrK2t8/Ly3r592+l3v1hGJCUlYXEGgMiztrZOTk5ua2vjReOJiYnjxo1TUlLiReMAICAsLS1pNNqXzsB2Xme8f/++uLh44sSJvAwGAORNmDChrq7u+fPnvGg8PT0dwwiAyFNWVtbR0Xn8+HGn3+28zmDfQxSXogGIPH19fTqdnpmZyYvGs7KyMIwAiANDQ8Mv3X288zojMzNzwIABGhoavEwFAOTJyMiMGjWq68cT9M7r16/fvn2LpzACiAMjI6MvHa58cT4DowOAmDA0NOTFfAa7TcxnAIgDQ0PD/Pz8urq6z7/1xfkM1BkAYqKLCc++yMzMVFdXHzhwINdbBgBBY2hoyGQyc3JyPv9WJ3UGk8l88uQJjkIAxISRkVFxcXF1dTV3m8W0KID40NXVlZeX7/SIpZM6o6CgoLa2FgMEgJgwNDRksVjZ2dncbRbTogDiQ0JCQl9fn9M6IzMzU0JCwsDAgPfBAIA8LS2t/v37c3eJRmtr69OnTzEtCiA+vrTSq5M6Iy8vT1NTU15envepAIA8Go2mp6eXm5vLxTaLi4ubmprGjh3LxTYBQJDp6+s/e/bs8+2d1BlFRUU6Ojq8jwQAgkJbW7u4uJiLDRYVFbGb5WKbACDItLW1X7161djY2GF7J3VGcXGxlpYWP0IBgGDQ1tZmVwbcUlRUpKioqKqqysU2AUCQaWlpsVis0tLSDttRZwAApaWlxd06o6SkBJMZAGKF/ZH/fCTpWGcwmczS0lLUGQBiRUtLq7q6+sOHD9xqsKioCMMIgFhRUVFRUlL6/AxsxzqjvLy8qakJByIAYuVLByK9hmlRADHU6cxoxzqDXYlggAAQKyNGjJCQkOBinYH5DAAx1OmK8o51RlFRkbS09NChQ/kUCgAEgIyMjLq6OrcuOWlsbHzz5g2mRQHETacryjvWGaWlpZqamhISnT/3BABEFRcvbS0pKWGxWCNGjOBKawAgLLS0tLqfz3jz5s2QIUP4lAgABMbgwYPfvn3LlabY7airq3OlNQAQFkOGDKmoqGAyme03dqwzKisr1dTU+JgKAASCmppaZWUlV5qqqKigKGrAgAFcaQ0AhIWqqiqTyexw5VrHOqOiogK31gEQQ6qqquz6oO8qKyv79+8vLS3NldYAQFiw5yk6HLFgPgMAKIqiVFVVuTifgWEEQAyx5yk6HLFgPgMAKIqi1NTUuDifgWEEQAxxOp+BAQJADKmqqjY2NtbV1fW9KUyLAognWVlZeXn5ruYzmpqaamtrMUAAiKFOD0R6B9OiAGLr8zOwf6sz2N/DAAEghtgffK7UGZjPABBbn1+59rc64+PHjxRFqaio8DVUH5w7d45GowUHB3O+S2Nj49atW3V0dOh0Oo1Gq62t5V08wREREUGj0Q4ePEg6CHf09PeelpZGo9F8fX15Gap7vfhz5Sf2ZahceZRaVVWVsrJy39vhG4wkHMJIgpGkWyoqKh2GEXr7LxobGymKkpGR4Wso/tq5c+fvv/9OOgWAwGF/8JuamvreVGNjo2gPIxRGEoAvkJGR6TCM/G0+o7m5mRL1OuPGjRtKSko5OTltbW0sFktBQYF0IgCBwL7dBVfqjKamJtEeRiiMJABfICMjw64lPvnbfAZ7iBHtu+uUlZWNGTNm7NixpIMACBYpKSkJCYkOA0TvNDc3i/YwQmEkAfgCaWnp7uczBHaA+Pjx44YNG9TV1eXk5CZOnHjr1q3PX8Nisc6cOWNlZaWoqCgnJ2dsbPznn3+yWCyKojZv3kyj0SorK1NSUmg0Go1GW7t2LXuvhoaG7du3jx07VlZWVklJycHB4c6dO5/a/HRKMjY21tbWVlFRceLEie2337t3z8rKSl5efvjw4bt27WLvdfjw4TFjxsjKyurp6QUFBXHyBj81GB0dbWVl1a9fv0GDBq1evfrdu3fdhun6LXzCScs9fTtxcXFLlizR1dWVkZEZOHDgzJkzGQxGj95U1/r4e+9UF5kTExNpNNqGDRs67BIYGEij0fbu3cthj5zEFjSfDxC909TUJLDDCIWRpMswGEkwkvTR5+dNKFY7oaGhFEXV19ezBE9DQ4OJiUn75DQabeHChRRFBQUFsV/DZDKXLFny+dtevXo1i8XatGlTh+1r1qxhsVhNTU3W1tYdvkWj0Y4dO8ZuNjw8nKKoBQsW0On/nf4xNTX9tH3hwoWftrPt379/69at7bdISEikp6d3+x4/dSQpKdl+dz09vZqami7CcP4Wum25p2/n1atXn/28KTqdHhsby3nXPP29s1is1NRUiqJ8fHw4zGxmZqaoqNghnq2trby8/IcPHzjpkZPYAqh///5+fn59b0dOTu78+fN9b4cXMJJ0EQYjCUaSvlu1apWzs3P7LX+rM0JCQiiKam1t5W8qjuzZs4eiqDFjxkRFRdXU1BQWFq5bt479c//0475w4QJFUYaGhmFhYZWVlbW1tbGxscbGxhRFJSQksF+jpKRkbm7evuV9+/ZRFKWpqRkaGlpVVVVaWurr6yshISErK/vq1SvW///7pihq5cqVubm5n34+n7Zv3ry5uLi4trY2ODhYSkpKSUlJUVHx1KlTb9++rays3LJlC0VRy5cv7/Y9fmrQw8Pj+fPntbW1cXFxhoaGFEX9+uuvHV7TPgznb4GTlnv0dl6/fu3k5BQaGvrixYvm5uY3b94EBgbKy8u7urpy/qZ4/XvvMDp0m/nixYsURR09evRTjCdPnlAU9e2333LYIyexBdDAgQPZx1J9JCkpefXq1b63wwsYSTq8BiMJRhLuWr9+va2tbfstf6szrly5IikpyddEHDM3N6fRaNnZ2e03Ojg4tP9x29nZSUpKlpeXt38N+/fq7e3N/vLz0cHCwoKiqMTExPYbvby8KIo6ceIE6///fVtYWDCZzPavYW93cXFpv3HevHkURe3bt+/TltbWViUlpYkTJ3b7HtkNTpo0qX1HBQUFUlJSenp67V/TIQyHb4GTlnvxdtLS0hYsWDB06ND2hy/Dhg3j/E11gSu/9w6jQ7eZm5qahgwZMm7cuE+vX79+PUVROTk5HPbISWwBpKGhsX///j420tLSQlFUSEgIVyJxHUaS9q/BSIKRhOu+//57CwuL9ls6rs8Q2LOq+fn5GhoaBgYG7Te6uLi0//LJkydtbW3Dhw+n0+mSkpISEhISEhLsXUpLS7toWVVVlf0B+2TGjBnsb33a4ujoSKPRPt/d1ta2/ZcjRoygKGrKlCmftkhKSmpoaLx584aDd0lRFOXs7Ny+Ix0dndGjRxcUFLR/TYcwHL4FTlru6dtJSEiwsrIKCgoqLy9vbW399LKGhoaevqlO8eL33m1maWnptWvXZmdnx8XFURRVW1t78eJFZ2fnT4v+uu2Rk9gCqJMTqz0n4Mu8MJK0fw1GkvZfYiThis+vN/lbncFisSQkOj7xRIgwmUyKotra2tra2j7VvOxvdb2KvtOPfQdfuk2qrKzs5019vpGdjVs+D8PJW+BET9/Orl27mpubfXx88vPzGxoa2D/2MWPGcCUMh3r6e+ck89q1a6WlpY8ePUpR1MWLF6urq9ufle/1X5qAk5SU7PsfKrsFjCRfgpGk/UaMJD3qUShISEi0tbX9bUv7L6SkpAT2venq6r58+ZI9ofRJRERE+y/19PT69ev38ePHz2dyurh1mq6ubkVFRUpKSvuNYWFh7G9x9U1wJDIyktVusXFhYWFeXt7IkSO72IXDt9CLlrtVWFg4ePBgX1/fkSNHysrK0mi0goKC58+f9/1NsfHi985J5sGDBy9cuPDatWuvX78+duzYqFGjXF1dOe+Rk9gCiCv3vWDPZGAkYcNIwiGMJCIzkjQ3N3cYRv5WZ8jIyLS0tHC3XuaWefPmsVisefPmxcTE1NbWFhUVrV+/Pjo6uv1rPD096+vrHR0db9269e7du+bm5pKSktu3b8+bN6/DK9tbsGABRVELFy4MCwurrq4uKyvbsWPHyZMnZWRkvvrqK56/sc+kpKR4enrm5+fX1dXFx8fPmTOnpaVl/vz5XezC4VvoRcvd0tTUfPv27ZEjR6qqqqqqqsLCwtzc3D7/E+p117z4vXOYedOmTS0tLStXrszKyvruu+/aH04f90wAACAASURBVOd12yMnsQUQV65HlZaWptFoAltnYCTpYheMJBhJ+q6Tw5X2BdSNGzcoimpsbPy8tiKOw6uSPDw8On3n4eHh7Nd8vnqrqanJysrq8106XMp14MCBDpE63c5eRJ2VldV+o4GBgYaGRrfvkd3g/Pnzu71mrEOnHL6FXrTc7du5fv16h05NTU3HjRunqqrKeddd4MrvvcPqrW4zf8L+qfbv37+6urr99m57FMar0VgsloqKCnu5Xx/JyMhcvHix7+3wAkaSLjrFSIKRpO/WrFnj4ODQfkvH+QyKSzce5jpZWdl79+6tW7du8ODBsrKypqamf/31V4flMDQa7ezZswEBAY6OjioqKtLS0jo6OrNnz/7rr78cHR2/1LK0tHRUVJSPj8+YMWOkpaUVFRXt7OzCw8M/3XuHz6ytrcPDwydNmiQnJ6empubp6RkXF9f1XY05fAu9aLlbs2bNunz5spGRkZycnLq6+po1a6Kjoz+fe+9117z4vXOYmaIo9g9w5cqVioqKPeqRk9gCiFv3C+fW/b54ASNJF7tgJMFI0nfdzGfExMRQFPXu3Tv+Vj/wX1863BFqQv2m2Hd+zM/PJx2ET+h0Olfue6Gmptb+ngHAZ0L9ofsSoX5TYjWSLF68eM6cOe23/O1+bewaRGBPrALwTVtbW1RU1LFjx6ZMmdLHBW7Cgslktra2cuV6VGlpaQwjAJRYjiSfz2f87byJgC8UF3aPHz+mfdns2bNJByRAMH8mvr6+dDrdxcWlqanJ29ubSAb+Y5/p4Mp5k88voAcuEsxPDVmC+TMR25Gkw+GK0KzPAOCzoUOH7t+/v/1FaKKNi/fX4sr9vgBEgxiOJB2GERqr3bXIxcXF2traKSkpZmZmfM8GACSVlpaOGDEiKSnJ3Ny8j01NmjRp6tSp7EczAIBYsbCwsLGx+fRAWqrDfIaamhpFURUVFfzOBQCksT/47EGgj1RVVSsrK/veDgAIncrKyg73mf1bnaGgoCArK4sBAkAMsT/4X7ordo+oqanhcAVAPFVUVHRVZ1AUNWDAAAwQAGKooqKCTqcrKSn1vSnMZwCIp9bW1qqqqm7qDAwQAOKpsrJywIABXHmMlqqqKg5XAMTQ+/fvWSxWh9OvHesMNTU11BkAYqiiooIrizMoHK4AiCv2AUb38xk4EAEQQ5+v3uo1NTW19+/fd3g2NACIvE6Xk3cyn4E6A0AMcXc+g8lkfvz4kSutAYCwYE9kDhgwoP1GzGcAAEVxez6Doqh3795xpTUAEBYVFRX9+/fv6n6gFEUNHz68pKSEj6kAQCAUFxcPHz6cK02x2yktLeVKawAgLEpKSjQ1NTts7FhnaGlpVVdXf/jwgV+pAIA8Fov14sULbW1trrQ2YMAAJSWl4uJirrQGAMKiuLhYS0urw8aOdQZ7oCkqKuJPJgAQBOXl5Y2NjZ8PEL02YsQI1BkA4qaoqOjzw5WOdcaIESMkJCQwQACIFfahBbfmM9hN4XAFQNwUFRV1P58hIyMzZMgQDBAAYqWoqEhaWnro0KHcalBLSwuHKwBipbGx8fXr193PZ1AUpa2tjaWgAGKluLiYPZfJrQZRZwCIm5KSEhaL1f18BkVRWlpamM8AECudznb2hZaW1ps3b+rr67nYJgAIsi+dfu28zsCBCIBYKS4u5uLiDIqitLW1WSwWZkYBxEdRUZGSkpKysnKH7Z3UGaNGjcrPz8c9gwHER15enq6uLhcbHDlyJI1Gy83N5WKbACDInj9/PmrUqM+3d1JnjBs3rrGx8fnz57xPBQDkvX///uXLl4aGhlxsU0FBQVtbOysri4ttAoAgy8zMNDIy+nx753UGnU7PzMzkfSoAII/9Ye90gOgLIyMj1BkA4iMrK6vTw5VO6gwZGZlRo0ZhgAAQE5mZmQMGDODiRa1sRkZGOFwBEBOvX79++/Ytp3UGhQECQJxkZWUZGxtzvVlDQ8P8/HxccgIgDthzEz2oMwwNDTGfASAmvjTb2UdGRkZtbW05OTlcbxkABE1mZuaQIUMGDRr0+be+OJ9RXFxcXV3N42AAQBiTyXzy5Akv6gxdXV15eXnMjAKIg6ysrC+t8frifAaLxcrOzuZlKgAgr7CwsLa2luuLQCmKkpCQ0NfXx8wogDjoYlq08zpjxIgRSkpKjx8/5mUqACAvMzOTXRDwonEjIyMMIwAir6Wl5enTpz2rM2g0mrm5eWJiIi+DAQB5DAbD0NBQQUGBF41bWFikpqa2trbyonEAEBCPHj1qaGiwtLTs9LtffGyStbU1g8HgWSoAEAgMBsPGxoZHjVtbW9fV1WVkZPCofQAQBAwGQ01NrdObgVJd1xlFRUUvX77kWTAAIKyhoSE9Pd3a2ppH7evp6ampqeGIBUC0sQ9XaDRap9/9Yp1hYWFBp9Nx6gRAhKWkpDQ3N/OuzqDRaBYWFqgzAERbQkJCF8PIF+sMeXl5IyMjDBAAIozBYGhoaGhqavKuC2tr6/j4eN61DwBk5efnv379ujd1BoUlGgCijsFgTJ48maddWFtbl5eX4wHxAKIqPj5eRkZm/PjxX3pBN3VGenp6bW0tD4IBAGEsFispKYl3J03YJk6cKC0tjSMWAFHFYDAmTZokIyPzpRd0VWdYWVm1trampqbyIBgAEPbkyZP3799bWVnxtBc5Obnx48fj1AmAqGIwGF0frnRVZwwfPlxXV/fu3bvcTgUA5EVGRg4YMIAXT1DrwM7O7s6dO7zuBQD4r6ys7NmzZ/b29l28pqs6g6IoV1fX8PBwrqYCAIEQHh4+bdo0SUlJXnfk6upaWFiYn5/P644AgM/Cw8NlZWW7vgdPN3WGi4tLRkZGeXk5V4MBAGF1dXUPHjxwcXHhQ1+WlpbKyso4YgEQPREREfb29nJycl28pps6w87OTlZWFnOeACLm3r17zc3NTk5OfOiLTqc7ODigzgAQMa2trdHR0d0ernRTZ8jJyU2ZMiUiIoJ7wQCAvPDwcFNTU3V1df505+rqev/+/YaGBv50BwB8wGAwqqqq+lpnUBTl6up69+5dPAkJQJTcuXPH1dWVb925ubk1NjbGxcXxrUcA4LXw8PBRo0bp6up2/bLu6wwXF5cPHz4kJydzKRgAEJabm1tQUMCfxRls6urqhoaGOHUCIEoiIiI4OVzpvs4YM2aMjo5OWFgYN1IBAHkRERHKysoWFhb87NTV1RXDCIDIKC8vz8zMnDZtWrev7L7OoChq5syZ165d63MqABAIISEhbm5udDqdn53OnDnz+fPnWVlZ/OwUAHjk2rVrCgoKdnZ23b6Sozpj4cKFz549y8jI6HMwACDs1atXDAZj4cKFfO7XyspqxIgRgYGBfO4XAHghICDgq6++6vqKVjaO6gwLCwsMEACiISAgQEFBwdnZmc/90mi0efPmXb16lc/9AgDXlZeXJyQkuLu7c/JijuoMGo02f/58f3//vgUDAPICAwNnz54tKyvL/67d3d0LCgrS09P53zUAcFGPDlc4qjMoilq4cGFhYeGjR4/6EAwACHvx4kVSUhL/T5qwmZubjxw5EjOjAMIuMDBwzpw5HB6ucFpnmJmZYYAAEHYBAQFKSkqOjo6kAsybNy8gIIDFYpEKAAB99OLFi+TkZA5PmlCc1xkURc2fPz8wMBADBIDwCgwMnDt3rrS0NKkA7u7uRUVFDx8+JBUAAPooICBAWVmZ88OVHtQZ7AEiJSWlV8EAgLDCwsK0tDTOj0J4YcKECSNHjsRiLwDhxT5pwvnhSg/qjPHjxxsYGJw5c6ZXwQCAsHPnzg0ZMsTBwYFsjKVLl166dKmlpYVsDADohaysrNTU1KVLl3K+Sw/qDIqiPD09r1y5UlNT08NgAEBYW1vbuXPnPDw8+Hx7rs95enpWVFSEhoaSjQEAveDn56ejozN16lTOd+lZnbF8+fLW1tagoKCe5QIA0sLCwsrKylauXEk6CDV8+HBnZ2c/Pz/SQQCgZxobGy9fvuzl5UWj0Tjfq2d1hqqq6pw5czBAAAidU6dO2dvbd/tkRf5YvXp1ZGRkSUkJ6SAA0AMhISHV1dXLly/v0V49qzMoilq9enVSUhLuQQ4gRF6/fh0eHr5q1SrSQf5r5syZQ4YMwWIvAOHi5+f31Vdfqaur92ivHtcZU6dOHTVqFAYIACFy+vTp/v37z549m3SQ/6LT6cuXLz9z5kxbWxvpLADAkYKCgri4uF4crvS4zqDRaJ6enhcuXKivr+/pvgDAfywW6+zZs8uXLydyr/EvWb16dXl5eXh4OOkgAMCREydOaGho9OLRSD2uMyiK8vDwqKurw2pQAKEQGRlZUFAgOCdN2HR0dOzs7I4fP046CAB0r7Gx8fz5856enpKSkj3dl9a7+3suXbo0MzMzIyOjR4tOAYD/2McfkZGRpIN0dOPGjTlz5mRnZ+vr65POAgBd8fPz++6774qKinq6OIPqdZ2RmZlpYmISERHB/6dLAwDnsrKyjI2Nw8PDp02bRjpLRywWy8DAwMbG5uTJk6SzAMAXsViscePGWVpanjp1qhe797LOoCjK0dFRUlLyzp07vdsdAPhg+fLl6enpmZmZgjn1ePz48c2bNxcXFw8ZMoR0FgDoXGho6KxZs7KysgwMDHqxe2/WZ7Bt2bIlMjLy8ePHvW4BAHjq5cuXAQEBW7ZsEcwig6IoDw8PZWXlY8eOkQ4CAF+0b98+V1fX3hUZVF/qDBcXFyMjo4MHD/a6BQDgqUOHDqmpqS1evJh0kC+SlZVdu3btkSNH6urqSGcBgE6kpaXFxsZu2bKl1y30vs6g0WibNm26cuVKWVlZrxsBAB6pqalhL90i+BR4Tqxfv76hoeHChQukgwBAJ/bu3WtsbGxnZ9frFnpfZ1AUtWTJElVV1SNHjvSlEQDgBT8/v9bW1jVr1pAO0o2BAwcuW7bswIEDTCaTdBYA+Jvi4uKQkJB//OMffTn32qc6Q0ZGZuPGjceOHausrOxLOwDAXQ0NDfv27Vu1apWKigrpLN374YcfCgsL/f39SQcBgL/ZtWuXhoaGu7t7XxrpU51BUdR3330nKyu7d+/ePrYDAFx07NixDx8+/OMf/yAdhCNjxoxZtGiRr69va2sr6SwA8F8lJSVnz57dtm2blJRUX9rpa52hoKDw448/Hj58+M2bN31sCgC4oq6ubs+ePRs2bBg6dCjpLJzy8fEpKiq6fPky6SAA8F++vr7Dhw/v6dNZP9fXOoOiqA0bNigrK+/Zs6fvTQFA3/3xxx91dXU//vgj6SA9oKur+8033/j6+jY3N5POAgDU8+fPL1265OPj08fJDIordYacnNzWrVuPHj2KC08AiKuurt67d+/mzZsHDRpEOkvP/Otf/3r16tW5c+dIBwEAysfHR0dHZ9GiRX1vigt1BkVRa9asGThw4K5du7jSGgD02oEDB9ra2r7//nvSQXpMU1Nz5cqVv/32W1NTE+ksAGLtyZMnAQEBO3bsoNPpfW+NO3WGjIzML7/84ufnV1RUxJUGAaAXPn78eOjQoS1btgwYMIB0lt7Ytm1bRUWFn58f6SAAYs3Hx0dfX3/+/Plcaa33zzfpoLm5WU9Pz9bW9uzZs1xpEAB6ytvb+/Tp04WFhf379yedpZe+//57f3//vLw8RUVF0lkAxFFqaqq5ufm1a9dmz57NlQa5VmdQFBUQELB48eLExMRJkyZxq00A4FBBQYGBgcHevXs3bNhAOkvvvX//fvTo0atXr965cyfpLABih8ViTZkyhclkxsfHc+u5SNysMyiKsrW1bWlpYTAYAvvcJgBRNWvWrOfPn2dkZPR9fThZhw4d2rp1a3Z29qhRo0hnARAvly9fXr58eXJy8sSJE7nVJpfrjPT09IkTJ166dIkri1QBgEMxMTEODg7h4eEuLi6ks/RVa2uriYnJmDFjQkJCSGcBECMNDQ16enrOzs7cXSPF5TqDoqiVK1fevXv32bNn8vLy3G0ZADrV1tZmamqqpaV18+ZN0lm4IyoqysnJKTIy0snJiXQWAHHh4+Nz4MCB3NxcdXV1LjbLnetN2tu5c2dNTQ3uRA7AN8ePH8/NzRWlD52jo6Obm9v333+PO5ED8EdZWdm+ffu2bdvG3SKD4sV8BkVRu3fv3r59+9OnT0eMGMH1xgGgvQ8fPowePdrDw+P3338nnYWb8vPzDQwM/vjjD8F/5CyACPj666/T0tKePHkiIyPD3ZZ5Umc0NTXp6+tPnDgxICCA640DQHsbNmwICgrKy8tTUlIinYXLvv/++8uXLz99+lRVVZV0FgBRFhsba2dn99dff82aNYvrjfOkzqAoKiwsbPr06aGhoTNmzOBF+wBAUVRiYqKNjc2ZM2e++eYb0lm4r6qqSl9f39HR8fz586SzAIisxsZGExMTXV3dW7du8aJ9XtUZFEUtWbLk/v37OTk5oneYBSAImpubx48fP2jQoOjoaFG9kvzWrVszZ868c+eOs7Mz6SwAounXX389ePBgVlaWtrY2L9rn/jrQTw4dOtTS0vLrr7/yrgsAcbZz586ioiI/Pz9RLTIoipoxY8a8efO8vLxqa2tJZwEQQVlZWXv27Nm5cyePigyKp/MZFEVduHBhxYoVsbGxNjY2vOsFQAzl5uaamJj89ttvW7ZsIZ2Ft16/fq2vr79y5UpRuqAGQBAwmUwbGxsmk8lgMCQlJXnUC2/rDIqiXFxciouLHz9+LCsry9OOAMQHk8m0tbWtra1NTU3lygMVBdypU6fWrFkTHx9vaWlJOguA6Dh48KC3t/ejR48MDAx41wsPz5uwnThx4uXLl3hkPAAXHT9+PCkp6fTp0+JQZFAU5enpaW9vv3bt2paWFtJZAEREaWnptm3bfv75Z54WGRQf5jOo/18xpaSkGBsb87ovAJFXXFxsbGy8bt06sXrS2PPnz42NjX/66ad//etfpLMACD0WizVt2rSysrL09HSu3zCjA37UGUwm09HR8c2bN2lpaXJycrzuDkCEMZlMe3v7ioqK1NRUcfs0HTp06Mcff4yLi8PZE4A+2r9/v7e3d3x8vLm5Oa/74kedQVFUWVmZsbHx4sWLDx8+zIfuAETV9u3bd+7cmZKSYmRkRDoLv7FYrJkzZz59+jQ9Pb1///6k4wAIq+zsbDMzs23btv3yyy986I5PdQZFUcHBwe7u7jdu3Jg5cyZ/egQQMampqdbW1nv37t24cSPpLGS8ffvWyMjIzc3tzJkzpLMACKXGxsZJkyYpKSndv3+fd9eYtMe/OoOiqOXLl0dERGRmZg4ZMoRvnQKIhtra2vHjx+vo6ISHh4vwDTO6FR4ePn369CtXrnz99dekswAIn/Xr11+5cuXx48d8ewAZX+sMDJQAvfbNN9+Eh4ejTKco6ttvv/X398/IyNDU1CSdBUCYREREuLm5Xb58edGiRXzrlK91BkVRCQkJtra2Bw4c2LBhAz/7BRBq/v7+ixcvvnnzJh4YRFFUfX39hAkT1NXVo6KiJCR4fnE+gGh4/fq1sbGxi4sLnx8YJOnr68vP/oYPH85kMn18fKZNm6ahocHPrgGEVG5u7qxZs1atWrV582bSWQSClJSUlZWVr69vS0uLnZ0d6TgAQqC1tXX27NmNjY03b97k9YWsHfB7PoOiKCaTOWPGjOzs7IcPHw4cOJDPvQMIl9raWgsLC3l5+bi4OD6PDgLuxIkT3377bXBw8Ny5c0lnARB0P/74459//slg/D/27jMuiqt/G/jMNnrvRQFBqiCICIgdMGjEaBSMPTaMqCjRBI0mECuaxK4RLLcgRTGW2EDAhoCKgAoiC0gTUGnS67bnxdx/Hm4r6s6cLb/vi3wisHMuQHevnXPmTNqQIUMoHhpBz8Aw7PXr105OTsbGxteuXZOSDQ0B+AwCgeC77767fv16ZmamsbEx6jgiZ/HixXFxcffv37eyskKdBQDRdf78+WnTph0/fvz777+nfnQ0PQPDsMePHw8fPnzFihU7duxAEgAA0ffHH3+sX7/+6tWrcFf0d+rs7Bw1alRLS0tGRoaSkhLqOACIooKCgmHDhs2bNw/V/lXIegaGYVFRUfPmzTt9+rSPjw+qDACIrJs3b44fP3779u1r165FnUV0PX/+fOjQoe7u7rGxsaizACByWlpanJ2dVVRUbt++zWKxkGRA2TMwDFu2bFlUVNS9e/fIvo8LAOKloqJi6NChw4cPP3fuHFwE/mHXr1//6quv/vjjj8DAQNRZABAhAoHAx8cnNTU1KysL4YUXiHtGd3f36NGjGxoa7t69q6amhjAJAKKjo6NjzJgxLS0t9+/fh+mAvti+fftvv/2WkJDg7u6OOgsAomLz5s2bN29OTk4eNWoUwhiIewaGYS9evHB2djYzM7t27RqqszoAiA4+n+/j43Pr1q309HQLCwvUccSDQCCYOXPmtWvXUlNT4eQoABiGxcTEzJkz58CBA/7+/miToO8ZGIbl5eWNGDHCy8srJiYGThEDKbdmzZoDBw7Ex8ePGzcOdRZx0t3d7eXlVVpaevfuXdgyFUi5O3fueHp6rly58o8//kCdRTR6BoZh165dmzRp0oYNGyjeNwwAkXLkyJGlS5dGRETMnTsXdRbxU19fP3z4cCUlpdu3bysoKKCOAwAaxcXFrq6uzs7OFy5coOZOaR8mKj0Dw7Bjx44tWbLkP//5z/z581FnAQCB+Pj4yZMnh4SEbNiwAXUWcVVSUuLq6urk5PTvv/+KwjMsABSrq6sbPnw4cTtWEWnbItQzMAxbv379X3/9dfXqVQ8PD9RZAKBUdnb26NGjfX19jx07hjqLeMvIyBg7duzcuXMPHz6MOgsAlOro6PDw8Hj58uXdu3d1dHRQx/kv0eoZAoFg1qxZCQkJd+7cGTRoEOo4AFCkrKzMzc3NxsbmypUrTCYTdRyxFxcXN3PmzD///BOudAXSg8fj+fr6iuASctHqGRiGdXZ2Tpgwgc1mp6SkDBw4EHUcAEj34sWLUaNGEasKlJWVUceRELt27Vq7du2RI0cWLVqEOgsApBMIBAsXLjx9+vS1a9dGjhyJOs7/ELl7i8jKyl6+fNnLy2vcuHEpKSkmJiaoEwFAorq6uvHjx9Pp9Pj4eCgZQvTjjz82Nzf7+fnJycnNmjULdRwAyLV27dqYmJhz586JWsnARPB8BqGpqWncuHFNTU0pKSn6+vqo4wBAiqamJnd399ra2jt37vTv3x91HAkUFBT0119/xcbGws0NgARbv379H3/8ERMT4+vrizrLO4hoz8AwrLa2dsyYMTwe7/bt26KzngUAYWlvb/fy8iopKUlJSRkwYADqOJJJIBD4+/sfP378/PnzEydORB0HAOHbsmXLb7/9JspThKLbMzAMq6qqIuatb9y4oa6ujjoOAELT3d39zTffZGVl3bp1y9raGnUcSSYQCJYsWRITExMfHz969GjUcQAQpv37969atergwYPLli1DneW9RLpnYBhWUlIyatSo/v37x8fHq6iooI4DwJdqbGwUCARz5sy5e/fuzZs3Bw8ejDqR5ONyuTNmzEhOTk5ISDA2NtbT00OdCAAhOHz4sL+//86dO0X8ls401AE+YsCAAcnJyeXl5e7u7vX19ajjAPCleDyekZHR9evX9+zZAyWDGgwG4++//zYyMhoxYgRsqgEkw65du/z9/Tdt2iTiJQMT/Z6BYZilpWVaWlpjY+PIkSOrqqpQxwHg8zU1NX3zzTc0Gq2rq2v+/PmDBg06ePBgY2Mj6lwSSyAQ3Lp1a+7cuf3798/NzdXU1NyxY8eFCxdQ5wLgi+zYsWPt2rV//PHHxo0bUWfpA4GYePHihY2NjYmJSXFxMeosAHyO169fDxs2TFdXNzc3d8yYMTiO4zhOp9OZTObMmTNv3rzJ5/NRZ5QcVVVV27ZtMzIywjCMuBE0jUbLzs5etGgRi8U6c+YM6oAAfA4+n7927Vocx/ft24c6S1+JTc8QCATV1dWDBw/u379/YWEh6iwAfJqXL1/a2toaGRkVFRUJBIK8vLzed98g9gDV1dUNCgoqKytDHVaM8Xi8pKSkb7/9lk6nMxiM3j/hZcuWCQQCPp+/evVqOp1+/Phx1GEB+DR8Pj8gIIBOp584cQJ1lk8gTj1DIBA0NDS4uLjo6Ojk5OSgzgJAX5WXlw8cONDCwqKioqLngytWrHh7i3EGg4Hj+NixY+Pi4rq7uxFmFjuFhYXBwcF6eno4jvduGAQlJaXa2tqeLw4ODsZxfO/evQgDA/BJuFzuggULWCzW2bNnUWf5NGLWMwQCQVNT06hRozQ0NO7cuYM6CwAf9+jRIwMDg8GDB1dXV/f+eH19vaqq6jtnM4m2oa6uHhQUVFVVhSq5uIiKinJzc8Nx/H23hqHRaG+fZN6yZQuO4yEhITBdBURfa2urt7e3vLz8tWvXUGf5ZOLXMwQCQXt7+7fffisjIxMTE4M6CwAfEh8fr6SkNG7cuIaGhrc/e+jQIRrtvWuxcRy3tLRsamqiPrZ4+euvvz6wBI1Op1tYWHA4nLcfGBYWxmAw5s+f39XVRX1sAProxYsXjo6OWlpa6enpqLN8DrHsGQKBgM/nE2c+g4ODUWcB4N2OHj3KZDI/8DLG5XJtbGzePslPvDqqqqo+e/aM4sxiatmyZb3Xu7zhA28BExMTVVRU3Nzces+qACA6njx5YmRkZGpqWlBQgDrLZxLXnkEIDw9nMBgLFiyAmWwgUnr34A+flk9NTcVx/O0zGSwW6+7du5QFFndcLtfLy+vteRMmkzllypQPPzYnJ6d///4DBw6EBeZA1CQnJ6uqqrq6utbU1KDO8vnEu2cIBIKEhARlZWV3d3dim0UAkOvs7Jw5cyaLxYqMjOzL10+bNu3tF8iQkBCyc0qY6urqfv36vfGTZDKZJSUlH31sVVXVkCFDNDU1U1NTKYgKQF/85z//YTKZ06dPN1BstgAAIABJREFUb29vR53li4h9zxAIBJmZmXp6era2trC1BkDuxYsXrq6uampqN27c6ONDnj9/Lisr2/tkxujRo2VkZODCy757/vz5kCFD1NXV1dTUeiZQGAzGxo0b+3iE5uZmLy8veXl52FoDIMflctetW4fj+C+//CIB65QloWcIBIKysjJ7e3s1NbUrV66gzgKk1507d/T09AYOHPj06dNPemBwcDDx6kin07///vueaRc/P793LmAEvaWnp+vq6pqbm7PZ7MzMTFlZWWIPNG1t7dbW1r4fh8Ph+Pv74zj+008/wY8doFJXVzd+/HhJeqchIT1DIBB0dHQsWrQIx/GgoCAej4c6DpA6YWFhLBbr66+/fuelJR/W1tZG3NxrzJgxPYuNTp06JS8vP378+M84oPSIiYmRk5ObMGFCz8zpP//8Qyx5iY6O/owDRkVFycvLjxo16uXLl0JNCsDHZWdnm5iYGBoa3rt3D3UWoZGcnkEgnusnTpz4+vVr1FmAtOjo6FiwYMEXdtzTp09bWVm9USmys7P79+9vZmb2qSdIpAGXyw0KCsIwLCAg4I0fe2hoqKur62efcH748OGAAQMMDAxgKS6g0smTJ+Xl5UePHv3q1SvUWYRJ0nqGQCB48OCBkZGRmZnZ48ePUWcBki8pKWno0KHq6uoJCQlfeKh3PrlUVVU5OzsrKytfunTpC48vSZqbmydPniwjI/O+DZi/8GxEfX29l5eXjIzMzp07S0tLv+RQAHxUZ2dnQEAAjuMBAQGSN2cngT1DIBC8fPly1KhRCgoK4rUJPBA758+fZ7FYOjo6bDabvFE6OzvnzZtHp9NDQ0PJG0WMFBUVWVtb6+npkXpumcfjzZkzB8MwX1/fT1rnAcAnKS0tJd5LiN2G4n0kmT1DIBBwOJw1a9bgOD5jxgyY3gZC19bWtnTpUmJFBYZhpqamZG/Vt2fPHhqNtmjRIinfvDIxMVFNTc3e3r68vJy8UZqbm3/44Qccx83MzDQ0NMzNzR88eEDecEBqRUVFqaio2Nra5ufno85CFontGYTk5GQDA4N+/frdunULdRYgOXJzc21tbVVUVGJiYpqamphMJo7jNBpt9erVbW1t5I179epVFRWV4cOHS9j0bd+FhYUxmcwZM2aQ+nNOTEw0MDAg9mnduXPnq1evJkyYwGAwgoODuVwueeMCqdLU1DR37lzisjJS/z4jJ+E9QyAQ1NbWfvPNN8S8l5S/EQRfjs/n79mzh8VijR07tufmqxMnTiSuSmUwGP369ev7zhmfoaCgwMLCwtDQMDMzk7xRRBCHw1m+fHlftlj9Ek1NTYsXLyZaI7EJB7H1O/F7l5GRcXV1hX16wJe7e/euqamptrb25cuXUWchneT3DEJERISiouLQoUPFd4t4gNzLly+9vLzefl974sSJnpclOp2O4/iSJUtaWlpIilFfXz9u3DgFBQVJnc19W11d3dixYxUVFc+fP0/eKPHx8bq6ur13FLWxsen9Bbm5uXZ2dioqKlFRUeTFAJKNw+EQ++WMHz/+xYsXqONQQVp6hkAgyM/PHzJkiKKi4r59+2CDDfCpTpw4oa6ubmFh8faJhIaGhjfuhcZgMAwMDJKSkkgKw+FwiNXpQUFBEn8mPzs729jYeMCAAbm5uSQN0djY+MZpDGLP8i1btrzxlW1tbcuWLcNxfPbs2XDrNfCpcnJyhg0bJicnd/DgQQnY6LOPpKhnCASCrq6ujRs3MplMV1fXJ0+eoI4DxENxcbGnpyeNRlu5cuX7rjsYN27cG/cL7TmxQd6N3SMiIuTk5Ly8vOrr60kaArnIyEg5ObkxY8ZUV1eTNMSVK1d0dHTevsUMhmHv27bk8uXLhoaGmpqaJ0+eJCkVkDAdHR0bNmwgXn2kbTsc6eoZhNzcXBcXFyaTGRQU1NnZiToOEF08Hi8sLExRUdHGxubDl5OEhYW9877kTCZTW1v74sWLJCXMysoyNjbu379/RkYGSUOg0rOjAHnnbBoaGhYvXoxhWO/TGD3MzMw+8Ni2tragoCA6ne7l5QUbbIAPS01NtbKykpeXDw0NlfgTkG+Txp4h+L/XDyUlJTMzM1JX7QHx9fjx42HDhvWxj1ZXV7/ztYp4DcNxfPHixSRtv1NbW+vh4SErK3vs2DEyjo9EZWWli4uLkpLSP//8Q9IQ165d09DQeGPCqweLxerLPdjS0tKsra2l9vUDfFRjY2NAQACNRpswYUJZWRnqOGhIac8glJaWenl50Wg0f39/2Kcc9GhtbQ0KCmIwGG5ubn0/w+nm5vbOqsFgMMhewEjswE1cICcBF1WlpKQQ90UjdXKzpqZm7Nix72uHGIY9fPiwL8fp7Oz87bffWCzWsGHD+vgQICXOnDmjr6+vra0dExODOgtKUt0zCCdPntTS0tLU1Dx06BC8I5FyfD4/MjLSwMBARUXl4MGDn7ReeN++fW+/OWYwGIMGDSKujSTbhQsXlJWV3dzcxHoRO7FDxuTJk3vui0YePp8fGhpKo9Hebhv9+vX7pEPl5ua6urrS6fQlS5aQt5QEiItHjx6NHTsWx/H58+fX1dWhjoMY9AyBQCBoaWkJDg6WkZGxtLS8evUq6jgAjQcPHhDnJObOnfsZG2FVVlYStwntbdq0ae3t7WSkfSc2m21lZaWtrS2Os4EdHR3z58+n0+mk7pDxths3bigqKvZeB8pisYKCgj71OHw+Py4uzsjISEFBITg4GNZ+Saf6+vqAgAA6ne7o6Hjnzh3UcUQC9Iz/r7Cw0MfHB8MwDw8PaVsPLOWqqqr8/PxoNNqYMWO+5NS3o6MjUTUYDAaLxdLS0nJ3d6f4JFlzc/O3337LYDDE62YoRUVFtra2Ghoa165do3jo8+fP4zg+cODA3it5P3tdbVtbW2hoqKKiopmZWVxcnHCjAlHW3d29Z88eVVVVfX39sLAw2D2hB/SMNyUkJFhbW8vIyPz8889wYxSJ19raunnzZgUFBRMTky9fcvjHH38wGAwGgzFw4MCnT58+evRITk7ut99+E0rUvuuZDpg9e7ZY7Gd85coVNTU1BweHkpISiocuKytTV1f38/PjcDhr167FcRzHcV1d3S88oVJWVubr64thmKenZ05OjrDSApF18eJFCwsLWVnZX375hbw9+sQU9Ix34HA4+/btU1dXV1NT27JlS3NzM+pEQPg6Ojp2796to6OjqKi4devWjo6OLz9mSUkJhmGzZs3q2Wbj77//ptFo8fHxX37wT3X16lV1dXV7e3tR3ie7pxLNmTOH+krU2dnp6OhoZ2fXM7d14cIFJSWlVatWCeX4KSkpQ4YModFoM2fOJPWOvgChpKQkV1dXDMOmT58OVzi/E/SM92ppaQkNDVVVVdXQ0AgODoa2ITG6u7vDwsIMDAxkZGT8/PxevnwpxIO/vVXGvHnz1NXVkVzSVlxcPHjwYA0NDdG8h0Jtbe3EiRNZLNbff/+NJMDSpUuVlJTeaADFxcVCvM6Fz+dfvHhx8ODBNBrNx8ensLBQWEcGyKWlpY0bN46Yar9//z7qOKILesZH1NfXBwcHKysra2lphYaGUrmmDwgdh8OJiIgwNTVlsVh+fn5VVVUUDNra2mptbe3i4oLkitO2trbvv/8ex/GffvqJpA08Pk9qamq/fv2MjIzu3r2LJEBsbCyO4+Ttz9Ebj8eLi4szNzdnMplz584V5TNMoC/u3bs3adIkDMPc3NzEcc01xaBn9El1dXVgYKCcnJyhoeGBAwfEYs4b9NbZ2Xn8+HEzMzMmk+nn5/f8+XMqR2ez2UpKSmvWrKFy0N4iIiIUFBScnJyoXwDxNuLep0wm09vbG9WO6QUFBUpKSoGBgVQOyuFwjh07ZmxsLCMjs3z5clH4XYBPlZaW1tMwrl+/jjqOeICe8QmqqqpWrFghJyenoaGxcePGz7j0EVDv9evX27Zt09PTY7FYCxYsQPXkHhMTg+M4wjus5ufn29raqqioUPMO/n3q6uomTpxI3PMW1YJ84gyTs7MzkjNMXV1dhw4dMjIyotPpvr6+cL5dLPB4vLNnzxLrMFxcXJCsuBJf0DM+WW1tbWhoqL6+PovFmjt3LtyPTWSVlpYGBQWpqKgoKysHBARQfA7jbUuWLFFVVaVmz6536ujoIO4YEhAQgOQl9v79+8bGxv369UtLS6N+9B7Eihm0S/Z4PN7FixddXFwwDHN0dIyIiIBNAkVTZ2dnRESEpaUljUabNGkSeTdhlmDQMz5Te3v74cOHLSwscBz/+uuvYYpOpNy/f9/X15dOpxsZGe3evVtE1vB2dHQMGTKk99UNSCCZQxGFuRJCWFgYqiuA3unmzZtff/01juPm5uaHDx+GFWCi49WrV7/++qumpqacnNwPP/xQUFCAOpG4gp7xRfh8flJSEjFdZ2FhERoaWlNTgzqU9GpqagoLC3Nzc8MwzN7ePiIiQqRWPgoEgmfPnqmoqPzwww9oY1A8h0JcV4J2roTw+PFjOTm5vtwgjWJFRUUBAQFycnIqKip+fn7Z2dmoE0kvHo+XlJTk4+NDbLUXFBQk1hv5iwLoGcKRlZX1ww8/KCsry8jIzJgxIzk5mcqNk0FaWtqCBQsUFBTk5eXnz5+fmpqKOtF7/fvvvziOR0REoI1B2RyKiMyVCASC5uZmCwuLMWPGiOwMRXV19Y4dO8zNzTEMGzZs2JEjR2DHJypVVlZu2rTJ2NgYw7CRI0dGREQIZVsdAD1DmFpbW48fP06sFTI1Nd22bRsUYVLV1dXt3r3b2tqaOIFx8OBBCm6+9eVWr16toKCQl5eHOgi5cyiiM1dChJk2bZqOjo7o/5Pk8/k3b96cPXu2rKyskpLSkiVLYK0oqTgczr///jtp0iQ6na6lpbVmzZr8/HzUoSQK9AxS5OfnBwUFaWlp0Wg0Nze3PXv2wMUpQtTY2BgRETFp0iQWi6WkpOTn5yde9yvq7u52c3OzsLAQhYUjPXMoZ86cEeJhRWeuhPDXX3/R6fTk5GTUQT5BY2NjWFiYvb09hmHGxsYBAQHi9fdcxPF4vDt37gQEBOjq6tJoNA8Pj4iICFgfQwboGSTq6Og4c+aMj4+PvLw8g8EYP3780aNHkb+xE1/Nzc1RUVGTJ0+WkZGRkZHx9vaOiorq2eFbvFRUVGhqan733XeogwgEveZQ/Pz8hLI3THJysoGBQf/+/ZHPlRDu3bvHYrG2b9+OOshnun//fmBgYL9+/TAMs7KyCgkJgRs9fjYej3f79u3ly5fr6OgQ50G3b98O+4WTCnoGFVpbW2NjY6dOnSorK8tkMidOnHjs2DHhbnctwerq6qKjo3v/9E6cOCEBt7hLTk6m0+nh4eGog/xXdHS0ioqKjY3No0ePPvsgHR0dgYGBOI7PmDFDRH5H9fX1xsbGEydOFIXTKl+Cz+enpqYGBATo6+tjGGZra7t58+aHDx/CUrC+6OrqunHjxhs/PbiEhBrQMyhFvCP39vaWlZXFcdzBwWH9+vUpKSmidlkEcjwe7/79+yEhIc7OznQ6nclkSuTZoA0bNsjKymZlZaEO8l/l5eWjR49mMpmfN9mRl5dnb2+vrKwcFhZGRrzPwOPxvLy8+vXrV1tbizqL0PB4vFu3bvn7++vq6mIYpq+vv3Dhwri4OBEpdiKlrKzs8OHDU6ZMUVJSwjDM2to6ODhYFJZGSRXoGWi0tbVdvnx5+fLlpqamGIapqqpOnz796NGjlZWVqKOhVF1dffLkyVmzZmlqamIY1q9fvyVLlpw9e7apqQl1NFLweDxPT09TU1PRWb5KLN5ksVjjxo2rqKjo+6PCwsLk5eWdnZ2LiopITfhJNm3axGQyRWT6Ruh4PF5mZuaWLVvc3NzodDqDwRgxYsTWrVuzsrLE/eTNl+jo6EhKSlqzZg2xQlxBQcHb2/vgwYNwWxlUcIFAgAGkSkpKkpOTk5OTExISWlpa9PT0RowY4ebmNmLECAcHBxqNhjoguUpKSlJTU9PS0lJTU/Pz8+l0urOzs7e3t4eHx5AhQ3AcRx2QXDU1NQ4ODo6OjsT1rqjj/FdmZuacOXNevXp16NChWbNmffiLq6urFy1adO3atTVr1mzevJnJZFIT8qNu3brl4eGxZ8+eFStWoM5CutbW1ps3b16+fPnq1auVlZWKioouLi5ubm6Ojo6jRo1SUVFBHZBczc3NGRkZPc8knZ2dAwYM8PDwmDRp0vjx42VkZFAHlGrQM0RIR0dHeno68U/l3r17LS0tqqqqw4cPHz58+IgRI+zt7cXryUIgELzzhbO1tTUnJyctLS0tLS09Pb22tlZeXt7JyWnkyJHDhw8fOXKkoqIi9WkRun37toeHx86dOwMDA1Fn+f86OjrWrVu3f//+6dOnh4eHq6qqvvPLEhISFixYICsrGxUVReyQJiKqq6sdHBxGjBgRFxeHOgulBAJBbm5uSkoK8WRSUVHBZDIdHBzc3Nzc3NycnJz69+//zkeJTs3tCx6PV1hYeO/evdTU1PT0dDabTaPRrK2tiW9z9OjR7/w2ARLQM0QUj8djs9lEN09LSyspKcEwTE9Pz8bGxtra2tHR0cbGxsbGRlZWFnXS97p48aK9vX3//v1fvHiRlZX19OnTvLy8rKwsNpvN5/N1dHScnJyIMzdOTk5S/oZj+/btwcHBN2/eFKmXagzDrl27tmDBAhkZmZMnT44YMaL3p4gism/fvrlz5x46dEik2iGPx/vqq6/Ky8szMzPFq50L3cuXLzMzM4lnkoyMDA6Ho6ysPHDgwJ6nEXt7e01NzQMHDoj4WZ+GhgbiCYR4Jnn48GF7ezuTybSzsyPO/o4bN05DQwN1TPAO0DPEQ2Vl5ePHj3Nzc4n/FhQUcLlcFotlbW1tZWVlbGxsYmJibGxsbGxsZGTEYrGQhORwOJWVlaWlpWVlZaWlpRcuXHj16lVbW1tHRwedTjczM7Ozs7O1tbW1tR08eLCJiQmSkKJJIBBMnTo1Kyvr4cOHxNoU0VFTU7No0aKEhITe0yKZmZmzZ8+uqak5dOjQzJkzUWd807p16/bu3Zuenu7g4IA6iwhpaWnp/TTy5MmT5uZmHMf19fVramqWLVtmYmLS80yCsJ9VV1cTzyHEf4uLi3NycmprazEM09XVtbW17XkmsbW1FZ15OvA+0DPEUnd399OnT3Nzc4nOQfxrbGlpwTCMRqPp6+sTzxdaWloaGhrEfzU0NDQ1NYn/YTAYnzEoj8er/191dXW1tbW1tbXl5eWlpaVVVVVcLhfDMHl5eRMTE+JTmzZt8vLysrGxkZOTE/JPQbI0NDQ4OjoOGDDg2rVrdDoddZz/IRAIjhw5EhgYOGjQoMjIyISEhJ9//pnYmNnAwAB1ujdduXLF29v72LFjCxYsQJ1FpAkEgrKystzc3B9//LG4uNjBweHly5evXr0iPquurk68gdHX19f4P5qamj3PJ/Ly8p83bnNzc93/6f1kUlFRQXSL9vZ2DMMYDIahoaGxsbGpqamNjY2dnZ2dnZ2WlpbQvn9AFegZkqO+vr7nHUBZWVl5eXltbW19fX1tbW1zc3Pvr1RRUaHRaPLy8sRshZqaGoZhLBZLQUEBw7COjo7Ozk4Mw5qamvh8PofDaW1txTCsoaGh90GUlJSIEqOpqdm/f/+ecyomJiba2toYhunq6lZXV3t7e1+8eJGiH4GYe/DgwciRIzdu3Lhx40bUWd4hLy9v+vTpRUVFNBotNDSU2CcDdag3VVRUODg4eHl5RUVFoc4iHm7cuOHu7o5h2Llz56ZOndrR0dH7XEJZWdmrV6962gCPx+t5oJycHLGlDTFlpqCgwGKxcBwnlvLweDziaae9vb2rqwvDMOKiqtbWVg6H03MQGRmZnhJjaGjY8xxC3BPn894RAVEDPUMqcDicN05F8Pn8nj5BFIiuri7ibYSsrCxx7kFVVRXH8Z7+8cZJkQ/Pzrx+/bpnrjQ1NVXUlh2IrP37969evTohIcHT0xN1lv/B5/P379//yy+/KCoq1tXVeXh4HDlyRNSW2nE4nDFjxjQ3N9+/f/+z321LFYFA4OTk9PjxYxqNtn79+pCQkA9/fUNDQ++TEJ2dnVwulziT2tbW1t3dzefzm5qaMAyj0WjEzMsb72cUFRWJpxHimUSklvUAsiC4lhZIgevXrxN/wRgMhouLC+o44mT27Nna2tpVVVWog/x/xcXFY8aMYTAYQUFBXV1d9+7ds7KyIvbjEqnNKFesWKGoqAh7cvfdmTNniH+nOI57e3ujjgMkk4TvzQBQefz4MbE+i8vl3rt378qVK6gTiY3Dhw+rq6vPmjWLWOyClkAgCA8PHzx4cH19/f3790NDQ1kslrOzc3Z29rJly/z9/b28vJ4/f446JoZhWFxc3IEDB/7++28rKyvUWcQDj8dbv349sUOPQCDIzs5GnQhIKNRFB0im+fPn98yt0ul0S0tLad6g8FPl5OTIy8uvW7cObYyCgoIRI0YwmcyQkJDu7u63v+Du3buWlpbKysrh4eFoT2wUFhYqKyuvWLECYQaxExYW1nsbQBzHYedyQAboGYAUxI6/PWg0WmRkJOpQ4uTYsWM4jp8/fx7J6N3d3Vu3bpWVlXVwcPjwbdU6Ojp++uknOp0+ZsyYwsJCyhK+kcHBwcHJyamzsxNJAHHU3t6uo6PzxkrelJQU1LmABIJ5EyB8XC63qKio90cEAsG6deuIZeegLxYuXPj9998vXLiwtLSU4qEfPnzo6uq6ZcuWoKCge/fuDR48+ANfLCsru3PnzszMzNbWVjs7O+LMB2VRCf7+/mVlZadPn5by3d4+yd69e+vq6gS9rgNgMpmPHj1CGAlILNRFB0ignJyct/+m0en0PXv2oI4mTqh/m97W1hYUFESn00eNGsVmsz/psRwOZ8+ePYqKira2tnfv3iUp4duioqIQnvgRUw0NDcrKym/8C2UwGIsWLUIdDUgg6BlA+CIjI995+zdVVVVJvfMqSYhlBytXrqRgrCtXrhgZGamqqn7JVSTFxcXjx4/HcdzPz6+5uVm4Cd+Wm5srLy8fFBRE9kAS5ueff37nNpp2dnaoowEJBD0DCN+aNWveubsGg8H47bffUKcTM6dPn8YwLCoqirwhysrKvv32WwzDZs2aVV1d/YVH4/P5J06cILZdOn36tFASvlNLS4uVlZWrq+s716iC96mqqnrfBBOLxeJwOKgDAkkDPQMI39ixY983TycnJ/flr2TSZvny5SRtC9HR0bF582Z5eXlzc/Nr164J8cg1NTULFy7EcXzcuHF5eXlCPHKPOXPmaGtrV1ZWknFwCbZ48eIPbGxP0i8LSDPoGUD4iI3/3nif1PPUhvxyTbHT3d3t6uo6aNCgtrY2IR42OTnZyspKXl4+ODiYpCUgmZmZLi4uDAYjICBAuFNm+/fvp9FoiYmJQjymNCgrKyPONeI4LiMj80bhoNFoMTExqDMCSQM9AwjZixcvej9tqaurq6iorFmzJjw8/Pbt2zU1NagDiqXy8nINDY2FCxcK5WgVFRVz587FMGzSpEllZWVCOeb78Hi8iIgILS0tPT29iIgIoWyzkZGRISMjs2nTpi8/lBTq7OzMyck5c+bMli1bnJycFBUVe9/jEBa7AKGD+5sAISsqKoqLi7OwsLCwsDA3N79y5YqPj09LSwvcb+ILCeU2pB0dHTt27NixY0f//v337dv31VdfCTHhBzQ0NISEhBw8eNDNzW3//v12dnZfciiRvbGt2Pnhhx/YbPatW7eqqqrYbHZBQYG8vPz333+POheQLKiLDpBweXl5GIY9fPgQdRBJ8PPPP8vKymZnZ3/ewy9evGhiYqKgoEDeRMmHZWVlDR8+nMFg+Pn5EZs3fCo+nz9lyhRDQ0M4MSYUo0ePXrp0KeoUQMLBPl2AXGZmZgwGg81mow4iCbZu3Tps2LAZM2YQd9zuu2fPnk2aNGny5Mk2Njb5+fkhISFItrQaMmRIamrqsWPHLly4YGFhsXfvXj6f/0lH2Llz5+XLl2NjY7W0tEgKKVXYbLaFhQXqFEDCQc8A5GKxWCYmJgUFBaiDSAIGgxEXF9fa2rpkyZI+PqS9vT0kJMTW1vbZs2eJiYmXLl3q168fqSE/DMfxefPmFRQUzJ49e82aNc7OzhkZGX187N27d3/99dcdO3aMGDGC1JBSorGxsbq62tLSEnUQIOGgZwDSWVpaQs8QFh0dnejo6LNnzx44cODDXykQCGJjY62srPbs2RMaGvrkyRNPT09qQn6Uqqrq3r17Hzx4ICMjM3z48GXLltXU1Hz4ITU1NT4+Pl5eXoGBgdSElHjEWUY4nwHIBj0DkM7S0hLmTYRo7Nixv/32248//nj37t33fU1KSoqzs/OcOXPc3d0LCgpWrVrVc/tc0eHg4HDnzp3jx49funTJzMxs69at7e3t7/xKPp8/Z84cBoNx4sSJN279BT4bm82WlZU1MjJCHQRIOOgZgHQWFhYFBQWfOhMPPmDjxo3u7u7fffddfX39G58qLCz09fUdPXq0iopKVlbW8ePHdXR0kITsC2IapbCwcMOGDTt37jQ3Nw8PD+fxeG98WUhISEpKytmzZ9XV1ZHklEgFBQXm5uZwzQ4gG/QMQDpLS8v29vaKigrUQSQHjUaLjo7GcXz+/PmC/7s0vb6+ft26dba2tk+ePImLi0tKSrK3t0ebs4+Ie5QUFxdPmzZt+fLldnZ2ly9f7vns9evXt23btnfvXkdHR4QhJQ+bzYbFGYAC0DMA6aysrDAMgyUawqWurn769OmkpKSdO3e2t7fv2LHD1NT05MmT+/fvz83N9fHxQR3wk2lqau7du/fJkyc2Njbe3t6enp6PHz+urKycOXOmj4/P0qVLUQeUNHCxCaAG9AxAOnV1dU1NTViiIXTOzs7btm375ZdfTE1NN2/eTOy55OfnJ9Znwi0sLOLi4tLf23s2AAAgAElEQVTT09vb24cMGeLg4KCoqBgeHo46l6ThcrklJSXQMwAFoGcAKsAlJ2RITk6Ojo4WCASNjY1paWmhoaFKSkqoQwmHq6tramrqhAkT6uvrX758uXXr1k/dMgR8WHFxcXd3N8ybAApAzwBUgEtOhCs/P9/X19fT01NDQ+POnTsGBgaBgYFvL58Ua5cvX7569erRo0dDQ0PDwsJMTU337t3L5XJR55IQbDYbx3E4nwEoAD0DUMHCwgJ6hlCUlZUtWLDA1ta2pKTk5s2bSUlJbm5u586du3fv3u+//446ndCUl5d///33fn5+CxcuXLVqVVFR0axZs3766afBgwefPXtWAHdl+mJsNtvQ0FBRURF1ECD5oGcAKlhaWr548QJOfX+JFy9eLF++3MLC4s6dOxEREQ8ePBgzZgzxKTs7u927d2/dujUhIQFpRuHo6uqaNm2aoaHh7t27iY8QS0Tz8vIGDRrk6+s7dOjQq1evog0p7goKCuBkBqAG9AxABeIZDZZofB7iglUzM7OLFy/u3LkzLy9v9uzZb2xXtXTp0jlz5syePbu8vBxVTmEJCAgoLCyMi4vrfb9yDMMGDhx4+vTpnJwcU1PTSZMmubq6Xr9+HVVIcVdQUACLMwA1oGcAKgwYMEBGRgamTj5VS0sLccHqsWPHgoODCwsLV61a9b5boB06dEhXV3fGjBnd3d0U5xSiU6dOHTly5D//+c/73m3b2NjExcXdvXtXU1PTw8NjxIgRt2/fpjikBIDzGYAy0DMAFeh0upmZGZzP6Lu2trYdO3YYGRnt3Llz9erVxcXFQUFBb7y/f4OCgsL58+efPn26fv16ynIKV2FhoZ+fX2Bg4LRp0z78lc7OzpcuXUpNTWUymWPGjPH09MzKyqImpASoqampr6+H8xmAGtAzAEXgkpM+6u7uDg8PNzMz27Jli5+fX3FxcUhIiLKycl8eS+zbvXv37rNnz5KdU+ja2tqmTp1qbW29ffv2Pj7Ezc2NWAzb2Njo5OTk7e39+PFjUkNKBuJfIvQMQA3oGYAicMnJR3E4nPDw8AEDBgQEBEyePPnZs2ehoaGqqqqfdJDvvvtuyZIlCxYsELuzR/7+/q9evTp16hSLxfqkB3p4eDx48CAxMbGysnLIkCG+vr5FRUUkhZQMBQUFCgoKBgYGqIMAqQA9A1DEwsKiqKgI9j94Jy6Xe+LECQsLi5UrV06dOrW0tDQsLOyz73+2b98+c3NzX1/fjo4O4eYkT1hYWFRUVHR0tLGx8ecdwcPDIysrKzIy8uHDhzY2Nj/88APcUud9iEWgcOdbQA3oGYAilpaW3d3dZWVlqIOIlu7u7qNHj1pYWCxZsmTcuHGFhYX79+/X09P7kmPKyMicPXu2srIyMDBQWDlJlZOTExgYuGHDBi8vry85Do1Gmz17dn5+/qFDh+Lj483MzPz8/EpLS4WVU2LAHdQAlaBnAIoQ759g6qRHd3d3ZGSktbW1v7+/m5tbXl7e0aNHjYyMhHJwIyOjEydOhIeHR0ZGCuWA5GlpafH19XVxcQkODhbKARkMxuLFi589e3bkyJFbt26ZmZn5+vrCX7ze4A5qgErQMwBFlJWV9fT04Okew7Curi5iHcaSJUuGDx+en58fGRlpbm4u3FG8vb1Xr17t7++fl5cn3CMLkUAgWLBgQWNjY3R0tHBv/8ZkMufNm8dms0+dOpWbm0vcAzY7O1uIQ4iprq6usrIyOJ8BKAM9A1DHwsJC7BYnCldra+vevXtNTEx+/PHHadOmlZSUREZGmpqakjTczp07HRwcvv3225aWFpKG+EK7d+++cOFCdHT0F04VvQ+NRvPx8cnLy7tw4cKLFy+GDh3q7e394MEDMsYSF0VFRTweD3oGoAz0DEAdab5rK7HjlpGR0caNG318fIqKivbu3Uv2gn8GgxEbG9vQ0ODn50fqQJ/n/v3769ev37p1q7u7O6kD0Wg0b2/vzMzMf//9t7q6etiwYZ6envfv3yd1UJHFZrNpNJqZmRnqIEBaQM8A1JHOS1vr6+tDQkKMjIy2bt26ZMmS8vLyvXv3kvT2/W2GhoaxsbFnzpwJCwujZsQ+ev369YwZMzw9PX/++WdqRsRx3NvbOyMjIykpqbW11cXFZcSIEVK4czmbzTY2Nv7wnm8ACBH0DEAdS0vL2tra+vp61EEo8urVq59//tnY2PjgwYNr166trKwMDQ1VV1enOIa7u/svv/yyatUq0dkxk8/nz549WyAQREREUH91pYeHx927dxMTE2k0moeHx9ixY5OTkynOgBDc2QRQDHoGoA7x7CYNpzSI/bONjY1PnjwZEhJSVlb2yy+/9HFPTzKEhISMGjVq2rRpr1+/RpWht61bt16/fv3UqVMaGhqoMnh6eqakpNy6dYvBYHh6eg4dOjQuLo7H46HKQxm4qBVQDHoGoE7//v3l5eUle4nGw4cP582bZ21tff369R07dpSUlKxZs0ZBQQFtKhqNFhUVxeVyv//+e4FAgDbMzZs3f//99127drm6uqJNgmHY6NGjk5KSHj58aG1tPXv27IEDB+7du7e9vR11LhIVFhbCRa2AStAzAHVwHDc3N5fUnpGamurt7T1kyJAnT54cP36cuLeq6MyCa2trnzlzJiEhYffu3QhjVFdXz549e9q0aStWrEAY4w329vaRkZGFhYXe3t7r1683NjYOCQkRkXM/wlVVVdXc3Aw9A1AJegaglOTdTY3P51+6dMnJyWnkyJENDQ0XL17Mzs6eN2+ecHeDEApXV9fNmzcHBQWlpqYiCcDj8WbPnq2oqHjkyBEkAT7MxMRk79695eXl/v7++/fvNzIyWrVq1fPnz1HnEia4gxqgHvQMQClJuuSkra0tPDzc0tJyypQpurq6GRkZxCkN1Lk+5Oeff540adLMmTNra2upH33Dhg1paWmnT59GuFTlo7S0tEJCQsrLy7ds2XL+/HkzM7N58+Y9efIEdS7hYLPZqqqqn33rHAA+A/QMQClLS8uSkpKuri7UQb5IXV0dcalqQECAi4sLm80mTmmgzvVxOI4fP36cyWTOnDmT4jWPV65c2blz56FDhxwcHKgc9/MoKiquWrWquLj46NGj2dnZtra2I0aMuHTpEupcX6qgoMDKygp1CiBdoGcASllaWnK53JKSEtRBPlNRUdGqVauMjIwOHjy4ePHi0tLSyMjIgQMHos71CdTU1E6fPp2amrpt2zbKBn3+/Pn8+fNnzZq1YMECygb9csTm5bm5uRcvXpSTk5s8ebKjo2NkZCSHw0Ed7TPBnU0A9aBnAEqZm5vTaDSxmzoRCASJiYkTJkywsLCIj4/fuXNnWVlZaGgoZdttCZeTk9Off/4ZEhKSmJhIwXAcDue7777T09MLDw+nYDihIzb4SkpKSktLMzExWbhwoamp6c6dOxsbG1FH+2QFBQXQMwDFcOQXuQGRcu/evdWrV5M6RGVlpZqaGpJLPW/cuCEvL/9JD+nq6jp9+vSff/6Zm5vr5ua2atWqb7/9VtTWeLq7u7e1tX3qo0pLS9XU1FRVVcmI1BuXyy0tLe3Xr5+srOynPnbDhg2ituSlrKzs8OHD4eHhHA5n1qxZq1ev/oyZiK1btyKZhaHgX5+rqyvaa5qAqIGeAf5HQkLChAkTli9fzmKxUGcRprKysvPnzzc1NfV9BWJNTc1//vOfffv21dXVffPNN2vWrHF2diY15GdTUlJydXUdNGgQ6iBCduDAgb///nvRokWog7xDS0tLbGzsrl27ioqKxo0bFxAQMGnSpL7vbbpw4cKbN29OnTqV1JDUS0xMNDQ0TEhIQB0EiBIBAL3Ex8djGNbU1IQ6iJB90vf16NEjPz8/OTk5LS2toKCgiooKsuN9IUVFxaNHj6JOIXyi/33xeLyLFy96eHhgGDZ48OCwsLCOjo6+PHDBggVfffUV2fGoJ6nfF/gSsD4DgP/i8/mXL192d3e3t7dPTU0ltlIIDQ01NDREHQ2IKOJOsElJSRkZGdbW1itWrBgwYMDWrVuRXDYMgGiCngEA1tzcHB4ePmjQIG9v766urosXLz558mTJkiWis5snEHFOTk4xMTHPnz/38/PbvXt3v379fH1909PTUecCAD3oGUCqFRQUrFq1Sl9ff+3atSNHjszNzSX22qL+JqJAAujq6oaEhFRWVoaHhxcUFLi5uQ0dOjQ8PLyjowN1NACQgZ4BpBGxWbinp6eVldXVq1d//fXX8vLysLAwyVtKCagnKys7b968x48fZ2ZmEpMpJiYm69atq6ioQB0NAASgZwDp0tjYuHfv3gEDBkyZMgXDsH///bewsDAoKEhNTQ11NCBpiE29ysvLAwMDo6KiTExMvL29k5OTUecCgFLQM4AUWbZsmZ6e3u+//z59+vSioqKkpCSYIgFk09PTCwoKKi4uPn78eHV1taen55AhQwoLC1HnAoAi0DOAFHnw4EFoaGhFRcWff/45YMAA1HGAFJGRkZk3b15GRkZmZqaTk5P4br0PwKdioA4AAHUyMzNF+U6hQBo4OjqGhYV1d3e/fPkSdRYAqADnMwAAgGowWwekB/QMAAAAAJAFegYAAAAAyAI9AwAAAABkgZ4BAAAAALJAzwAAAAAAWaBnAAAAAIAs0DMAAAAAQBboGQAAAAAgC/QMAAAAAJAFegYAAAAAyAI9AwAAAABkgZ4BAAAAALJAzwAAAAAAWaBnAAAAAIAs0DMAAAAAQBboGQAAAAAgC/QMAAAAAJAFegYAAAAAyAI9AwAAAABkgZ4BAAAAALJAzwAAAAAAWaBnAAAAAIAs0DMAAAAAQBboGQAAAAAgC/QMAAAAAJAFegYAAAAAyAI9AwAAAABkgZ4BAAAAALJAzwAAAAAAWaBnAAAAAIAs0DMAAAAAQBboGQAAAAAgC/QMAAAAAJAFegYAAAAAyAI9AwAAAABkgZ4BULpz5w7qCODTwK9M7NTW1rLZbNQpgPRioA4ARJG7uzudTid7FA6Hk5+fb2dnR/ZAGIY1NTVRMApC27ZtO3LkCAUD5efnGxkZycvLUzBWe3s7BaOgcu/ePRcXFwoGqq6u5nA4hoaGFIxVUlIyZMgQCgYCYgR6BvgfJiYmgYGB1Iz16NGjjo4OU1NTHR0dCoabMGGCjIwMBQNRb+XKlZ2dnRQM1NrampGRISsrO3z4cAqGGz58uK2tLQUDUe+rr75SVVWlZqxTp061trZS9iuztLSkYCAgRnCBQIA6A5BSQ4cOzcrKWrNmzZ9//ok6C+iTv/76a+3atXp6elVVVTiOo44DPq6iosLIyEggENy7d8/Z2Rl1HCCNYH0GQKO0tDQ7OxvDsKioKD6fjzoO6JOoqCgcx1++fJmeno46C+iT2NhYBoPBZDJjY2NRZwFSCnoGQCMmJobBYGAYVl1dDUsLxcKzZ88ePXokEAjgRUuMREREcLlcDocTFRXF4/FQxwHSCHoGQOPkyZMcDgfDMCaTGRMTgzoO+Ljo6Ggmk4lhGIfDiY6O5nK5qBOBj2Cz2U+fPiUmx+vr62/duoU6EZBG0DMAAjk5OQUFBcT/czic2NjY7u5utJHAR0VFRRHVEMOwxsbG5ORktHnAR/VUQwwKPUAHegZAIDY2tufpD8Ow1tbWxMREhHnAR2VnZz979qznj/CiJRZ6zhpiGMbhcE6dOkXNdUkA9AY9A1BNIBD0fmeMYRidTo+OjkYYCXxUbGwsi8Xq+SOHw/nnn386OjoQRgIflpGRUV5e3vsjHR0dCQkJqPIAqQU9A1AtPT29srKy90e4XO6FCxdaW1tRRQIfxufzT548+cbcVmdn5+XLl1FFAh/1RjXEoNADRKBnAKq9MWlC6O7uhhctkXXnzp3q6uo3Pkin06OiopDkAR/F5/Ojo6PfqIZcLvfixYvNzc2oUgHpBD0DUIrL5cbGxvaeNCHgOA4vWiLr7XfGGIZxudz4+PjGxkYkkcCH3bx5s7a29u2Pc7ncf//9l/o8QJpBzwCUun79+uvXr9/+OI/HS0hIqK+vpz4S+LAPXBDE5/PPnz9PfSTwUTExMW9XQwwKPUABegagFLE74Ts/JRAIzp07R3Ee8FGJiYnvO9MuEAhOnjxJcR7wUd3d3WfOnHlnNeTxeNevX3/nqQ4ASAI9A1Cns7Pz3Llz79vfic/nwy6TIugDvxQ+n5+SkvLq1Ssq84CPio+Pb2lped9neTzemTNnqMwDpBzcRw1Qp6Oj4+nTpz1/TE9PDwgIuH37toKCAvERGo3m4OCAKB14t7y8vN6bLowaNWrNmjXffPNNz0fMzMxUVFRQRAPv9uLFi5cvX/b8cdOmTXV1dfv27ev5iIaGhrGxMYJkQCrBfeEBdeTk5BwdHXv+SJy8tbe3V1ZWRhcKfISNjU3vP9LpdCMjo96/RyBq9PX19fX1e/6oqanZ3d0NvzKACsybAAAAAIAs0DMAAAAAQBboGQAAAAAgC/QMAAAAAJAFegYAAAAAyAI9AwAAAABkgZ4BAAAAALJAzwAAAAAAWaBnAAAAAIAs0DMAAAAAQBboGQAAAAAgC/QMAAAAAJAFegYAAAAAyAI9AwAAAABkgZ4BAAAAALJAzwAAAAAAWaBnAAAAAIAs0DMAAAAAQBboGQAAAAAgC/QMAAAAAJAFegYAAAAAyAI9AwAAAABkgZ4BAAAAALJAzwAAAAAAWaBnAAAAAIAs0DMAAAAAQBboGQAAAAAgC/QMAAAAAJAFegYAAAAAyAI9AwAAAABkgZ4BAAAAALLgAoEAdQYgyXg8Xtn/qaqqqv8/XC63ra2trKzMysqKRqPJyspqaGhoaGhoaWkZGhqamJiYmJjo6+ujji+lqqurS0tLy8rKKioqampqiF9Ze3s7hmFsNltHR0dNTY1Op6urqxO/NX19fWNjY2NjYxMTEyaTiTq+NGprayspKSkrKystLSV+ZXV1dY2NjRiGvXjxgsPhGBkZYRimrKxM/CvT0tIifmUDBgxQVlZGHR9IMugZQMh4PF5eXl5aWlpmZubjx4/z8vI6OzsxDJOXl+/fv7+GhoampqaGhgaDwcAwTFFRsbW1FcOwzs5O4pmxpqamqqqqu7sbwzBVVdXBgwfb2dk5Ozu7ubkZGxsj/c4kWVVVVXp6+r179x4/fvz48eO6ujoMwxgMhr6+vq6uLlEm5OXlMQxTUFBob28XCAR8Pr+uro6oIJWVlc3NzRiGsVgsKysrOzs7R0dHNzc3e3t74hcNhK61tTUjIyM9Pf3Ro0ePHj0qLS3l8/kYhmlraxO/Mi0tLVVVVQzDmEwmjUbr6urCMKy5ubmurq62trampubly5fEoYyNje3s7Ozt7V1dXV1dXVVUVBB+X0DyQM8AwlFWVpaQkBAfH3/r1q3m5mZlZWUnJyc7Ozs7Oztra2tjY2Ntbe0+HorP51dVVZWUlDx58iQnJ+fx48cPHz7s7u7W19cfP368l5fX+PHj1dTUSP12pEFLS8v169fj4+MTExPLysoYDIatra2Dg4OdnZ2tre2AAQMMDQ373hJev35dVlaWn59P/MoePHjw+vVrBQWFESNGTJgwYcKECebm5qR+O9KAx+M9ePAgPj4+ISEhOzuby+UaGRkNHTqU+JWZm5ubmJgQdbAvOjs7y8rKioqKcnNzc3JysrOzi4qKaDSanZ2dl5eXl5eXm5sb1ETw5aBngC9SX19/6tSpkydP3r9/X1FR0d3dffz48SNGjLCxsaHT6cIapaOjIzMz886dOwkJCXfv3sUwzN3d3cfHZ+rUqerq6sIaRUpwudyEhITIyMhLly51d3c7OTl5eXmNHj3ayclJUVFRWKMIBAI2m52WlpaUlJSUlNTQ0GBtbe3j4+Pr62ttbS2sUaRHbm5uZGRkTEzMixcvjIyMvLy83N3dhw8fbmBgIMRRampq0tPTb9y4kZCQUFRUpK6uPnXqVF9f33HjxkHhAJ9PAMCn6+rqOnfu3JQpU1gslqKi4rx5865du9bV1UXB0A0NDbGxsVOnTpWVlZWRkZk5c+aNGzf4fD4FQ4u7rKysVatWaWtr4zg+atSoo0eP1tbWUjAuh8NJSUkJCAggFtw4OzsfPXq0paWFgqHF3atXr3bt2mVvb49hmImJya+//vrkyRNqhi4qKvrjjz+cnJwwDNPT0/vll19KSkqoGRpIGOgZ4NM0NTVt375dW1ubRqN5eHhERka2trYiSdLc3Hzs2DEXFxcMw2xsbKKiorhcLpIkIo7P51+4cIF4wTA3N9+0aVNpaSmSJDwe78aNG7NmzZKVlVVRUdmwYQM1RUccPX36dN68eQwGQ0VFZdGiRbdv30ZVpouLizdu3Kivr0+j0b799tusrCwkMYD4gp4B+qquru63335TU1NTVlZev359RUUF6kT/9fjx4zlz5jAYDFNT0yNHjlBzWkUscLncmJgYW1tbHMenTJmSlpaGOtF/1dXVbd26VUtLS0FBITAwsKqqCnUiEZKdnT19+nQajWZlZXXixAli1S1yHA7n7NmzQ4cOxTBswoQJd+7cQZ0IiA3oGeDjXr9+vXbtWkVFRU1NzU2bNjU0NKBO9A7FxcV+fn4yMjKGhob79+/ncDioE6HE5/NPnDgxcOBAOp0+a9as3Nxc1Ineoa2tbffu3QYGBjIyMj/88MOLFy9QJ0IsKyvr66+/xnHcwcHhn3/+4fF4qBO9Q0JCwsiRIzEMGz16dEpKCuo4QAxAzwAfQrxcaWtr6+jo/Pnnn6I/p15RUbFq1SpZWVk7Ozupfcv18OFDV1dXBoOxaNGioqIi1HE+orOz8/Dhw0ZGRsrKynv27JHOgtjQ0LBixQo6ne7q6nrlyhXRX290+/ZtDw8PHMfnzp376tUr1HGASIOeAd6LzWZ7eHjQaLS5c+fW1dWhjvMJnj17NnHiROJJsLq6GnUc6rS2tgYFBTEYjKFDh2ZkZKCO8wna29uDg4NlZWUHDx4sOvM71IiLi9PR0VFXVw8LCxP9htHbxYsXjY2NVVVV9+zZA6ujwPtAzwDv0N7e/uOPPzIYDGdn5+zsbNRxPtM///xjaGgojk/fn+f06dN6enqamprHjh0T0++3oKDA09MTx/FFixaJ5vSccLHZ7NGjR9NoNH9//9evX6OO8zlaW1vXrVvHYrEcHR0zMzNRxwGiCHoGeNPTp09tbW3V1NTCw8NFc4a471paWtauXUun06dOnSrBr1ttbW0LFy7EcXzJkiX19fWo43wpojCZmJjcv38fdRYSRUZGKioqOjo6PnjwAHWWL/X06dMxY8awWKw9e/aIaccF5IGeAf4H8dw3dOjQ4uJi1FmE5vbt2wYGBv3795fIE/L5+fl2dnYqKipnzpxBnUVoamtrJ0yYwGAwgoODxb3svq2joyMgIADH8YCAAIm5PIrP5+/Zs4fJZE6ePFkCyi4QIugZ4L/a29sl77mvh6S+bkVERCgoKDg5OUneHko9r1ve3t6S9LqVn59va2srYb2wB9Hp+/XrJ5GdHnwe6BlAIBAIKisrbW1tNTQ0Ll26hDoLWXg83rZt2xgMhq+vb2dnJ+o4X4rL5fr7++M4/tNPP3V3d6OOQ5aUlBQDAwMTExM2m406ixD8+++/CgoKw4cPf/78OeosZKmpqfHy8mIymcePH0edBYgE6BlAwGazjYyMrK2ty8vLUWch3Y0bN1RUVMaNG9fU1IQ6y+fr7OycPn26rKzsuXPnUGchXU1NjYuLi6amprgv1zh+/DiDwfDz85P4a3f5fP769etxHA8NDUWdBaAHPUPaPXjwQEtLy8nJSXp2gM7NzTUwMLC1tRXTbShbWlrGjx+vqqp6+/Zt1Fko0tbWNnHiRAUFhatXr6LO8pn27NmD43hQUBDqINQ5cOAAjUZbuXKlJM1Ugs8APUOqXb9+XVlZ2cPDo7m5GXUWSpWWlhI30S4sLESd5dO8evVqyJAhurq6Dx8+RJ2FUhwOZ9GiRQwGQ+zOxvP5/J9++gnH8T///BN1FqqdPXtWVlZ29uzZEjy1Bz4Keob0unr1KovFmjNnjnQ+BRAv2Pr6+mK0grKmpsbCwsLMzEySrgbqOz6fv2bNGhqNduLECdRZPsHSpUtZLFZsbCzqIGgkJiYqKipOmTIFNvKSWtAzpNTdu3cVFBTmz58vzRe7NzU1OTg4DBw4UCz2DG1ubh46dOiAAQOk/D4g69evZzAYly9fRh2kT3799VcGg3HhwgXUQVBKTU2Vl5dfvHixND/bSDPoGdKosLBQW1t70qRJEr8e7aOIMwR2dnYivotXd3f3V199paWlVVBQgDoLYnw+f/HixXJycqJ//5pDhw7hOH706FHUQdC7fPkyg8HYsGED6iAAAegZUqeystLIyMjFxaW1tRV1FpFQXFysp6c3duxYkb3YlcfjzZgxQ1lZOSsrC3UWkcDlcqdNm6aiovLo0SPUWd4rNjaWRqPBBRc9Tp48ieP4rl27UAcBVIOeIV2ampqsra0HDRokpjdTIMnDhw9VVFRmzZqFOsi7rV69WlZW9saNG6iDiJD29vaRI0caGhqK5izSzZs3WSxWYGAg6iCiZceOHTQa7Z9//kEdBFAKeoZ0mTFjhq6ubmVlJeogIic5OZlOpx84cAB1kDedOXMGx3GpXUX4AQ0NDQMHDhw7dqyoLTB89eqVrq7u9OnTYTnC2/z9/ZWVlYuKilAHAdSBniFFDh06RKPREhMTUQcRUSEhITIyMiI1N/Hs2TMVFZXly5ejDiKicnJy5OTkgoODUQf5/3g8nqenp6mpaWNjI+osoqizs9PR0dHOzq69vR11FkAR6BnSQgSfkUWNqL1CdHd3u7i4wDPyh4lae/79999Fra2KGmjP0gZ6hlRoaWmxtLQcPXq0qJ1hFjXV1dV6eno+Pj6ogwgEAsHKlSsVFRUl474epJo1a5a2trYoLNS4deuWaM6+iZozZ85gGBYdHY06CKACLuyDJCUAACAASURBVBAIMCDpFi9efOnSpUePHunp6aHOIuquX78+fvz448ePz58/H2GMa9euTZgwISYm5rvvvkMYQyw0Nzc7OjpaWFhcvnwZbQxra2sXF5d//vkHYQxxsXz58ujo6Pz8fHhSknjQMyRfRkaGq6vrqVOnfHx8UGcRDytXroyNjS0oKNDQ0EASoKury87Ozt7e/vTp00gCiJ3U1NRRo0adPXt26tSpqDIEBgZGRkYWFBRoamqiyiBGOjo6Bg0a5OLiEh0djToLIBf0DAnH4/GGDh2qpaWVmJiIOovYaG5utrKy+uabbw4dOoQkQEhIyK5du/Lz8w0MDJAEEEfz58+/efPm06dPFRUVqR/9yZMnQ4YM+fvvvxctWkT96GIqISFhwoQJ169fHzduHOosgETQMyTcnj17goKCcnJyLCwsUGcRJ1FRUfPnz09PT3d2dqZ46OLi4kGDBm3ZsmXNmjUUDy3WampqLC0tly5dun37doqHFggEY8eObW9vv3fvHo1Go3h0sfbNN9+w2eycnBwZGRnUWQBZoGdIslevXllaWgYEBGzatAl1FvHj7u7e1NR0//59Op1O5biTJk0qKyt7+PAhk8mkclwJcPDgwR9//PHRo0dWVlZUjnv8+HE/P78HDx44ODhQOa4EeP78ubW19caNG9etW4c6CyAL9AxJtmDBgpSUlCdPnsjJyaHOIn6ePn1qb28fFha2YMECyga9evXqpEmTbt++PXLkSMoGlRg8Hs/Z2VlLSys+Pp6yQdva2gYMGPDdd9/t3buXskElybZt27Zt21ZcXKyjo4M6CyAF9AyJ9fz5czMzs2PHjs2dOxd1FnG1ZMmSmzdvstlsBoNBzYgjRoxQV1e/ePEiNcNJnsTExK+++iojI8PJyYmaEXft2vXbb7+VlpZqaWlRM6KE6ezsNDU1nTt3bmhoKOosgBTQMyTWsmXLEhMTCwoKKHuNlDwlJSUWFhaRkZEzZ86kYLj/x959xkV1JWwAv1OoUgVsoBRRQQQLFoodELCCIERsIbbEaIiaaBKTlazJRo01mmhsqKAoKCqKg4KVKgjSi0pTrBSRIlJm5v0w+xpXsXLvnJk7z//D/jaI5zxyYebhlnMuXrzo5OSUkJDg4OAghenYysHBoXPnzidOnJDCXE1NTT179pw+ffrvv/8uhenY6vfff//5559LS0vxqA4roWew08OHD83MzLZs2bJgwQLSWeTbzJkzb9y4kZ2dLYX7+5ycnLhcbkxMDNMTsdupU6c8PT0zMzOtra2Znmvnzp1ff/11cXFxt27dmJ6LxRoaGkxMTL788svAwEDSWYB+6BnstHz58tDQ0OLiYlVVVdJZ5Ft+fn6/fv2OHz/u4eHB6ETXrl2zs7O7dOnS6NGjGZ2I9cRi8YABA6ysrA4fPszoRK2trb1793Z3d//zzz8ZnUgR/Pvf/966dWtpaammpibpLEAz9AwWqq6u7tGjx5o1a5YuXUo6Cxt4eXndvXs3JSWF0VmmTJlSWVmZkJDA6CwK4ujRozNmzCgoKDA3N2duluDg4Llz5968edPExIS5WRTEkydPTExMfvzxx2+//ZZ0FqAZHvVmodDQUA6HM3/+fNJBWGLp0qWpqamZmZnMTXH//v2oqCj0Qrp4e3t369YtKCiI0Vn27Nnj6emJkkELXV1df3//PXv2kA4C9EPPYKGDBw96eXkRWRWRlYYPH96rV6+QkBDmpjh06JCWltakSZOYm0Kh8Hg8Pz+/Q4cOiUQihqYoKyuLi4ubPXs2Q+MroFmzZt28efPatWukgwDN0DPY5ubNmykpKXiWlV5+fn7BwcGtra0MjR8SEuLr64slEWk0e/bssrKyq1evMjT+gQMHDAwMxo0bx9D4CsjW1rZfv37BwcGkgwDN0DPY5sCBA4aGhriXkF6zZs16/PjxhQsXmBj8xo0bWVlZqIb06tu376BBg5h70zp8+PCMGTOwZiu9ZsyYERoa2tTURDoI0Ak9g1XEYvHhw4dnz54t5aWyWa9nz5729vYMvWkFBwebm5vb29szMbgimzVr1rFjx549e0b7yImJiYWFhaiGtJs1a9bTp0+luZwrSAF6BqskJCSUlpbOmDGDdBAWmjVr1okTJxobG+kdViwWSx6O4HA49I4Mfn5+z549O3v2LO0jHzlyxMrKCruZ0M7Q0HDUqFGhoaGkgwCd0DNY5ezZs6amplZWVqSDsNDkyZMbGxtpv96fkZFx//79KVOm0DssUBTVqVOnoUOHMvHLsUAgmDx5Mu3DAkVRkyZNiomJYe5eKJA+9AxWEQgEEyZMIJ2Cnbp162ZtbU37m5ZAIOjSpcuAAQPoHRYk3N3dBQIBvasE3bp16/bt2+7u7jSOCS+4u7s/efIET52wCXoGe1RWVmZmZrq6upIOwlpubm60LwoeGxvr6uqKiyYMcXNze/DgQW5uLo1jxsbGamlp4X4ahvTp08fU1BSr77MJegZ7SJaSdHR0JB2EtUaMGJGfn19VVUXXgK2trampqdgCnjkDBw7U0tKid5XV+Ph4BwcHbE/InBEjRmBhXDZBz2CPxMREKysrXV1d0kFYy9HRkcPhJCUl0TXgjRs36uvrsTsrc3g83tChQ+l900pMTMTJDEY5OjomJSXhFg3WQM9gj5SUlGHDhpFOwWa6urq9evWicaOT1NRUHR0dCwsLugaE19nb29N4yCoqKkpLS+3s7OgaEF5nb2/f0NCQl5dHOgjQAz2DPbKzs3E7IdP69++flZVF12iZmZn9+/fHzRmM6t+//+3bt+laRSMjI4OiKPygMcrS0lJFRSU7O5t0EKAHegZL3L17t6qqysbGhnQQlrO2tqbx5S8zMxOHjGnW1tZCoZCuX46zsrK6dOnSqVMnWkaDNvH5/D59+qBnsAZ6Bkvk5+dTFCX7K2dcv36dw+EEBgaSDvKR+vbtW1JSQtdqXQUFBX379qVlKEbJ9VHr2bOnioqK5Aek/fLz82X/p4yS80NGUZSVlRWum7AGegZLlJSUaGlp6enpkQ7yj/j4eA6H88svv7Tzc2SKmZmZWCwuKytr/1DV1dVPnz41MzNr/1A0Yt9R4/F4PXr0KCkpoWW00tJSHDIpMDU1peuQAXF4NIslSktLTU1NSad4t8GDB9O7aJKUSb7IJSUl7b95s7S0lKIoExOTdodiHAuOGl1vWiUlJWPGjKFlKEbhkIHswPkMligvL+/evTvpFOynra2to6Nz9+7d9g8lGaRHjx7tHwreztjYmJZDRlFUeXk5DpkUGBsbNzQ0VFdXkw4CdBADK7i6un722Wc0DlhdXf3FF1907txZVVXV1tb29OnTQUFBFEWFh4e/+ByRSLR37157e3sNDQ1VVVUbG5vt27eLRCKxWLxmzZo2v9lSU1Mpilq9evVbPuftI4vFYsni35s3b7548aK9vb26urqRkdFvv/0m+dM//vijd+/eKioqffr0CQsLo/FrImFubv7rr7+2f5w9e/Zoamq2f5yX4ai16Ycffujfv3/7x3n69ClFUdHR0e0f6gUcsjbduHGDoqibN2/SOywQgZ7BEoMHD16xYgVdozU2Nr7y5B6Hw/H19X355U8kErW5Mez8+fPF7Xv5e/vI4v9/+fP19X1lTcZNmzatWLHi5Y9wudwbN27Q9WWRsLOzW7ZsWfvHWbt2rampafvHeQFH7U02btxoZGTU/nGKioooikpNTW3/UBI4ZG9y584diqISExNpHBNIQc9gCXNz8//85z90jbZ+/XqKovr06XPhwoW6urqSkpIlS5ZIXlBevPwdPHiQoihra+uzZ89WVVXV19dfuXKlf//+L14d4uLiKIpas2bNyyO//PL3ps9558gvNjP7+uuvS0tL6+vrjx07pqSkpK2trampuWfPnsePH1dVVS1fvpyiqNmzZ9P1ZZEYP368v79/+8f5/vvvBw0a1P5xXsBRe5OgoKAOHTq0f5y0tDSKom7fvt3+oSRwyN6kvr6eoqioqCgaxwRS0DNYwsjIaNOmTXSNNnToUA6Hk5OT8/IHXVxcXn75GzNmDI/Hu3///sufI9mwauXKleJ2vPy9c2TJy5+bm9vLn+Dl5UVR1MaNG198pLW1VVtbW3JDHI08PT2nT5/e/nGWLl1qb2/f/nFewFF7k8OHD/N4vPaPk5iYSFFUeXl5+4eSwCF7k5aWFoqiIiIiaBwTSMHzJizR3NyspKRE12hFRUWGhoavrBPg6ur68iaKubm5QqFQcvOp5JtJ8n8oipKc8/xo7znyqFGjXv5bxsbGFEWNHDnyxUd4PJ6hoeGjR4/aE+Z1ysrKTU1N7R+nublZWVm5/eO8gKP2JioqKkKhUCgU8ni89owjOe74QaOYP2R8Pp/H49HygwbEoWewRGtrK40vfxRFvb4Ytvh/H5MTiUQURQmFwtf/bnNzc3umfs+RVVVVX/4jSeDXPygZjUbKysoNDQ3tH6elpYX2PT9x1Nok6XPNzc1qamrtGUeysxd+0Nr8IO0/aEpKSu38B4KMwHOtLMHj8Wjc3rBnz57l5eWvrMf38u9YFEVZWFioq6vX1NS8fpbs2LFjFEVxuVzq/1+a36TNz3nnyGS1tLTQch6Cz+e3+RL/0XDU3kRyEr79R03SC/GDJh10/aABcegZLKGiokJj9/fy8hKLxd7e3pcvX25oaCgrK1u6dOn58+df/py5c+c+e/bM2dn5zJkzFRUVzc3NZWVlUVFRXl5eFy5coCiqY8eOFEXFxcVVVVW9aaI2P+edI5PV3NysoqLS/nHoPWQUjtqbNTU18Xi8dl40oV46L0JHKIrCIXszyXUuWn7QgLzXmyzIo549e754rr39nj179sr+XhwOZ9q0aRRFnTx5UvI5IpHo008/bfObSiAQiMXi1tZWQ0PDV77ZXrk9rc3PeefILx7rfzmz5Kb37Ozslz9oZWVlaGhI15dFYsKECZ9++mn7x/nuu+9sbW3bP84LOGpvsn//fnV19faPI3nepKioqP1DSeCQvYnk0uSZM2doHBNIwfkMltDR0ampqaFrNDU1tUuXLi1cuLBTp06S5YMiIyMlO37p6upKPofD4QQFBR09etTZ2VlXV1dZWdnMzMzDw+PEiRPOzs4URfF4vGPHjg0fPrxDhw5vmqjNz3nnyGRVV1e/+CK0h46OzpMnT9o/zgs4am9C4yGjKIrGo4ZD9iaSlUAlp2FA7pEuOkCPcePGzZ07l7nxhULhwIEDORxOZWUlc7PIhV69ev3yyy/tH2f37t1aWlrtH+ctcNQkVq1aZWNj0/5xJFWe3vVAX4FDJiFZD7SwsJB0EKABzmewhL6+fmVlJY0DLl++PCQkpKys7NmzZxkZGT4+Pjdu3Bg9erRMbQlLRFVVFS1fBH19/draWnqf3MNRa1NlZSUtXwEtLS0lJSX8oEmB5D4SnM9gBzzXyhJGRkaxsbE0DlhYWLhp06aXP6KhofHKRxRQXV1ddXW1kZFR+4eSXC8vLy/v2bNn+0eTwFFr0507d2jZZZDD4RgaGtK1JZsEDlmb7ty5o6ampuBlizVwPoMljI2N6d1GefPmzZ9++qm5ubmKioqBgYG3t3dSUtIrezEoIMlm7pLd4dtJsiO8ZEC64Ki1qaSkRPLVbj8TExMcMimQHLLXFxcBeYTzGSxhamr65MmTmpoaya1q7derVy/JvpHwspKSEg6HQ8ubloGBgYaGBr3tEEftdSKRqKysjJZqSFGUiYkJDpkUlJSU0HXIgDicz2AJS0tLiqIkexMAc3Jzc3v06PGWG/s/iIWFBQ4Z00pKShobGyU/IO1naWmJQyYFubm5kudugAXQM1jC2NhYR0cnKyuLdBCWy87Otra2pmu0/v3745AxLTs7m8vlvrKHyEezsbG5d+8evbeCwiuEQmFBQQGNP2hAFnoGS3A4nH79+uFNi2n09gwbGxscMqZlZWWZmppqaGjQMppk2/Ts7GxaRoM23bx5s7GxsV+/fqSDAD3QM9hj6NChycnJpFOwWW1tbX5+/tChQ+kacOjQoZWVlbdv36ZrQHhdUlISjYesa9eu3bt3xw8ao5KSktTU1NAzWAM9gz0cHByys7OfPn1KOghrJSYmikQiBwcHuga0tbVVU1NLSEiga0B4hUgkSk5OdnR0pHFMBwcHHDJGJSQkDBs2DJuosQZ6Bns4OjoKhcJr166RDsJa8fHx5ubmnTp1omtAJSWlwYMHx8fH0zUgvCInJ6empobGakhRlIODQ1JSEr177cLL4uPj6T1kQBZ6Bnt06dKlb9++586dIx2EtaKjo2nf92Hs2LHR0dH0jgkvREdH6+vrS26qoIuTk1N1dfX169dpHBNeKCkpuXnzJvENVoBG6Bms4u7uLtliEWhXUVFx48YNd3d3eod1d3cvLy/Ho5IMEQgEbm5uXC6dL3RWVlbGxsb4QWOIQCDQ0NDA+Qw2Qc9gFXd39/z8/OLiYtJBWOjMmTNKSkpjxoyhd9ghQ4bo6+ufOXOG3mGBoqgnT54kJibSXg0pinJzc8MhY8iZM2ecnZ1VVFRIBwHaoGewyqhRowwMDMLDw0kHYaGQkJCJEyfS9XjkC1wu18PD49ixY/QOCxRFHT16lMfjTZgwgfaRPT0909LSioqKaB9ZwT1+/Dg2NtbX15d0EKATegar8Pl8Dw+PsLAw0kHY5t69e1euXJk1axYTg/v4+Fy/fh1Pt9IuODjY09NTW1ub9pGdnJw6deqEdki7w4cPq6mpTZ48mXQQoBN6Btv4+vqmp6fn5+eTDsIqwcHBOjo6TJyBpyhqzJgxnTp1Cg0NZWJwhVVUVJSUlMRQNeTz+Z6enocOHWJicEUWHBzs7e2trq5OOgjQCT2DbcaOHduzZ889e/aQDsIqhw4d+uSTTxh6oJ/P58+ePXv37t14VJJGwcHBnTp1Yu6xBX9//+zsbCzYRaO8vLz09PTZs2eTDgI0Q89gGw6H4+/vf+DAgaamJtJZWCItLS0nJ2fmzJnMTTFv3rzy8vLz588zN4VCEYvFISEhM2bM4POZ2pJ62LBh/fv33717N0PjK6CDBw8aGxuPGDGCdBCgGXoGC3322Wf19fUHDhwgHYQltm7damVlZWdnx9wUffr0GTt27KZNm5ibQqFERUUVFxf7+/szOsvnn39++PDhBw8eMDqLgmhoaNi7d++nn35K70PIIAtwRFmoa9euc+bMWbduXWtrK+kscq+4uDg0NPS7775jeqLvvvsuNjY2MTGR6YkUwW+//TZp0iSmN8jw9/fv2LEj2iEtduzY0djY+OWXX5IOAvTjiMVi0hmAfsXFxX369AkKCmL0bL8iWLBgwYULFwoLC5k7A/+Co6Ojvr7+qVOnmJ6I3WJjY11cXBISEqSw1tOGDRsCAwNLS0v19fWZnovFmpqazMzMZsyYsX79etJZgH7oGaw1e/bs69ev5+Tk4DzkRysvLzc3N9++ffu8efOkMN3p06enTJmSkZFhY2MjhenYasyYMUpKStK52aWhocHU1PSLL774+eefpTAdW/3555/ffPNNUVFRt27dSGcB+qFnsFZBQYGVlVV4ePjUqVNJZ5FXAQEBERERRUVF0tk6UiwWDx48uHfv3njG9aMlJyfb29tfvnx51KhR0plxzZo1GzduLCsrY2KhDkXQ0tLSu3fviRMnbtu2jXQWYAR6Bpv5+Pjk5eXduHFDSUmJdBb5U1JSYmVltW7duiVLlkht0rCwMD8/v5SUlEGDBkltUtYQi8WjR48Wi8VXr16V2qQ1NTUmJiaLFy/+5ZdfpDYpm2zbtu2bb765detWjx49SGcBRqBnsFlZWVnfvn0DAwO//fZb0lnkz+TJk4uKijIyMqTZ0sRi8dixYxsaGpKTk3HB60MFBwd/+umnSUlJQ4cOlea8W7duXbFiRWZmpoWFhTTnZYFHjx5ZWFgsWrTo119/JZ0FmIKewXL//ve/161bl5eXZ2xsTDqLPDl16pSHh8eFCxfGjh0r5alzc3MHDhz4559/zp8/X8pTy7Xa2loLCwtPT88///xTylMLhcIhQ4bo6enFxMRIeWp5N2vWrKtXr+bl5XXo0IF0FmAKegbLNTc329jYWFtbY3O199fY2GhlZeXo6BgcHEwkwPLly/fv319QUGBgYEAkgDxavHhxeHh4QUGBrq6u9GdPTU21s7MLDQ318fGR/uxyKi4ubtSoUSdOnJgyZQrpLMAg9Az2i4mJGTdu3JkzZ5jYuJKVVq1atX379vz8fFJ3v9fV1VlaWrq5uWH9+PeUnp4+dOjQffv2EVy1et68eVFRUQUFBbgh9H20trba2tp269ZNIBCQzgLMQs9QCD4+PikpKenp6R07diSdRdalpKSMGDFiw4YN0rz983Xh4eG+vr5RUVEMbd7GJo2NjXZ2djo6OpcvX+ZwOKRiVFZWWlhYeHh4oB2+j1WrVm3evDknJ8fMzIx0FmAWeoZCePLkycCBA/v163f69GmCL8Syr6amZtCgQaampjExMcRvw5wzZ86ZM2fS09Nxb83bLVy4MCwsLD093dTUlGySqKioSZMm7d+/H5uBvd3FixfHjRu3c+dO6axMA2ShZyiK5OTkkSNHrlu3bunSpaSzyC4vL6/ExMQbN2506dKFdBaqoaFhyJAh2traV69exZPJbxIWFvbJJ58cO3ZMRtaJWbZs2a5du1JTUy0tLUlnkVGPHj0aMGDAqFGjjhw5QjoLSIUYFMZ//vMfJSWlhIQE0kFk1JYtW7hc7oULF0gH+Ud2dra6uvoPP/xAOoiMunXrlpaWVkBAAOkg/2hubra3t+/Xr19DQwPpLLJIKBQ6OTmZm5s/ffqUdBaQEvQMBSIUCt3c3ExMTCorK0lnkTnXrl1TVlb+5ZdfSAd51e7du7lc7tmzZ0kHkTkNDQ0DBgwYMmRIU1MT6Sz/o6SkRFdXd+7cuaSDyKJVq1apqqpmZGSQDgLSg56hWB4/fmxsbGxvb49ftl5269atTp06jR8/XigUks7ShtmzZ2tqal6/fp10EBnS0tIyceJEfX39oqIi0lnacPLkSS6XK4O1law9e/ZwOJw9e/aQDgJShZ6hcCTvqc7OzrL2WyARVVVVOTk5vXr1GjJkSF1dHek4bWtubnZzc9PX1y8oKCCdRSaIRKLPPvtMXV1dli8C7ty5k8Ph/P3334WFhaSzyITIyEg+n7969WrSQUDa0DMUUUpKioaGhp+fn2z++i5N1dXV6urqmpqap06dIp3lbRoaGhwcHLp3737nzh3SWchbsWKFkpKSjF9Levz4sZOTE0VRP/30E+ks5CUlJamrqy9YsIB0ECAAPUNBRUdHKykpffPNN6SDkNTY2Dh69Gg9PT3JPdEWFhY7duyQ2bMaFRUVffr0sbGxqampIZ2FpE2bNnE4nIMHD5IO8kYJCQl+fn6SR4SMjIxUVVWvXLlCOhRJWVlZurq6np6era2tpLMAAegZiiskJITL5S5btkwkEpHOQkBtba2Tk5OOjk5mZuaYMWO4XC6Hw+Fyuerq6l9++WVubi7pgG0oLS01NDS0tbV99OgR6SxkrF+/nsPhbNiwgXSQNtTX1+/atcvKyoqiKGVlZYqiuFxuRkaGl5eXhobG+fPnSQckIzU11cDAYNSoUY2NjaSzABnoGQrt+PHjKioqM2bMaG5uJp1Fqh4+fDho0KDOnTunp6eLxeKMjIyXly+TvEn079//wIEDsvaVKS4u7tWrl6mp6c2bN0lnkSqRSLRixQoOh7N+/XrSWV518+bNlStXamlpcbncF8u7KSkp+fv7i8XilpaWzz77TFlZ+fDhw6STStuFCxe0tLScnJxqa2tJZwFi0DMUnQK+EBQXF/fu3fuVt+rZs2e/shaW5AyHnp7eypUrS0tLCQZ+haQkdenSRVKSFMGLt+pDhw6RzvIPoVAYExPj5ubG4XBeX0hNWVn5xc00IpHo22+/ldkzMQw5duyYqqqqAv4aA69AzwBxSkqKgYHBsGHDKioqSGdhXFpaWpcuXWxtbR8+fPjyx+/evSs5jfE6Pp/P5XI9PDxiY2Nl5BrT06dPx44dq62tfenSJdJZGFdXV+fm5qahoXHu3DnSWf7r/v37P//8c+fOnTkcDo/Ha/N75vXbP9euXcvhcH744QcZ+S5i1ObNmxX5siy8DD0DxGKxuKCgwMTEpHv37vHx8aSzMGj37t1qamrOzs5tnrz5/vvv+Xz+WxbPNTExefz4sfRjt+n58+fTpk3j8/nr169n8Ut5VlaWhYVFp06dUlJSSGf5x6pVq97yfUJRVMeOHdv8Htu3bx+fz58wYQKL18qrq6ubMWOGbF7hAiLQM+C/ampqvLy8JA+4s+951xevfV999dWbzuLW1ta+aT9bHo+nra0ta8tXiESiLVu2KCsrOzs7v3J6hh0OHDigrq4+dOjQkpIS0ln+h0gkmjNnTptnMiiK4nK5O3fufNPfTUlJMTU1NTIyiouLk2Zm6cjLy+vXr5++vn5UVBTpLCAr0DPgH2x938rNzbWystLX13/nigvbt29/fZtWDoejrKwss0tCsfJ96316IVnNzc3jxo17/QQYl8vt2bNnS0vLW/5uTU2Nt7c3+zq9pBeOHDmyvLycdBaQIegZ8KqkpCRjY2MjI6MTJ06QztJezc3N69evV1NTe8/XvpaWFnNz81eqBofDOXLkiBTSfrSqqqrJkyfz+fxVq1Y9e/aMdJz2unjxYu/evQ0MDKKjo0lneZuGhoZevXq9fgfo6dOn3/l3RSLRhg0blJSUXFxcbt26JYW0jLp37563tzeXy/3hhx/e3rFAAaFnQBuqqqpmzZrF4XAmTJggm/tHvI/Lly9bWVmpqamtWbPm/RcIioiIeOVtQ1NT087OTsZvkhWJRNu2bdPS0jI1NY2MjCQd5yPdv3/fz8+PoqhJkybdu3ePdJx32Lp1K5fL1dPTe1E1+Hy+o6Pj+4+Qgc36yQAAIABJREFUnJxsbW2tqqq6evVqOV1eoqWlZdOmTZqamj179oyJiSEdB2QRega80dWrV/v166empiZ3L4KVlZULFizgcDhOTk4fcVOFvb295J2Dy+WuWbPm9u3b5ubmPXv2lP3fOx88eCApiBMnTiwuLiYd5wMIhcK///5bW1vbyMgoLCyMdJx3EIlEq1ev5nA4q1evLioq6tixo+ReDQ6Hk5qa+kFDtbS0bNmyRUtLy8zMTO7uaYiLi7OxsVFSUvrqq6/q6+tJxwEZhZ4BbyO57qChoWFubn7w4EHZPyNaU1Pzyy+/6OjoGBsbf/R1n+TkZA6Hw+Fw5s+fL/nIgwcPJEtWpKWl0ReWKRcuXLC0tFRXV//+++9l5wGZNxEKhRERETY2NioqKqtWrZL9nYRbWlrmzp3L5/Nf7DuampqqpqbG4XB8fX0/bszy8nIfHx/JiZwPbSpE5Obm+vn5cTgcNzc32e/fQBZ6Brzb3bt358yZw+fzzczMdu7c+fz5c9KJ2lBRUfHjjz9qa2vr6Oj861//aufb1bRp0yZOnPjy1ZYXqzgIBIJ2h2VcU1PT77//3qlTJ3V19a+//lo278trbW09dOiQlZUVl8v18vKSi31N6+rq3N3dNTQ0XrmnWCAQdOjQoZ3PxcTExAwdOpSiKFdX16tXr7YrKGPS09O9vLy4XK6VldXx48dJxwE5gJ4B76u4uPjzzz9XUVExNDTcvHmz7Kwfevfu3eXLl2toaBgYGPz666+0bDNWXl7++g2VTU1NM2bMUFZWDgkJaf8UUtDQ0LBlyxYjIyMVFZWFCxfKzu+djY2Ne/bsMTc35/P5M2fOlM3dZF738OFDW1vbzp07X79+/fU/pevLe+7cuZEjR1IUNXLkSIFAIDsPpFy9enX8+PEcDsfW1jYiIkJ2goGMQ8+AD/Po0aPVq1draWmpqqpOmzYtMjKS1MWUZ8+ehYWFTZw4kc/nd+rUafXq1U+fPmV60pcvzDM9F12ampoOHDjQu3dviqJsbW23bNlC8J7W69evf/XVV/r6+kpKSrNmzZKLcxgSRUVFvXr1MjMzk87OMvHx8RMnTuRwOEZGRl999VVGRoYUJm3T3bt3165d26dPH4qiHB0dIyMjWbwuHDABPQM+RnV19Y4dOxwcHCiK6tq16/Lly6W210Zzc/O5c+dmzZrVoUMHZWVlDw+PiIgIKV/KkTxo8NVXX8nRr3Stra1nz56dPn26mpqaqqqqt7f3qVOnpHZ7b15e3o8//mhiYkJR1MCBAzdt2vTgwQPpTE2LlJSUTp06DRkyRMo75ebm5n733XdGRkYURQ0ZMuSPP/6Q2sI2VVVVu3fvHjlyJIfD6dSpU0BAQJtncQDeCT0D2uXWrVv/+te/zMzMKIoyNDScN29eWFjY/fv3aZ8oPz9/165dU6dO1dLSoijKzs5u+/btBBdvPn78uKqq6tSpU+XrSRyxWPz06dN9+/aNHj2ay+Wqq6tPmDBh+/bt2dnZtHemioqKkydPLlq06MW3x7fffpudnU3vLFJw/vx5TU1NFxcXUtcKhUJhbGzsnDlzNDU1uVyura3tjz/+eOnSJdrvmX3+/Hl8fPyaNWscHBx4PJ6qqqqvr++ZM2dk/wZwkGUcsVjc5tK5AO9PLBZfv349OjpaIBCkpKQIhUIzM7Nhw4bZ2NhYW1tbWlr26NHj7VuHvKKxsbG4uDg3Nzc7OzsrKyspKamioqJDhw6jR492d3d3d3eXvHWRdfnyZQ8Pj4EDB548eVJbW5t0nA9WXl4uEAgEAsGFCxdqa2t1dHTs7e379+9vbW1tZWVlbm7eoUOH1/9Wc3NzmxvOCYXCe/fuFRQUZGVlZWdnp6SkFBQUcLncAQMGSA6ZnZ3dmxbqlmUHDhyYP3++n5/f7t27X1+SS8qePXt24cIFgUAQHR1dUlKipKQ0cODAQYMG9e/fv1+/fr169ercufMHDVhVVXXr1q3s7Ozs7Oz09PTr1683NTUZGhq6ubm5ubmNGzdOUusB2gM9A2hWV1eXnJycmJiYmpqak5NTVlZGURSfzzcyMurevbu+vr6enp6enh5FUbq6uhRFtba21tXVtba2VlVVVVVVVVZWlpaWPnjwQPK3zM3NbWxs7OzsHBwcBg0aRPyF/hW5ubnu7u5aWloCgaB79+6k43wkoVCYlZWVkJCQnJyclZVVUFDQ0tJCUZSBgYGJiUmnTp309PQkd1R06NDhypUro0aNamxsFIlENTU1FRUVVVVV9+7dKysrk/ytrl27WltbDxkyxMHBwcHBQUdHh/S/7+OtW7fu+++/X7FixW+//cbhcEjH+R93796Nj49PSkq6ceNGdnb206dPKYpSV1c3NTXt2rWrgYGBnp6e5NqipC8+e/asqampsbGxsrKyqqrq/v37paWldXV1FEVpaGhYWVkNHDjQ3t7e0dGxZ8+ehP9twC7oGcCsmpqawsLCkpKSkpKSe/fuVVdXV1ZWVldXUxT15MkTiqL4fL6mpiafz9f7f8bGxiYmJqampn369FFVVSX9L3iH+/fvu7u7V1ZWCgQCGxsb0nFo0NLScvPmzeLi4pKSkrKyMsnbUlVVVUtLS0NDw61bt/T19bt168blcrW1tSXvZ127djU1NZUcMkmJlHdCoXDJkiW7du3atm3bF198QTrOu5WVlRUVFUkO2YMHDySHrKGhobm5uaGhgaIodXV1FRUVNTU1yU9Zly5djI2NTU1Ne/bsaWpqKmstCtgEPQOgvZ48eTJlypScnJxTp06NGDGCdBwGXbp0aezYsZMmTYqMjCSdhUFNTU2zZs2KjIwMDg6eNm0a6TgA8u3VrSkB4EPp6urGxMQ4Ozu7uLiEh4eTjsOg0NBQDocTHR0tORfFSk+ePHFxcYmNjY2JiUHJAGg/9AwAGqioqISGhn722WfTp0/fsWMH6TiMaGlpOXr0qFgsFolEr+82xw73798fPXp0UVHR5cuX2X1qCkBq0DMA6MHj8f76669ff/31yy+//O6779h3RVIgENTW1lIUJRaLg4ODScehX25urp2dnVAoTE5OZsetNgCyAD0DgE4rV64MCgratGmTv7+/5PkL1jh06JDkeR+RSHT16tV79+6RTkSny5cvSx61SEhIkN9HhwBkEHoGAM3mzJkTFRUVERExYcIEyXODLNDQ0CBZY17ynzwej013opw4ccLd3X3s2LECgUAel0IBkGXoGQD0c3FxuXDhQmZmppOT0+PHj0nHocGpU6eam5tf/KdQKDxw4ADBPDT6448/vL29FyxYcOzYMdl/jhpA7qBnADBiyJAhSUlJNTU19vb2t27dIh2nvUJCQrjcf14uxGJxRkaGvP+7xGJxYGDg119//dNPP0n2rCGdCICF8HMFwBQzM7O4uDhdXd0RI0akpaWRjvPxqqurY2JiWltbX/6gkpLSkSNHSEVqv+bm5lmzZv3222/BwcGBgYGk4wCwFnoGAIM6d+58+fLlQYMGjR49WiAQkI7zkcLDw19/fKalpWX//v0k4tCgvr5+ypQpp06dOnXq1IwZM0jHAWAz9AwAZmloaERGRvr6+k6ePHnv3r2k43yM4ODgNh/TLS4uzsjIkH6ednr48OGoUaMyMjKuXLni5uZGOg4Ay33AFpoA8HH4fP7u3buNjIzmz59/9+5d+TpLf//+/cTExDZ7hrKycmho6IABA6Sf6qMVFRW5u7tLHs3t1asX6TgA7IfzGQDSwOFwAgMDt27dumbNmq+++kokEpFO9L5CQ0PftOZYc3PzwYMH5WhFstTUVHt7ex0dnaSkJJQMAOnA+QwA6VmyZImRkZGfn195efmhQ4fU1NRIJ3o3yVLcL8rE7du3O3XqpKWlJflPHo9XVFRkbm5OLuD7iomJ8fLysrOzO378uKamJuk4AIoC+7UCSNvly5c9PT0HDBhw4sQJHR0d0nE+jJaW1ubNm+fOnUs6yIc5cODA/Pnz/fz8du/eLVnVFACkA9dNAKRt9OjR8fHxRUVFw4cPv3v3Luk47Ldu3Tp/f/9ly5YFBQWhZABIGXoGAAFWVlbJyck8Hs/Ozi4rK4t0HNYSCoWLFi1atWrVX3/9tXbtWg6HQzoRgMJBzwAgo1u3bpcvX+7Zs+fo0aPj4uJIx2GhpqamTz75ZN++fUeOHPn8889JxwFQUOgZAMTo6urGxMS4uLi4uLiEhYWRjsMqT548cXZ2vnDhQmxsrLe3N+k4AIoLPQOAJBUVlcOHD8+dO9fPz++vv/4iHYclysrKHBwc7t69m5iYOHz4cNJxABQanmsFIIzH4/3555+9e/devHhxYWHhli1bcBtBe+Tk5Li7u+vo6MTHxxsZGZGOA6Do0DMAZEJAQICuru68efNqamr27NmDxyI+zqVLlzw9PQcNGnTixAltbW3ScQAA100AZMbs2bPPnj174sSJ8ePH19XVkY4jfyIiIsaPH+/k5HT27FmUDAAZgZ4BIEMkty5mZWU5OTk9fvyYdBx58scff0ybNm3BggXh4eGqqqqk4wDAf6FnAMiWIUOGJCUl1dTU2Nvb37p1i3QcOSAWiwMDA7/++uuffvpp69atXC5e1gBkCH4gAWSOmZlZXFycrq7uiBEj0tLSSMeRac3NzTNnzvztt99CQkLkayNcAAWBngEgizp37nzlypVBgwaNGjVKIBCQjiOj6uvrp0yZEhkZeerUKT8/P9JxAKAN6BkAMqpDhw6RkZHTp0+fPHnynj17SMeROQ8fPhw1alRGRsaVK1fc3NxIxwGAtuG5VgDZxefzd+3aZWhouGDBgvLyclwXeKGoqMjNzU0sFsfFxcnFrvQACgs9A0CmcTicwMBAfX39gICAqqoq3OdIUVRKSsrEiRNNTU3PnDljYGBAOg4AvI2iv2AByIXFixcfO3Zs79693t7ejY2NpOOQdPr06TFjxtjZ2V26dAklA0D2oWcAyAdPT88LFy5cvXrVycmpqqqKdBwy9u/fP3XqVB8fn4iICHV1ddJxAODd0DMA5Ia9vf2VK1fKy8tHjhx59+5d0nGkbd26df7+/suXLw8KCuLzcc0XQD6gZwDIEysrq+TkZCUlJTs7u8zMTNJxpEQoFH7xxRerVq3asWPH2rVrSccBgA+AngEgZ7p163bp0iVzc/MxY8ZcvXqVdBzGNTU1ffLJJ/v37z9y5Mjnn39OOg4AfBj0DAD5o6ure/78eRcXl3HjxoWFhZGOw6Dq6mpnZ+eLFy/GxMR4e3uTjgMAHww9A0AuqaioHD58eN68eX5+fn/++SfpOIwoLS11dHQsLy9PSEgYPnw46TgA8DFwLxWAvOLxeNu3b+/Vq9eSJUtu3ry5ZcsWDodDOhRtcnJy3N3ddXR04uLijIyMSMcBgI+EngEg3wICAnR1defNm1dTU7Nnzx4lJSXSiWhw6dIlT0/PQYMGnThxQltbm3QcAPh4uG4CIPdmz5599uzZkydPjh8/vra2lnSc9jp+/Pj48eOdnZ3Pnj2LkgEg79AzANjA2dn5woULWVlZTk5Ojx8/Jh3n423dutXHx2fBggVhYWGqqqqk4wBAe6FnALDE4MGDk5OTa2tr7ezsbt68STrOBxOLxd99993SpUv/85//YBsXANbATzIAe5iamiYmJnbp0sXBwSEpKYl0nA/Q3Nw8c+bMzZs3h4SErFy5knQcAKANegYAq+jp6cXExAwbNszFxeXs2bOk47yX+vr6yZMnR0ZGRkZG+vn5kY4DAHRCzwBgmw4dOpw6dcrPz2/KlCm7d+8mHecdHj58OHLkyMzMzKtXr7q6upKOAwA0w3OtACzE5/P//vvvbt26LVy48N69e4GBgaQTta2oqMjNzU0sFsfFxZmbm5OOAwD044jFYtIZAKBdtmzZ0tzc3OYfJSYmRkZGzp07t1evXrTMFRkZaWNjY2Ji0v6hxGLxli1bVFRUPv300zdt8u7u7m5tbd3+uQCAFPQMALmnqampoqKioaHR5p82NzcrKytLOdJ7amlp4fP5b1rG9M6dO7t37547d66UUwEAjXDdBIAN1q1bx773Y01NTdIRAKC9cB8oAAAAMAU9AwAAAJiCngEAAABMQc8AAAAApqBnAAAAAFPQMwAAAIAp6BkAAADAFPQMAAAAYAp6BgAAADAFPQMAAACYgp4BAAAATEHPAAAAAKagZwAAAABT0DMAAACAKegZAAAAwBT0DAAAAGAKegYAAAAwBT0DAAAAmIKeAQAAAExBzwAAAACmoGcAAAAAU9AzAAAAgCnoGQAAAMAU9AwAAABgCnoGAAAAMAU9AwAAAJiCngEAAABMQc8AAAAApqBnAAAAAFPQMwAAAIAp6BkAAADAFPQMAAAAYAp6BgAAADAFPQMAAACYgp4BAAAATEHPAAAAAKagZwAAAABT0DMAAACAKegZAAAAwBT0DAAAAGAKegYAAAAwBT0DAAAAmIKeAQAAAExBzwAAAACmoGcAwAe4ffs26QgAIE/4pAMAAA2io6OrqqqkMFFwcPDEiRN1dXWlMFdLS4sUZgEARqFnAMg9Y2Pj1NTU1NRUpicSiUTl5eX37t3T0tJiei6Korp06aKpqSmFiQCAORyxWEw6AwDIh3379s2dO9fS0jIvL490FgCQD7g/AwDeV0hICIfDyc/Pz83NJZ0FAOQDegYAvJfHjx9fuXJFLBYrKysfOXKEdBwAkA/oGQDwXkJDQ7lcLkVRzc3N+/fvxyVXAHgf6BkA8F4OHjwoFAol/7+8vDwlJYVsHgCQC+gZAPBuxcXFN27ceHEOQ1lZOTQ0lGwkAJAL6BkA8G6hoaF8/j+PwTc3N4eEhLw4vQEA8CboGQDwbsHBwa+smlVVVXXp0iVSeQBAXqBnAMA7ZGVlFRYWvvJBJSWlw4cPE8kDAHIEPQMA3iE0NFRJSemVD7a0tBw9evT58+dEIgGAvEDPAIC3EYvFBw8ebHOrkcbGRoFAIP1IACBH0DMA4G0SExPv37/f5h/xeLxDhw5JOQ8AyBfsowYAbyNZ+vPFdRPJo60cDoeiKKFQeObMmbq6Oux2BgBvgp4BAG8zatQoa2vrF/8ZEBDg4+Pj6Oj44iO1tbXoGQDwJtivFQA+gJaW1ubNm+fOnUs6CADIB9yfAQAAAExBzwAAAACmoGcAAAAAU9AzAAAAgCnoGQAAAMAU9AwAAABgCnoGAAAAMAU9AwAAAJiCngEAAABMQc8AAAAApqBnAAAAAFPQMwAAAIAp6BkAAADAFPQMAAAAYAp6BgAAADAFPQMAAACYgp4BAAAATEHPAAAAAKagZwAAAABT0DMAAACAKegZAAAAwBT0DAAAAGAKegYAAAAwBT0DAAAAmIKeAQAAAExBzwAAAACmoGcAAAAAU9AzAAAAgCnoGQAAAMAU9AwAAABgCnoGAAAAMIUjFotJZwAAwmpraysqKqpeUl1d3dTURFFUTU2NWCxubm5uaGigKCo6Orpv3749evTg8/mampoURXXo0EFZWZmiKF1dXb3XKCkpkf2nAQBZ6BkAiqK+vr60tLSkpKSkpKT0/z148KCqqqqlpeXFp6moqEgqwov2QFGUkpKShoYGRVHq6uqNjY1isbi1tbWuro6iqGfPnr1oJBUVFbW1tS9Pqq2t3blz5+7du5uampr8P1NT065du3I4HCn+6wGADPQMAHZ68uRJdnZ2VlaW5H9v375dWVkp+SMDA4MX7/qGhoaSVqGvr29gYKCnpyfpEx+tpaXl5fMilZWVDx8+LCsrk9SaO3fuSDqNioqKiYlJv379rK2tra2t+/fvb2pqyuXiSi4A26BnALDEvXv3EhMT09PTs7Ozs7Oz79y5Q1GUrq6ujY2NtbV17969TU1NJfWiQ4cOpEIKhcJ79+5JOsft27fz8vIyMzOLi4tFIpGGhoaVlZWNjY2Njc2wYcMGDhzI5/NJ5QQAuqBnAMgroVCYk5MTHx+fmJiYkJBQVlbG5/MtLS2tra0l3cLa2rp79+6kY75bQ0NDbm5uZmampCFlZmY+efKkQ4cOQ4cOdXR0dHBwcHBw0NbWJh0TAD4GegaAPBGLxenp6dHR0VevXk1KSqqrq9PW1nZwcLC3tx8+fPjQoUMJnqugi1gsLigoSExMjI+PT0pKKiws5HK5VlZWw4cPd3FxcXJy0tLSIp0RAN4XegaAHKiqqjp//nx0dPS5c+cePXrUrVs3JycnBwcHR0dHKysrdt/W8Pjx46SkpPj4+Li4uOvXr3O5XEdHRzc3Nzc3t/79+5NOBwDvgJ4BILsyMzNPnjwZHR2dmprK5XIdHBzc3d0V+f21srIyJiZGIBCcO3fu8ePH3bp1c3NzGz9+/Pjx49XU1EinA4A2oGcAyJycnJywsLCwsLDCwkIjIyNJt3B2dsb1ghdEIpHk+pFAILh27ZqamtqkSZN8fHzc3NxUVVVJpwOAf6BnAMiKkpKSyMjIgwcPpqenGxoaenl5TZs2zdHREetMvF1VVVVUVFR4eHh0dLSysvLYsWNnz549efJkFRUV0tEAAD0DgLQnT54EBwfv27cvMzOza9eu3t7ePj4+Dg4O7L7rggn3798/duxYWFhYYmKitra2r6/vvHnzBg8eTDoXgEJDzwAgQywWX716dffu3cePH1dSUvL19Z05c+aIESNQL9rv7t274eHhe/fuzcvLGzhw4Pz58/38/PBkLAAR6BkA0vbkyZPw8PBt27bl5OTY2touWLBg+vTpkr1CgF5paWm7du06fPhwa2vrpEmTFixY4OTkhOtQANKEngEgPTdu3Ni4cWN4eLi6uvqMGTPmz5+vsE+OSNPTp08PHz68e/fuGzduWFtbL1261M/PD3dvAEgHegYA48RisUAg2Lhx48WLF21sbJYuXerj46Ourk46l8JJS0vbtm1baGhox44dlyxZ8vnnn3fs2JF0KACWQ88AYFBzc/ORI0d+//33nJwcR0fHlStXTpw4EeftyXr06NGOHTu2bdvW0NDg4+Pzww8/WFhYkA4FwFroGQCMqK+v3759+9atW6urq/38/JYtW2ZtbU06FPyjvr5+7969W7ZsuXv3rqen508//WRjY0M6FAALoWcA0KyxsXHHjh1r1659/vz5l19+uWTJkm7dupEOBW0TCoXHjx9fu3ZtZmamt7d3YGCgpaUl6VAArIIn6ABo09zcvGvXLnNz859++mn69Om3bt367bffUDJkGY/H8/HxSU9PP3fu3K1bt/r16+fj43Pz5k3SuQDYAz0DgAYtLS0HDx60tLRcsmTJxIkTb9++vXXr1s6dO5POBe/L2dk5LS3tyJEj2dnZlpaWPj4+t2/fJh0KgA3QMwDaKzIy0srKav78+a6ursXFxX///XfXrl1Jh4IPxuFwpk2blpOTExQUlJ6ebmVl9e233z59+pR0LgD5hp4B8PFycnLGjRvn4eExaNCgwsLCv/76y9DQkHQoaBcejzd79uz8/PzNmzcHBQX17t179+7dQqGQdC4AeYWeAfAxqqurAwICBg4cWFVVdeXKlSNHjpiYmJAOBbRRUlJatGjR7du3/f39lyxZYm1tfe7cOdKhAOQSegbAh2ltbd21a5eFhcXhw4c3bNiQkpIyYsQI0qGAETo6OmvXrs3KyurZs6ebm9ukSZOKi4tJhwKQM+gZAB8gIyPDzs5u8eLF06dPLyoqCggI4PF4pEMBs3r37n369OmYmJjS0lIrK6vAwMDm5mbSoQDkBnoGwHtpaGhYtmzZ4MGDtbS08vLytm7dqqWlRToUSI+zs3N6evq//vWvdevWDRs2LC0tjXQiAPmAngHwbleuXBk0aFBQUNDGjRtjY2PNzc1JJwIClJSUvv/++5ycHD09PTs7u4CAgPr6etKhAGQdegbA29TU1CxcuHDMmDG9e/fOzs4OCAjgcvFTo9B69uwZExOzd+/ekJAQGxubmJgY0okAZBpeMQHe6PTp0xYWFmfOnImIiDh9+rSRkRHpRCATOBzO7Nmzs7OzBwwY4OrqunDhwoaGBtKhAGQUegZAG549e/bFF19MnjzZ3d09Ly/Pw8ODdCKQOd26dYuIiAgLCzt+/Litre3169dJJwKQRegZAK/Kycmxs7MLDQ0NCQkJCgrS1tYmnQhkl7e3d25urpmZmb29fWBgIFb0AngFegbAP8Ri8datWwcPHqyvr5+TkzNjxgzSiUAOdO7cOSoqasOGDWvXrh0xYgTW2AB4GXoGwH/du3fP2dl5xYoVP//8c2xsLO7GgPfH4XACAgKSk5NramoGDx4cFhZGOhGArEDPAKAoirp06dKgQYPu3buXmJi4cuVKPFQCH2HAgAFpaWmffPKJr69vQEBAS0sL6UQA5OHFFIDatWuXq6urnZ3dtWvXbG1tSccBOaampvbXX3+dPHly//79Y8aMuX//PulEAIShZ4BCq6+v9/X1XbRo0Zo1a06ePIlbPoEWU6ZMSUlJqa6uHjBgwMWLF0nHASAJPQMU161bt+zt7S9evCgQCFauXMnhcEgnAvbo06fPtWvXRo4c6erqum7dOtJxAIhBzwAFFRkZOXjwYDU1tfT0dBcXF9JxgIU0NTXDw8NXr179ww8/zJw5s7GxkXQiAALQM0ARbd682dPTc9q0aXFxcd27dycdB1iLw+H8+OOPUVFRZ8+edXJyqqioIJ0IQNrQM0CxCIXCr776avny5T/99NOePXtUVFRIJwL2c3NzS0lJqaystLOzKygoIB0HQKo4YrGYdAYAKWloaPDz8zt37lxQUND06dNJxwHFUlVV5eHhkZube+LEiVGjRpGOAyAlOJ8BiuLhw4ejR49OSEiIiYlByQDp09PTi4mJcXV1dXV1DQkJIR0HQEp4gYGBpDMAMC43N3fs2LFCofDy5csDBgwgHQcUFJ/Pnzp1ak1NzcqVK5WUlEaMGEE6EQDj+KQDADDu+vXrbm5uffv2PXHihJ6eHuk4oNC4XO7GjRvNzMwiZKf9AAAgAElEQVQCAgIqKys3btyIB6qB3dAzgOXi4+MnTJjg6Oh4/PhxNTU10nEAKIqivvzySwMDg5kzZ9bX1+/cuRPr3AOLoWcAm12+fHnSpEljxowJCwtTVVUlHQfgHz4+Ph06dPD29q6rqzt48KCSkhLpRACMQIkG1oqKinJ3d580aVJERARKBsigCRMmCASCqKioqVOnPn/+nHQcAEagZwA7HT161NPTc9asWSEhIXw+ztuBjBo9evTZs2fj4uLGjx9fX19POg4A/dAzgIVCQkJmzJixePHiv//+G1e+QcYNHz48NjY2Kytr8uTJWJsc2AfrdAHbRERE+Pr6Ll26dP369aSzALyvrKysMWPGDBs27OTJk8rKyqTjANAGPQNYJSYmZtKkSXPnzt2+fTseFwT5kpGRMWbMmNGjR4eHh+NiH7AGegawR0JCgqurq5eXV1BQEC6XgDxKTEx0dXX18PA4cOAAvoeBHdAzgCWuXbvm4uLi4uJy9OhR/C4I8is2NnbSpEl+fn579uzBOTlgAfRlYIOMjAx3d/fRo0cfOXIEJQPkmrOzc2ho6MGDB1esWEE6CwANsL8JyL3S0tIxY8YMGDDgxIkT2OcdWMDCwsLc3HzFihUaGhoODg6k4wC0C37zA/lWW1s7efJkPT29Y8eOYTEuYA0/P7+HDx9+88033bp1w/bCINfQM0COtbS0eHl5VVVVJScna2trk44DQKdly5aVlpZ+9tlnxsbGOKsB8gv3gYK8EovF/v7+ERERV69exVbvwEpCodDLyyshISExMbFXr16k4wB8DNwHCvLq3//+d0hISEhICEoGsBWPxzt8+LCZmZm7u3tFRQXpOAAfA+czQC4FBwfPmTNnx44dCxcuJJ0FgFkPHjyws7MzMTE5f/487nQGuYPzGSB/UlJS5s+f/80336BkgCLo2rXrmTNnMjIylixZQjoLwAfD+QyQM1VVVYMHDzY3N4+OjubxeKTjAEhJZGSkh4fHrl275s2bRzoLwAdAzwB5IhQKx48fX1hYeP36dX19fdJxAKTqhx9+2LRpU1xc3JAhQ0hnAXhf6BkgT7799tvt27fHx8fb2tqSzgIgbSKRaMKECbm5uWlpaQYGBqTjALwX9AyQGydPnpw6derevXv9/f1JZwEgo7q6evDgwaampufPn8d1Q5ALuA8U5ENhYeGcOXMWLVqEkgGKrGPHjhEREUlJST/99BPpLADvBeczQA40NjYOGTJES0vr8uXLysrKpOMAELZv37558+ZFRUW5u7uTzgLwDugZIAcWL14cEhKSmZlpbGxMOguATJg5c2ZMTExmZmaXLl1IZwF4G/QMkHXnzp1zd3c/dOgQdpMCeOHp06cDBgywsLA4e/Ysh8MhHQfgjdAzQKZVVFTY2NiMGzfuwIEDpLMAyJaEhIRRo0b98ccfixYtIp0F4I3QM0B2icXiKVOm5OTkZGRkaGlpkY4DIHNWr169fv36lJQUa2tr0lkA2oaeAbLrzz///Prrr69cuYJNsQHa1NraOnLkyLq6utTUVFVVVdJxANqA51pBRhUUFHz77berVq1CyQB4Ez6fHxISUlZWhsdcQWbhfAbIIpFINGrUqOfPnyclJfH5fNJxAGTa3r17Fy5cmJSUhPXIQQahZ4AsklwxSUlJGThwIOksALJOLBaPGzfu0aNHaWlpSkpKpOMA/A9cNwGZc//+/R9//HHFihUoGQDvg8Ph7Nq1q7i4+PfffyedBeBVOJ8BMsfDwyM/Pz8zMxP3tQG8v7Vr1wYGBt64ccPS0pJ0FoB/oGeAbDly5Iifn19sbOzYsWNJZwGQJ62trcOGDdPQ0Lh8+TJW7gLZgZ4BMqS6urpv374eHh47d+4knQVA/mRmZg4ZMmT79u0LFiwgnQXgv9AzQIYsWLAgKioqLy9PW1ubdBYAufTtt9/u2bPn5s2bBgYGpLMAUBR6BsiOjIyMwYMHHzx40M/Pj3QWAHn17NkzCwuL8ePH46QgyAj0DJAVo0ePbmpqSkxMxKVlgPY4ePCgv79/SkqKra0t6SwA6BkgG8LDw319fZOTk4cOHUo6C4B8E4vF9vb2ampqly5dIp0FAD0DZMDz588tLS1HjhyJTVkBaJGcnOzg4HDs2LGpU6eSzgKKDj0DyPv111/Xrl1bWFjYrVs30lkAWGLWrFkJCQl5eXlYhwbIwnqgQNijR4/Wr1///fffo2QA0Gjt2rUVFRWbN28mHQQUHc5nAGELFy48d+5cfn6+mpoa6SwArLJmzZoNGzYUFxfr6emRzgKKC+czgKSysrL9+/f/61//QskAoN2yZctUVVU3bNhAOggoNJzPAJL8/f3j4+Pz8/Ox+TsAEzZs2BAYGFhUVNS5c2fSWUBB4XwGEHPr1q2QkJDVq1ejZAAwZPHixTo6OuvXrycdBBQXzmcAMX5+fmlpabm5uegZAMz5448/Vq5cefv2bUNDQ9JZQBGhZwAZubm5NjY2R44cmTZtGuksAGzW1NTUq1evKVOmbNu2jXQWUEToGUCGt7d3YWFhZmYml4uLdwDM2rlzZ0BAQEFBgampKeksoHDQM4CAvLy8fv36HT9+3NPTk3QWAPZrbm7u06fPhAkTtm/fTjoLKBz8KgkEbNy4sXfv3lOmTCEdBEAhKCsrL126NCgoqLKyknQWUDjoGSBtjx8/Pnz48PLly3HFBEBq5s6dq6amhs3iQfrwQg/S9scff2hpac2cOZN0EAAF0qFDhwULFmzbtu358+eks4BiQc8AqXr27Nnff//95ZdfYgFQACkLCAiora0NCQkhHQQUC3oGSFVQUFBDQ8OiRYtIBwFQOJ07d54+ffqGDRtEIhHpLKBA8LwJSI9IJOrTp4+Li8tff/1FOguAIiooKOjbt+/p06cnTJhAOgsoCvQMkJ7IyEhPT8/8/PzevXuTzgKgoMaPH9/S0hITE0M6CCgK9AyQnokTJ7a0tJw7d450EADFdebMmcmTJ9+8edPc3Jx0FlAIuD8DpKS8vDw6Onr+/PmkgwAoNHd39+7du+/bt490EFAU6BkgJXv37tXV1Z00aRLpIAAKjcfjzZkzJygoqKWlhXQWUAjoGSANIpEoKCjI399fRUWFdBYARTdv3ryKioqoqCjSQUAh4P4MkAaBQDB+/Pi8vDxLS0vSWQCAcnV1VVJSOnPmDOkgwH7oGSANU6dOffLkyaVLl0gHAQCKoqhjx475+vqWlJT06NGDdBZgOVw3AcY9fPjwzJkz8+bNIx0EAP5r8uTJ+vr6+/fvJx0E2A89AxgXHh6upqbm5eVFOggA/JeysvKMGTMOHTpEOgiwH3oGMO7IkSNTpkxRVVUlHQQA/uHr63vz5s2MjAzSQYDl0DOAWeXl5UlJST4+PqSDAMD/GDp0qImJydGjR0kHAZZDzwBmhYWFaWtru7i4kA4CAP+Dw+H4+PgcPXoUTwMAo9AzgFlhYWGenp5YNgNABvn4+JSUlKSlpZEOAmyGngEMunPnTkpKCi6aAMgmW1tbc3NzXDoBRqFnAIOOHDmio6MzduxY0kEAoG3Tpk3DpRNgFHoGMCgiImLq1KnKysqkgwBA23x8fO7evZuamko6CLAWegYwpbKyMjU1FRunAciyAQMG9OjRQyAQkA4CrIWeAUyJjo7m8/m4aAIg41xdXaOjo0mnANZCzwCmREdHDx8+XFNTk3QQAHgbNze3lJSUiooK0kGAndAzgBEikSgmJsbNzY10EAB4B2dnZx6PFxsbSzoIsBN6BjDi+vXrjx8/dnd3Jx0EAN5BS0vLwcEBl06AIegZwAiBQGBkZGRlZUU6CAC8m5ubm0AgEIlEpIMAC6FnACOio6Pd3d05HA7pIADwbu7u7hUVFdhTDZiAngH0q62tTU1NHTduHOkgAPBebGxsunTpEhMTQzoIsBB6BtAvKSlJKBQOHz6cdBAAeC8cDmf48OEJCQmkgwALoWcA/RITE83Nzbt06UI6CAC8L0dHx8TERCxADrRDzwD6JSQkODo6kk4BAB/A0dGxqqqqsLCQdBBgG/QMoJlQKExJSUHPAJAvAwcO1NDQwKUToB16BtAsMzOzrq7OwcGBdBAA+AB8Pn/IkCHoGUA79AygWUJCgo6OjqWlJekgAPBhHB0d4+PjSacAtkHPAJolJCQ4ODhwufjWApAzjo6Ot27devjwIekgwCp4MwCaXb9+fdiwYaRTAMAHGzZsGIfDSUtLIx0EWAU9A+hUV1dXXFw8YMAA0kEA4IPp6up27949OzubdBBgFfQMoFN2drZYLLa2tiYdBAA+ho2NDXoG0As9A+iUlZWlqalpYmJCOggAfAxra+usrCzSKYBV0DOATtnZ2TY2Ntg+DUBOWVtbFxQUNDU1kQ4C7IGeAXTKysrCRRMA+WVjY9Pa2lpQUEA6CLAHegbQRiwW5+TkoGcAyK8+ffqoqKjg0gnQCD0DaHPnzp2amhobGxvSQQDgI/H5fAsLC9wKCjRCzwDaSM619u3bl3QQAPh4VlZW+fn5pFMAe6BnAG1KSkq0tbU7duxIOggAfDxTU9PS0lLSKYA90DOANqWlpaampqRTAEC7mJiYlJSUkE4B7IGeAbQpKSlBzwCQd6ampg0NDRUVFaSDAEugZwBtSktLsUIXgLyT/LaAUxpAF/QMoA16BgALdO/encfj4RYN+L/27jysiWthA/gkrAGBakBcqiKgIEiQxYVEwQJqaG2tRYTWFsGlUihqH23t87ResPa20lat12pbF2pVVEBFxSUuiLKjiJRNUCsIrkCqhEUJkHx/5H6UixSiTjjJ5P394SNJyLxzFPLmzMwJXdAzgB6KiVYcNwHQdHp6ekOHDsV8BtAFPQPoUVlZKZfLMZ8BwAC45ARohJ4B9KiurqYoavjw4aSDAMDLsrKyun37NukUwBDoGUCP2tpaAwMDMzMz0kEA4GVZWFjU1dWRTgEMgZ4B9KirqzM3NyedAgBowOVyxWIx6RTAEOgZQA+xWMzlckmnAAAamJubYz4D6IKeAfQQi8WYzwBgBi6XK5FIpFIp6SDABOgZQI+6ujrMZwAwg+I9w19//UU6CDABegbQA/MZAIyheM+AUzSAFugZQA+cnwHAGIr3DDhFA2iBngH0+Ouvv7TqE+Hz8vJYLFZ0dDTpIP9DPVP1gV27drFYrIMHDyr5eDUZqOeN3WcGDBjAYrFw3ARogZ4B9GhubjYyMiKdQk1lZGSwWKyvv/6adBAApejq6urp6TU3N5MOAkygSzoAMERLS4uBgQHpFH3H3d1dLpeTTtGVeqYCTWRgYIDrTYAWmM8AekilUn19fdIpAIAe+vr6LS0tpFMAE6BnAA3kcnlra6sa9gyRSMRisX788ceLFy96eXmZmJi4u7tTFCWXy2NjY/l8vomJCYfDcXZ23rJlS+eZgEePHoWHhw8aNIjD4bi7ux8/frzLofQuB/jb29s3b97s5ubWv3//V155xd3dfcOGDYpp56+//nrKlCkURa1evZr1/xTf1XOMfwrfgy6pOp4hNTWVz+cbGxsPGzZs3bp1ins3b95sZ2dnaGhob2+fmJjY+XnS0tLmzZtna2trYGBgYWHx5ptvZmZmdn5Ar+PT6971MGK9evz48ccffzx48OCOrT/7mF7/ibvoYZezs7NZLNbHH3/c5VsSEhJYLNYPP/yg5BaVia0+DAwM0DOAHnKAl/bkyROKoo4dO0Y6SFenTp2iKCogIEBX97+HCF1cXGQy2bx58579WVi8eLHiu548eTJu3LjOd7FYrMDAQIqiEhMTFY+5fPkyRVFRUVGKLz/99NNnn3Dz5s1yuXzt2rXd/tz1GqPb8D3vb5dUimcIDAzseAaFDRs2fPbZZ51vYbPZV69eVXzX/fv3n02lq6t78eJF5cen173rYcR6RsvWuwxUr7s8fvx4ExOThoaGzkm8vLyMjY0fPXqkzBaVia1WrKysYmJiSKcAJkDPABrU19dTFCUSiUgH6UrxQktR1IIFC8rLy9va2uRy+e7duymKcnJyOnnypFgsbmxsvHjxorOzM0VRWVlZcrn8u+++oyjKzs4uJSWloaGhoqIiMjJS8Tz/1DNGjRplbGx86NChx48fNzU1FRQUrFy58rffflPcm56eTlHU2rVrO2frNUa34XvWbc+gKGr58uWVlZWNjY0HDx7U09MzMzMzMTHZsWNHTU2NWCxesWIFRVHBwcGK73rw4MG0adOSk5Orq6ulUunDhw8TEhKMjY39/PwUD1BmfHrdu55HrAcdWz937lxDQ8OtW7fCw8Ofd+tdBqrXXd6zZw9FUVu3bu2IUVJSQlHURx99pOQWlYmtVuzs7Lr8jwV4MegZQIOamhqKos6fP086SFeKF9pJkybJZLKOG1977TUdHZ179+51fqTiZWPVqlVyuXzChAksFqu4uLjzA6ZNm9ZDz3jttddGjRrV2trabYxue0avMboN37Nue4ZQKOz8GH9/f4qi1q9f33FLW1ubmZmZ4hxShby8vICAgCFDhnSeCHn11VcV9yozPr3uXc8j1oOJEyc+u3UfH5/n2nqXgep1l1taWgYNGjR27NiOx0dERFAUVVpaquQWlYmtVng83pdffkk6BTABzs8AGijOS1fb6018fX07TomgKKqkpKS9vX3YsGG6uro6OjpsNpvNZjs6OlIUVVVVRVHUn3/+OXToUMUtHWbMmNHDJjZu3CiTyWxtbZcsWbJ169arV6/2mqrXGN2GfwFeXl6dvxwxYgRFUZ6enh236OjoDB069OHDh4ovs7Ky+Hx+YmLivXv32traOh6mODpGKTc+ve7dC4yYws2bN5/dulAofK6td9HrLuvr64eFhRUXF6elpVEU1djYuGfPnunTp48ZM0bJLSoTW63gPFCgC3oG0EAul1MU9ZIvh6rTZaFSmUxGUVR7e3t7e3vHVIHiro4L+Z7dF3mP14s6OzuXlZXt3r175MiR6enpQqHQ0dGxqKioh29RJsaz4V+AoaFh5y8Vu/bsjYo8FEWtW7dOKpVGRUXdvHnzyZMnimx2dnbPPklnXcan1717gRFTnpJj20GZXQ4LC9PX19+6dStFUXv27JFIJMuWLXvhLao/Npvd8V8C4GVg/QyggeJKE035fWpvb5+fn3/v3j0zM7NuH2BjY3P58uXS0lIHB4eOG8+ePdvz0+rq6np6eirmCZqbm+3s7BYuXHjp0iWKothsNkVRnd8oKxODlFu3bllaWnZeK/PPP/+8ceNG//79FV8qMz7K7F0PI9YDW1vbS5culZSUdJ4bEIlEz7v1znrdZYqiLC0tAwMDDxw48ODBg59//nnUqFF+fn7Kb1GZ2GpF21bEAdXBfAbQQLN6xsKFC5ubm319fY8fP15bWyuVSm/fvn3ixAl/f/+UlBSKovz9/eVy+Zw5cy5cuNDU1HT79u1PPvnkzJkzPTwnn8//5ZdfSktLnzx5Ul9fLxKJxGLxrVu3FPcqVmRPT0/v/MFUvcYgZfjw4TU1NT/99FN9fX19ff3Jkydff/31zm9tlRmfXveu5xHrgWLr/v7+58+fb2xsrKioiIiI6DJizzu2ve6ywrJly1pbWxcsWFBUVBQZGdl5UkfJ/1Q9x1YrUqkUPQPo0SdngQDDKZY9SE5OJh2kK8WJkBs3bux8o0wmCwkJ6fbH4dSpU3K5vLm5mcfjdb6dxWIFBARQFHXkyBHFk3Q5kbDb38hLly5V3NvW1jZ06NAuP3e9xug2fM+6PQ+0yzMori4pKirqfKOjo+PQoUMVfz9y5EiXPC4uLmPHjuVyuYoHKDM+ve5dzyPWAyWva+15610Gqtdd7sDn8ymKMjU1lUgknW/vdYsad12rtbX1unXrSKcAJsB8BtBAs+YzWCzWb7/9Fh8f7+vr279/f319fWtr67fffjspKcnX15eiKA6Hk5qaumTJkoEDBxoaGrq5uR07dkxxjKDzRHpnubm5ERERDg4OHA7H3NxcIBDs2LFj48aNint1dHQOHjw4efJkY2Nj5WOQMmvWrLi4OB6Px+FwBg8evGTJkpSUlM61QJnx6XXveh6xHhgaGqampoaHh1taWhoaGrq4uCQlJXU5ofJ5x7bXXe4QFhZGUdSCBQtMTEyea4vKxFYrLS0tarjyHmgilhyfhgB00NXV3bt3b1BQEOkgKiGTydzd3QsKCmpra1/+xEzm0Z7x+eSTTzZt2nTjxg0bGxvSWVRr4MCB0dHRHYt8ALwwzGcAPRi2SvGKFSv27t17+/bt5ubmgoKCuXPnXr16derUqcx+EVWeFo5Pe3v76dOnf/75Z09PT8aXDArngQJ9cL0J0ENfX19Tjpsoo7y8fMOGDZ1v6devX5db+l5BQYGLi8s/3Ttr1qxnzzNQEdWNj/rsY2fR0dFr1qxR/H3VqlV9H6Dv4TxQoAvmM4AeHA7n6dOnpFPQZuPGjSEhIR2fqjVnzpzs7Owu5/FpM+0cnyFDhmzYsKHz5axMJZPJ0DOALjg/A+jh6OgYEBDQeQUCANBQYrHY3Nw8JSXF29ubdBbQeJjPAHpwudzOi0MAgOZS/Cwz+Gwb6EvoGUAPc3Nz9AwAZqirq6PQM4Am6BlADy6Xq/jdBACaDvMZQCP0DKAHjpsAMEZdXZ2RkRGHwyEdBJgAPQPogfkMAMZQnAdKOgUwBHoG0APnZwAwhlgsxkEToAt6BtCDy+U2NTU9efKEdBAAeFnoGUAj9Aygh+LzSO/cuUM6CAC8rKqqqldffZV0CmAI9Aygx8iRIymKqqysJB0EAF5WRUWFlZUV6RTAEOgZQI8BAwaYmZlVVFSQDgIAL0Uul1dVVSneOQC8PPQMoM2IESMwnwGg6e7fv//06VPMZwBd0DOANlZWVugZAJpOMSuJ+QygC3oG0GbkyJE4bgKg6SoqKvT09IYMGUI6CDAEegbQBvMZAAxQWVk5YsQIHR0d0kGAIdAzgDYjR458+PBhc3Mz6SAA8OJwsQnQCz0DaDN69Gi5XF5WVkY6CAC8uLKystGjR5NOAcyBngG0GT16NIfDKSoqIh0EAF6QXC4vLi7m8XikgwBzoGcAbXR0dMaMGYOeAaC5KisrJRIJegbQCD0D6MTj8QoLC0mnAIAXVFhYyGKxHB0dSQcB5kDPADo5OTkVFBSQTgEAL6ioqGjkyJGmpqakgwBzoGcAnXg8Xm1tbU1NDekgAPAiioqKnJycSKcARkHPADo5OztTFIVDJwAaqrCwECdnAL3QM4BOFhYWgwYNQs8A0ERPnz69efPm2LFjSQcBRkHPAJq5urpevnyZdAoAeG75+fltbW2urq6kgwCjoGcAzQQCQXp6OukUAPDcMjIyLC0tbW1tSQcBRkHPAJoJBIK7d+9WV1eTDgIAzyczM3Py5MmkUwDToGcAzSZMmKCvr5+ZmUk6CAA8B7lcnp2dLRAISAcBpkHPAJpxOJxx48ahZwBoluvXr9fW1mI+A2iHngH0EwgE6BkAmiUjI4PD4SguTQegEXoG0E8gEBQWFkokEtJBAEBZmZmZEydO1NfXJx0EmAY9A+jH5/Pb29tzc3NJBwEAZWVlZeHkDFAF9Ayg3+DBg+3t7c+dO0c6CAAopaqqqry8fOrUqaSDAAOhZ4BKCIXCU6dOkU4BAEo5deqUsbHxlClTSAcBBkLPAJUQCoVFRUVYRQNAI4hEIm9vbwMDA9JBgIHQM0AlvLy8jIyMzpw5QzoIAPSitbU1NTVVKBSSDgLMhJ4BKmFoaDh16lQcOgFQfxkZGfX19TNmzCAdBJgJPQNURSgUnj17trW1lXQQAOiJSCSys7OzsbEhHQSYCT0DVOWNN96QSCTZ2dmkgwBAT0QiEQ6agOqgZ4CqWFtb29ranjhxgnQQAPhH1dXVRUVF6BmgOugZoELvvPNOYmKiXC4nHQQAupeYmGhmZvbaa6+RDgKMhZ4BKjR37tyKioq8vDzSQQCge/Hx8bNnz8YVraA66BmgQm5ubqNGjUpISCAdBAC6UVVVdfny5blz55IOAkyGngGqFRAQEB8fj0MnAGrowIEDr7zyire3N+kgwGToGaBac+fOra6uxmeqAaihhISEOXPm4DNaQaXQM0C1nJ2dx4wZg0MnAOrm1q1b+fn5OGgCqoaeASo3Z86cxMREmUxGOggA/O3AgQPm5ub4jFZQNfQMULmgoKA7d+6kpqaSDgIAf9u7d29AQICuri7pIMBw6Bmgcg4ODh4eHjt27CAdBAD+KyMj49q1awsXLiQdBJgPPQP6wuLFiw8fPlxbW0s6CABQFEVt377d2dnZ1dWVdBBgPvQM6AtBQUFGRkZ79+4lHQQAqPr6+oMHD4aFhZEOAloBPQP6AofDCQoK2rZtGxbSACAuLi5OLpcHBQWRDgJaAT0D+khYWFhZWVlmZibpIADabseOHUFBQa+88grpIKAV0DOgjygOBm/fvp10EACtlpeXd/Xq1UWLFpEOAtoCPQP6zuLFixMTE8ViMekgANrr119/dXBw4PP5pIOAtkDPgL4THBxsZGT0888/kw4CoKVqamr27t27dOlS0kFAi6BnQN8xMjL68MMPN2/e/PTpU9JZALTR5s2bTUxMgoODSQcBLYKeAX1q2bJlEokkLi6OdBAArdPc3PzLL79ERERwOBzSWUCLoGdAn7K0tAwKCvr+++/xcScAfSw2NraxsRHLZkAfY2E9A+hjxcXFPB7v+PHjr7/+OuksANqivb3d3t5+2rRpW7duJZ0FtAt6BhAgFApbW1tTUlJIBwHQFgcPHgwMDCwpKbG3tyedBbQLegYQcPbs2enTp+fl5bm5uZHOAqAVPDw8LC0tjxw5QjoIaB30DCBjwoQJlpaWycnJpIMAMN+pU6def/31nJyciRMnks4CWgc9A8hQ/OLLzs6eNGkS6SwADDdx4sSBAwei1gMR6BlAjKenJ4fDOX36NOkgAEx29OjR2bNn5+bmjh8/nnQW0EboGUBMSldXIE4AABFcSURBVEqKr6/vhQsXvLy8SGcBYCa5XO7q6mptbX3o0CHSWUBLoWcASd7e3q2trenp6aSDADBTYmJiUFBQfn6+s7Mz6SygpdAzgKTMzMzJkyefO3fOx8eHdBYAppHJZOPGjXN0dNy/fz/pLKC90DOAMKFQWF9fn5WVxWKxSGcBYJS9e/eGhIQUFxdjzQwgCD0DCLty5cqECRPi4uKCgoJIZwFgjubmZsUCoDt37iSdBbQaegaQt2DBgrNnz5aVlRkbG5POAsAQUVFRGzduLC8vHzx4MOksoNXwOWpA3rfffiuRSNavX086CABD3LlzZ/369atXr0bJAOIwnwFqYd26dV999VVZWdnw4cNJZwHQeO++++6lS5dKS0sNDAxIZwFth54BakEqlY4dO3bChAl79+4lnQVAs2VnZwsEgqSkpFmzZpHOAoCeAWrj8OHDc+bMSUtLmzx5MuksAJpKJpNNmjTJxMQEn4cMagI9A9SIt7d3Q0NDTk6Ojo4O6SwAGmnHjh0fffRRfn6+k5MT6SwAFIXzQEGtbN68ubCw8D//+Q/pIAAa6cGDB5999llkZCRKBqgPzGeAeomOjv7++++Lioqsra1JZwHQMAEBAZcvXy4uLu7Xrx/pLAD/hZ4B6kUqlbq6ulpaWp47dw4rhAIo78SJEzNnzhSJRDNmzCCdBeBv6BmgdnJzcwUCQWxsbHBwMOksAJpBIpE4Ojp6e3v//vvvpLMA/A/0DFBHkZGR+/fvLy0tHThwIOksABogPDw8MTGxtLTUwsKCdBaA/4GeAeqoqanJycnJw8MjLi6OdBYAdZeTkyMQCPbs2fPee++RzgLQFXoGqKmTJ0/OnDkzISFhzpw5pLMAqK/GxkYXF5fRo0efOHGCdBaAbqBngPoKCwuLj4//448/sBg5wD8JDQ09fvx4YWEhPsoE1BN6Bqiv5uZmNze3gQMHnj9/Hit3ATxLsYrukSNH3nrrLdJZALqHdbpAfRkZGcXFxeXk5OCjXAGedffu3cWLF4eFhaFkgDrDfAaou5iYmNWrV2dkZEyYMIF0FgB1IZPJpk2bdv/+/by8PCMjI9JxAP4RegaoO8Xv06qqqqtXr2KVQwCFb7/9NioqKjMzc/z48aSzAPQEx01A3bHZ7N9///2vv/5avnw56SwAaiEnJycqKuqbb75ByQD1h/kM0AzHjh17++23f/3118WLF5POAkBSTU2Nm5sbj8dLTk5ms/FeEdQdegZojC+//PKHH35IS0vDiRqgtdra2qZNm1ZZWZmXl8flcknHAegdegZoDJlMNnPmzOLi4itXrmBxZdBOK1as2Lp1a2ZmpqurK+ksAEpBzwBN8ujRI3d39xEjRpw5c0ZXV5d0HIA+lZSU5O/vHxsbGxISQjoLgLJwbA80Sf/+/Q8fPpybm/vFF1+QzgLQp8rLy0NCQiIiIlAyQLNgPgM0z65duxYsWHDgwIG5c+eSzgLQFx49euTh4cHlclNTU/X19UnHAXgOmHkGzRMSEpKfnz9//vxXX32Vz+eTjgOgWlKp9J133mlqajp//jxKBmgczGeARpLJZP7+/unp6dnZ2aNGjSIdB0BV5HJ5SEhIUlJSWlrauHHjSMcBeG44PwM0EpvN3rdvn62trZ+fX21tLek4AKqyZs2auLi4uLg4lAzQUJjPAA324MGDSZMmDRs27OzZs4aGhqTjANBs//798+bN++mnn8LDw0lnAXhBmM8ADTZo0KCTJ0+WlJTMnz9fJpORjgNAp4sXL4aGhn7++ecoGaDRMJ8BGi8lJcXPz2/58uXfffcd6SwA9CgsLPTy8hIKhfv27WOxWKTjALw4nejoaNIZAF6KtbW1tbX1Z599pqOj4+npSToOwMsqLy/38fFxdnZOSEjQ09MjHQfgpeC6VmCCefPmSaXShQsXGhgYfPrpp6TjALy46urqGTNmWFlZHTlyBGcdAQOgZwBDhIaGNjQ0LF++3MTEJCwsjHQcgBfx8OHDadOmmZmZnTx50sTEhHQcABqgZwBzLF269NGjRxERESYmJvPmzSMdB+D51NXVeXt7y2Sy06dPDxgwgHQcAHqgZwCjREVFPXnyZP78+Xp6eliVHDRIfX29UChsbGxMS0sbNGgQ6TgAtEHPAKb59ttvJRLJBx98wGaz58yZQzoOQO8ePXrk5+f34MGDtLS0ESNGkI4DQCf0DGAaFou1ZcsWAwODoKCg7du3h4aGkk4E0JOHDx9Onz798ePHqamp1tbWpOMA0Aw9AxiIxWJt3LjR1NR04cKFDQ0NS5cuJZ0IoHtVVVW+vr5tbW0XLlwYOXIk6TgA9EPPAMZas2aNkZHR8uXLpVLpypUrSccB6KqiosLX19fQ0PDChQtDhgwhHQdAJdAzgMlWrVplYmISGRlZV1e3bt060nEA/nbt2rVp06YNGjRIJBKZm5uTjgOgKugZwHDh4eF6enphYWFSqfSHH35gs/GZPkBeTk7Om2++6eDgkJycbGpqSjoOgAqhZwDzLV682NTUdP78+VVVVXv27OFwOKQTgVY7fPjw+++/7+PjEx8fb2RkRDoOgGrhvR1ohcDAwNTU1LS0tKlTpz58+JB0HNBemzZtCggImDdvXlJSEkoGaAP0DNAWHh4e2dnZjx8/9vDwuHbtGuk4oHXa29sjIyM/+eST1atXb9++XVcX08mgFfC58KBdxGLx7Nmzi4uLDx8+PHXqVNJxQFs0NTW9++67Z86c2bVrV1BQEOk4AH0H8xmgXbhc7unTp318fIRC4e+//046DmiF6urqKVOm5ObmXrhwASUDtA16BmgdDocTHx+/bNmy0NDQiIgIqVRKOhEwWUpKipubm1Qqzc7OnjRpEuk4AH0NPQO0EZvNjomJOXLkSFxcnEAguH37NulEwEByuXzTpk1+fn58Pj8zMxNrioN2Qs8A7fXWW2/l5uY2NzePHz8+JSWFdBxglIaGhsDAwJUrV65duzYpKcnMzIx0IgAy0DNAq9nZ2eXk5Hh5eQmFwpiYGJwWDbS4fv26h4dHamqqSCRatWoVi8UinQiAGPQM0HYmJiYJCQlr16794osvgoKCHj9+TDoRaLa4uDh3d3dTU9OCggIfHx/ScQAIQ88AoFgs1ueff3769On09HRnZ+e0tDTSiUAj1dfXv//++x988EFoaOiFCxeGDh1KOhEAeegZAP/l4+NTWFjo4uIyderUZcuW4ToUeC65ublubm5nz549duzYpk2b9PX1SScCUAvoGQB/Mzc3P3LkyK5du3bu3CkQCK5fv046EWiAtra2mJiYKVOm2NjYFBQUzJw5k3QiADWCngHQVXBwcF5enkwmc3Nz27lzJ+k4oNZu3brl6em5Zs2aH3/8USQSDR48mHQiAPWCngHQDXt7+9zc3BUrVixZssTPz6+yspJ0IlA7Mpls27Ztzs7OEokkJycnPDwc15UAPAs9A6B7urq60dHRaWlpVVVVjo6OMTEx7e3tpEOBuigqKuLz+R9//HFERMSVK1d4PB7pRABqCj0DoCd8Pr+goOBf//pXVFTU+PHj8/PzSScCwp4+fRodHe3u7q6jo1NQULBu3ToDAwPSoQDUF3oGQC/09PRWrVp15coVAwODiRMnfv7550+fPiUdCsjIyMhwcXH5/vvvv/rqq7S0NAcHB9KJANQdegaAUhwdHTMzM9evX79lyxYej5ecnEw6EfSpe/fuBQcHe3p62tralpWVrVq1SkdHh3QoAA2AngGgLDabvXTp0pKSEhcXl7feemvGjBmlpaWkQ4HKPX369N///vfo0aPT09MTExOTk5OHDRtGOhSAxkDPAHg+w4cPj4+Pz8nJkUgkzs7OS5Ysqa2tJR0KVCU5OdnR0fGbb75ZuXLltWvX/P39SScC0DDoGQAvYuLEiZmZmTt37jx27JidnV1MTAzWD2WYa9euCYXCWbNmubm5Xbt2LTo62tDQkHQoAM2DngHwgthsdnBw8M2bN5cuXRoVFWVvb79t2zZc+8oAFRUVS5YscXJyEovFGRkZCQkJw4cPJx0KQFOhZwC8FGNj4+jo6JKSksmTJ4eHhzs7Ox86dAifL6+hKioqQkNDFadi7Nu379KlS3w+n3QoAM2GngFAAxsbm927dxcXF7u6ugYGBvJ4vMTERLQNDVJdXb1s2bIxY8ZcuHBhy5YthYWFc+fOxfqeAC8PPQOANvb29rt3787Pz7e1tQ0MDJw0adKJEyfQNtTc7du3IyMjR40adezYsS1btty4cePDDz/U1dUlnQuAIdAzAGjG4/GSkpIuX75sYWHx5ptvjh07dufOnS0tLaRzQVf5+fnvvfeera3t0aNHN27cWF5evnDhQjQMAHqx8GYLQHVu3Ljx008/bdu2zdTU9KOPPoqMjORyuaRDAZWRkRETE3PixAkejxceHj5//nysHQ6gIugZACp37969zZs3//rrr1KpNDQ0dPny5TY2NqRDaaOWlpZ9+/atX7++tLR0+vTpK1eu9PX1JR0KgOHQMwD6SGNjo+JF7ubNmx4eHsHBwR988AGHwyGdSyuUlZXt2rUrNja2vr4+MDDw008/dXJyIh0KQCugZwD0qba2tpMnT27fvv3UqVMDBgwIDg5etGiRvb096VzM1NTUlJCQsH379uzsbBsbm4ULF4aEhAwePJh0LgAtgp4BQMbdu3djY2NjY2MrKyunTJmyaNGid955p1+/fqRzMcSlS5diY2P379/f0tIye/bsRYsWeXt74zpVgL6HngFAkkwmO3/+/LZt244ePcpms319fQMCAlA4XlhJSUliYuL+/fuvX79uZ2cXGhq6YMECCwsL0rkAtBd6BoBaePToUXJycmJi4unTp3V1dX18fAICAvz9/Y2NjUlH0wCKehEfH19WVjZs2LDZs2cHBAQIBAJMYAAQh54BoF5qamoOHToUHx+fnp5ubGw8c+ZMPz+/GTNmDBw4kHQ09dLW1paZmSkSiY4ePXrt2rVhw4YFBATMnTt3woQJqBcA6gM9A0BN3b9//+DBg0ePHk1PT29ra3N1dRUKhX5+fhMnTtTR0SGdjpjq6mqRSCQSic6dOyeRSGxtbd94442AgAA+n496AaCG0DMA1F1jY+P58+cVL64VFRUDBgzw9fX18fERCAQODg7a8OIqFouzsrLS0tJEIlFxcbGRkdHUqVP9/PyEQqGtrS3pdADQE/QMAE1SXl5+6tQpkUiUmZnZ2NjYv39/Pp8vEAgEAsH48eOZtBrH9evXs7KyMjIysrKyysrKKIpycHCYPn26UCj09PQ0NDQkHRAAlIKeAaCR2traCgsLFS/DGRkZd+/e1dPTc3Nzc3Nz4/F4Tk5OY8eONTExIR1TWe3t7X/++WdhYWFRUdEff/yRnZ1dU1PD4XDGjx+vaFF8Pr9///6kYwLAc0PPAGCC27dvZ2ZmZmVlXb16tbi4WCKRsFgsKysrRedwcnKys7OzsrIyMzMjnZSiKKq1tbW6uvrWrVvFxcVFRUWFhYWlpaXNzc06Ojo2NjY8Hs/Dw8PDw8Pd3V1PT490WAB4KegZAEwjl8srKyuLiooUL+GFhYU3btxob2+nKGrAgAFWVlYjR47s+HPYsGFcLpfL5dJ+JEIul4vFYrFYXFtbW1FRUVFRUVlZqfjzzp07bW1tFEVZWFh0NCEej+fo6MikQz8AQKFnAGiDlpaWW7dudX6lV/wpFos7HmNsbMzlcs3/X79+/czMzNhstp6enmLRsH79+nWeXaivr5fJZK2trY2NjRRFNTU1NTU1KYpFXV2d4i8dv14MDAxGjBjRpeJYW1tjBS0AxkPPANBeEonk3r174v9VW1srFosbGxsbGhra2to6moTiy47vNTU11dHR6WghJiYmHA6H+78sLCwU3WXIkCHacF0MADwLPQMAAABUhU06AAAAADAWegYAAACoCnoGAAAAqMr/AZOiMfHomo7UAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Visualize Dask Computation Graph\n",
+    "\n",
+    "visualize(result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Qszhkwfrx2ar"
+   },
+   "outputs": [],
+   "source": [
+    "# Write the meshes as vtk files\n",
+    "\n",
+    "m1 = itk.mesh_from_dict(output_result[0])\n",
+    "m2 = itk.mesh_from_dict(output_result[1])\n",
+    "\n",
+    "itk.meshwrite(m1, 'm1.vtk')\n",
+    "itk.meshwrite(m2, 'm2.vtk')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "_c_VmhNIyCPT"
+   },
+   "outputs": [],
+   "source": [
+    "# Read the meshes for viewing\n",
+    "\n",
+    "v1 = vtk.vtkPolyDataReader()\n",
+    "v1.SetFileName('m1.vtk')\n",
+    "v1.Update()\n",
+    "m1 = v1.GetOutput()\n",
+    "\n",
+    "v2 = vtk.vtkPolyDataReader()\n",
+    "v2.SetFileName('m2.vtk')\n",
+    "v2.Update()\n",
+    "m2 = v2.GetOutput()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 717,
+     "referenced_widgets": [
+      "00a6b63103ea40cb97280c5226da49ec",
+      "856173aca43d43d5a2affc843effc3bc"
+     ]
+    },
+    "id": "ICt28TFryR9s",
+    "outputId": "1c75c2c3-120e-4b3c-ebb5-cde0351e0972"
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "00a6b63103ea40cb97280c5226da49ec",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Viewer(geometries=[{'vtkClass': 'vtkPolyData', 'points': {'vtkClass': 'vtkPoints', 'name': '_points', 'numberO…"
+      ]
+     },
+     "metadata": {
+      "application/vnd.jupyter.widget-view+json": {
+       "colab": {
+        "custom_widget_manager": {
+         "url": "https://ssl.gstatic.com/colaboratory-static/widgets/colab-cdn-widget-manager/a8874ba6619b6106/manager.min.js"
+        }
+       }
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#Visualize the meshes\n",
+    "\n",
+    "from google.colab import output\n",
+    "output.enable_custom_widget_manager()\n",
+    "\n",
+    "itkwidgets.view(geometries=[m1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 717,
+     "referenced_widgets": [
+      "a94aac452f134317b546f25e3e8ea65c",
+      "4193a5dee9b243b899733baac0bc46be"
+     ]
+    },
+    "id": "-rDaCgo5yfKX",
+    "outputId": "943632bf-a1ca-4616-95a3-f54c0dcdbca0"
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a94aac452f134317b546f25e3e8ea65c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Viewer(geometries=[{'vtkClass': 'vtkPolyData', 'points': {'vtkClass': 'vtkPoints', 'name': '_points', 'numberO…"
+      ]
+     },
+     "metadata": {
+      "application/vnd.jupyter.widget-view+json": {
+       "colab": {
+        "custom_widget_manager": {
+         "url": "https://ssl.gstatic.com/colaboratory-static/widgets/colab-cdn-widget-manager/a8874ba6619b6106/manager.min.js"
+        }
+       }
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from google.colab import output\n",
+    "output.enable_custom_widget_manager()\n",
+    "\n",
+    "itkwidgets.view(geometries=[m2])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "60Q7zAjaYemS"
+   },
+   "outputs": [],
+   "source": [
+    "# Close the cluster and free the resources\n",
+    "\n",
+    "cluster.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "collapsed_sections": [],
+   "name": "DaskComputationCoiled.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "00a6b63103ea40cb97280c5226da49ec": {
+     "model_module": "itkwidgets",
+     "model_module_version": "^0.32.1",
+     "model_name": "ViewerModel",
+     "state": {
+      "_custom_cmap": null,
+      "_dom_classes": [],
+      "_downsampling": false,
+      "_largest_roi": {
+       "dtype": "float64",
+       "shape": [
+        2,
+        3
+       ]
+      },
+      "_model_module": "itkwidgets",
+      "_model_module_version": "^0.32.1",
+      "_model_name": "ViewerModel",
+      "_rendering_image": false,
+      "_reset_crop_requested": false,
+      "_scale_factors": {
+       "dtype": "uint8",
+       "shape": [
+        3
+       ]
+      },
+      "_view_count": null,
+      "_view_module": "itkwidgets",
+      "_view_module_version": "^0.32.1",
+      "_view_name": "ViewerView",
+      "annotations": true,
+      "axes": false,
+      "background": [
+       1,
+       1,
+       1
+      ],
+      "blend_mode": "composite",
+      "camera": {
+       "dtype": "float32",
+       "shape": [
+        3,
+        3
+       ]
+      },
+      "channels": null,
+      "clicked_slice_point": null,
+      "cmap": null,
+      "geometries": [
+       {
+        "cellData": {
+         "activeScalars": 0,
+         "arrays": [
+          {
+           "data": {
+            "dataType": "Float64Array",
+            "name": "CellScalarData",
+            "numberOfComponents": 1,
+            "size": 105425,
+            "vtkClass": "vtkDataArray"
+           }
+          }
+         ],
+         "vtkClass": "vtkDataSetAttributes"
+        },
+        "metadata": {
+         "name": "Geometry 0"
+        },
+        "pointData": {
+         "activeScalars": 0,
+         "arrays": [
+          {
+           "data": {
+            "dataType": "Float64Array",
+            "name": "PointScalarData",
+            "numberOfComponents": 1,
+            "size": 53818,
+            "vtkClass": "vtkDataArray"
+           }
+          }
+         ],
+         "vtkClass": "vtkDataSetAttributes"
+        },
+        "points": {
+         "dataType": "Float32Array",
+         "name": "_points",
+         "numberOfComponents": 3,
+         "size": 161451,
+         "vtkClass": "vtkPoints"
+        },
+        "polys": {
+         "dataType": "Uint32Array",
+         "name": "_polys",
+         "numberOfComponents": 1,
+         "size": 421696,
+         "vtkClass": "vtkCellArray"
+        },
+        "vtkClass": "vtkPolyData"
+       }
+      ],
+      "geometry_colors": {
+       "dtype": "float32",
+       "shape": [
+        1,
+        3
+       ]
+      },
+      "geometry_opacities": {
+       "dtype": "float32",
+       "shape": [
+        1
+       ]
+      },
+      "gradient_opacity": 0.22,
+      "interpolation": true,
+      "label_image_blend": 0.5,
+      "label_image_names": null,
+      "label_image_weights": null,
+      "layout": "IPY_MODEL_856173aca43d43d5a2affc843effc3bc",
+      "lut": "glasbey",
+      "mode": "v",
+      "opacity_gaussians": null,
+      "point_set_colors": {
+       "dtype": "float32",
+       "shape": [
+        0,
+        3
+       ]
+      },
+      "point_set_opacities": {
+       "dtype": "float32",
+       "shape": [
+        0
+       ]
+      },
+      "point_set_representations": [],
+      "point_set_sizes": {
+       "dtype": "uint8",
+       "shape": [
+        0
+       ]
+      },
+      "point_sets": [],
+      "rendered_image": null,
+      "rendered_label_image": null,
+      "roi": {
+       "dtype": "float64",
+       "shape": [
+        2,
+        3
+       ]
+      },
+      "rotate": false,
+      "sample_distance": 0.25,
+      "select_roi": false,
+      "shadow": true,
+      "slicing_planes": false,
+      "ui_collapsed": false,
+      "units": "",
+      "vmax": null,
+      "vmin": null,
+      "x_slice": null,
+      "y_slice": null,
+      "z_slice": null
+     }
+    },
+    "04433edc426a4ba99ba1d3a937f42d15": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "06f88296a85a4161b62436df3bdbe371": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "ButtonStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "ButtonStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "button_color": null,
+      "font_weight": ""
+     }
+    },
+    "0fdf3ebec30d4459a90be4314731236d": {
+     "model_module": "@jupyter-widgets/output",
+     "model_module_version": "1.0.0",
+     "model_name": "OutputModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/output",
+      "_model_module_version": "1.0.0",
+      "_model_name": "OutputModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/output",
+      "_view_module_version": "1.0.0",
+      "_view_name": "OutputView",
+      "layout": "IPY_MODEL_c511b4eef0e74cd98b84c8c4e9b2cda5",
+      "msg_id": "",
+      "outputs": [
+       {
+        "data": {
+         "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008000; text-decoration-color: #008000\">⠧</span> <span style=\"color: #008000; text-decoration-color: #008000; font-weight: bold\">Creating Cluster. This might take a few minutes...</span>\n</pre>\n",
+         "text/plain": "\u001b[32m⠧\u001b[0m \u001b[1;32mCreating Cluster. This might take a few minutes...\u001b[0m\n"
+        },
+        "metadata": {},
+        "output_type": "display_data"
+       }
+      ]
+     }
+    },
+    "1756413d3140403a8b76e05a0e866375": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "IntTextModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "IntTextModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "IntTextView",
+      "continuous_update": false,
+      "description": "Workers",
+      "description_tooltip": null,
+      "disabled": false,
+      "layout": "IPY_MODEL_c9d8794770314d9f9477af9179f02cee",
+      "step": 1,
+      "style": "IPY_MODEL_6d320e968b5a41dcb994108cc4d95e50",
+      "value": 0
+     }
+    },
+    "35f0646f5ded451d99e92a7c74e9486e": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "VBoxModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "VBoxModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "VBoxView",
+      "box_style": "",
+      "children": [
+       "IPY_MODEL_89cfc99bacb3424983f0127b1065c98b",
+       "IPY_MODEL_9e81c59ecf804e56af1c69f30fda8cf9"
+      ],
+      "layout": "IPY_MODEL_641ae4f0ec3a4d78858476edec985aa0"
+     }
+    },
+    "3fbd04438ff14c56b54242a5270f7abb": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "IntTextModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "IntTextModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "IntTextView",
+      "continuous_update": false,
+      "description": "Minimum",
+      "description_tooltip": null,
+      "disabled": false,
+      "layout": "IPY_MODEL_c9d8794770314d9f9477af9179f02cee",
+      "step": 1,
+      "style": "IPY_MODEL_524f7dc765484bc1bde0936c51a13fcf",
+      "value": 0
+     }
+    },
+    "4193a5dee9b243b899733baac0bc46be": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "41aceabecac9409ca3cd650811e5b81c": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "4b8ceab0cbf144be98d10b01fb4c6401": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "524f7dc765484bc1bde0936c51a13fcf": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "54ee4db13cab4eebada9fe0ebc9dba3c": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "57cb38340f6f4d3ab264f2d2632dea0c": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "5a2b742a85db450980d791c0d30ec0bd": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HBoxModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HBoxModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HBoxView",
+      "box_style": "",
+      "children": [
+       "IPY_MODEL_1756413d3140403a8b76e05a0e866375",
+       "IPY_MODEL_5af73d4418724958af448bb859c5104f"
+      ],
+      "layout": "IPY_MODEL_4b8ceab0cbf144be98d10b01fb4c6401"
+     }
+    },
+    "5af73d4418724958af448bb859c5104f": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "ButtonModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "ButtonModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "ButtonView",
+      "button_style": "",
+      "description": "Scale",
+      "disabled": false,
+      "icon": "",
+      "layout": "IPY_MODEL_c9d8794770314d9f9477af9179f02cee",
+      "style": "IPY_MODEL_06f88296a85a4161b62436df3bdbe371",
+      "tooltip": ""
+     }
+    },
+    "5c3a8f89501747de8a2d87347077af33": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "641ae4f0ec3a4d78858476edec985aa0": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "67040281464e48f29e7bb370c7994cc3": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": "500px",
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "6d320e968b5a41dcb994108cc4d95e50": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "7c6a6eaedaf1455e9e4ce6e9bb2fc7b2": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_54ee4db13cab4eebada9fe0ebc9dba3c",
+      "placeholder": "​",
+      "style": "IPY_MODEL_e58a8323c0b64d82a5fa75377cf46e50",
+      "value": "<div class=\"jp-RenderedHTMLCommon jp-RenderedHTML jp-mod-trusted jp-OutputArea-output\">\n    <div style=\"width: 24px; height: 24px; background-color: #e1e1e1; border: 3px solid #9D9D9D; border-radius: 5px; position: absolute;\">\n    </div>\n    <div style=\"margin-left: 48px;\">\n        <h3 style=\"margin-bottom: 0px; margin-top: 0px;\">Cluster</h3>\n        <p style=\"color: #9D9D9D; margin-bottom: 0px;\">oai-processing</p>\n        <table style=\"width: 100%; text-align: left;\">\n            <tr>\n                <td style=\"text-align: left;\">\n                    <strong>Dashboard:</strong> <a href=\"http://3.80.217.99:8787\" target=\"_blank\">http://3.80.217.99:8787</a>\n                </td>\n                <td style=\"text-align: left;\">\n                    <strong>Workers:</strong> 2\n                </td>\n            </tr>\n            <tr>\n                <td style=\"text-align: left;\">\n                    <strong>Total threads:</strong> 16\n                </td>\n                <td style=\"text-align: left;\">\n                    <strong>Total memory:</strong> 61.48 GiB\n                </td>\n            </tr>\n            \n        </table>\n\n        <details>\n            <summary style=\"margin-bottom: 20px;\">\n                <h3 style=\"display: inline;\">Scheduler Info</h3>\n            </summary>\n\n            <div style=\"\">\n    <div>\n        <div style=\"width: 24px; height: 24px; background-color: #FFF7E5; border: 3px solid #FF6132; border-radius: 5px; position: absolute;\"> </div>\n        <div style=\"margin-left: 48px;\">\n            <h3 style=\"margin-bottom: 0px;\">Scheduler</h3>\n            <p style=\"color: #9D9D9D; margin-bottom: 0px;\">Scheduler-0760b654-375f-4759-af1f-7ce3779130c3</p>\n            <table style=\"width: 100%; text-align: left;\">\n                <tr>\n                    <td style=\"text-align: left;\">\n                        <strong>Comm:</strong> tls://10.0.0.85:8786\n                    </td>\n                    <td style=\"text-align: left;\">\n                        <strong>Workers:</strong> 2\n                    </td>\n                </tr>\n                <tr>\n                    <td style=\"text-align: left;\">\n                        <strong>Dashboard:</strong> <a href=\"http://10.0.0.85:8787/status\" target=\"_blank\">http://10.0.0.85:8787/status</a>\n                    </td>\n                    <td style=\"text-align: left;\">\n                        <strong>Total threads:</strong> 16\n                    </td>\n                </tr>\n                <tr>\n                    <td style=\"text-align: left;\">\n                        <strong>Started:</strong> 9 minutes ago\n                    </td>\n                    <td style=\"text-align: left;\">\n                        <strong>Total memory:</strong> 61.48 GiB\n                    </td>\n                </tr>\n            </table>\n        </div>\n    </div>\n\n    <details style=\"margin-left: 48px;\">\n        <summary style=\"margin-bottom: 20px;\">\n            <h3 style=\"display: inline;\">Workers</h3>\n        </summary>\n\n        \n        <div style=\"margin-bottom: 20px;\">\n            <div style=\"width: 24px; height: 24px; background-color: #DBF5FF; border: 3px solid #4CC9FF; border-radius: 5px; position: absolute;\"> </div>\n            <div style=\"margin-left: 48px;\">\n            <details>\n                <summary>\n                    <h4 style=\"margin-bottom: 0px; display: inline;\">Worker: coiled-dask-pranjal09-152383-worker-7fd143b21f</h4>\n                </summary>\n                <table style=\"width: 100%; text-align: left;\">\n                    <tr>\n                        <td style=\"text-align: left;\">\n                            <strong>Comm: </strong> tls://10.0.0.218:34367\n                        </td>\n                        <td style=\"text-align: left;\">\n                            <strong>Total threads: </strong> 8\n                        </td>\n                    </tr>\n                    <tr>\n                        <td style=\"text-align: left;\">\n                            <strong>Dashboard: </strong> <a href=\"http://10.0.0.218:44941/status\" target=\"_blank\">http://10.0.0.218:44941/status</a>\n                        </td>\n                        <td style=\"text-align: left;\">\n                            <strong>Memory: </strong> 30.74 GiB\n                        </td>\n                    </tr>\n                    <tr>\n                        <td style=\"text-align: left;\">\n                            <strong>Nanny: </strong> tls://10.0.0.218:32795\n                        </td>\n                        <td style=\"text-align: left;\"></td>\n                    </tr>\n                    <tr>\n                        <td colspan=\"2\" style=\"text-align: left;\">\n                            <strong>Local directory: </strong> /dask-worker-space/worker-2h63xzwp\n                        </td>\n                    </tr>\n\n                    \n\n                    \n\n                </table>\n            </details>\n            </div>\n        </div>\n        \n        <div style=\"margin-bottom: 20px;\">\n            <div style=\"width: 24px; height: 24px; background-color: #DBF5FF; border: 3px solid #4CC9FF; border-radius: 5px; position: absolute;\"> </div>\n            <div style=\"margin-left: 48px;\">\n            <details>\n                <summary>\n                    <h4 style=\"margin-bottom: 0px; display: inline;\">Worker: coiled-dask-pranjal09-152383-worker-f46a11c2fc</h4>\n                </summary>\n                <table style=\"width: 100%; text-align: left;\">\n                    <tr>\n                        <td style=\"text-align: left;\">\n                            <strong>Comm: </strong> tls://10.0.4.47:33463\n                        </td>\n                        <td style=\"text-align: left;\">\n                            <strong>Total threads: </strong> 8\n                        </td>\n                    </tr>\n                    <tr>\n                        <td style=\"text-align: left;\">\n                            <strong>Dashboard: </strong> <a href=\"http://10.0.4.47:37427/status\" target=\"_blank\">http://10.0.4.47:37427/status</a>\n                        </td>\n                        <td style=\"text-align: left;\">\n                            <strong>Memory: </strong> 30.74 GiB\n                        </td>\n                    </tr>\n                    <tr>\n                        <td style=\"text-align: left;\">\n                            <strong>Nanny: </strong> tls://10.0.4.47:35227\n                        </td>\n                        <td style=\"text-align: left;\"></td>\n                    </tr>\n                    <tr>\n                        <td colspan=\"2\" style=\"text-align: left;\">\n                            <strong>Local directory: </strong> /dask-worker-space/worker-n62u0x3u\n                        </td>\n                    </tr>\n\n                    \n\n                    \n\n                </table>\n            </details>\n            </div>\n        </div>\n        \n\n    </details>\n</div>\n\n        </details>\n    </div>\n</div>"
+     }
+    },
+    "8230507bb71d4e8fb7f1a79cf5e31036": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "ButtonStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "ButtonStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "button_color": null,
+      "font_weight": ""
+     }
+    },
+    "82eade6e25264c058e9a3e00e8a291a0": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "856173aca43d43d5a2affc843effc3bc": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "89cfc99bacb3424983f0127b1065c98b": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_57cb38340f6f4d3ab264f2d2632dea0c",
+      "placeholder": "​",
+      "style": "IPY_MODEL_41aceabecac9409ca3cd650811e5b81c",
+      "value": "\n        <table>\n            <tr><td style=\"text-align: left;\">Scaling mode: Manual</td></tr>\n            <tr><td style=\"text-align: left;\">Workers: 2</td></tr>\n        </table>\n        "
+     }
+    },
+    "95f476e89c704ea2b99117c533506201": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HBoxModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HBoxModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HBoxView",
+      "box_style": "",
+      "children": [
+       "IPY_MODEL_3fbd04438ff14c56b54242a5270f7abb",
+       "IPY_MODEL_e8b95ef0e41c47a4a1144699015e17fd",
+       "IPY_MODEL_bf2ddee8d91e41698fda46f6fea7de6b"
+      ],
+      "layout": "IPY_MODEL_82eade6e25264c058e9a3e00e8a291a0"
+     }
+    },
+    "9e81c59ecf804e56af1c69f30fda8cf9": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "AccordionModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "AccordionModel",
+      "_titles": {
+       "0": "Manual Scaling",
+       "1": "Adaptive Scaling"
+      },
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "AccordionView",
+      "box_style": "",
+      "children": [
+       "IPY_MODEL_5a2b742a85db450980d791c0d30ec0bd",
+       "IPY_MODEL_95f476e89c704ea2b99117c533506201"
+      ],
+      "layout": "IPY_MODEL_67040281464e48f29e7bb370c7994cc3",
+      "selected_index": null
+     }
+    },
+    "a94aac452f134317b546f25e3e8ea65c": {
+     "model_module": "itkwidgets",
+     "model_module_version": "^0.32.1",
+     "model_name": "ViewerModel",
+     "state": {
+      "_custom_cmap": null,
+      "_dom_classes": [],
+      "_downsampling": false,
+      "_largest_roi": {
+       "dtype": "float64",
+       "shape": [
+        2,
+        3
+       ]
+      },
+      "_model_module": "itkwidgets",
+      "_model_module_version": "^0.32.1",
+      "_model_name": "ViewerModel",
+      "_rendering_image": false,
+      "_reset_crop_requested": false,
+      "_scale_factors": {
+       "dtype": "uint8",
+       "shape": [
+        3
+       ]
+      },
+      "_view_count": null,
+      "_view_module": "itkwidgets",
+      "_view_module_version": "^0.32.1",
+      "_view_name": "ViewerView",
+      "annotations": true,
+      "axes": false,
+      "background": [
+       1,
+       1,
+       1
+      ],
+      "blend_mode": "composite",
+      "camera": {
+       "dtype": "float32",
+       "shape": [
+        3,
+        3
+       ]
+      },
+      "channels": null,
+      "clicked_slice_point": null,
+      "cmap": null,
+      "geometries": [
+       {
+        "cellData": {
+         "activeScalars": 0,
+         "arrays": [
+          {
+           "data": {
+            "dataType": "Float64Array",
+            "name": "CellScalarData",
+            "numberOfComponents": 1,
+            "size": 32225,
+            "vtkClass": "vtkDataArray"
+           }
+          }
+         ],
+         "vtkClass": "vtkDataSetAttributes"
+        },
+        "metadata": {
+         "name": "Geometry 0"
+        },
+        "pointData": {
+         "activeScalars": 0,
+         "arrays": [
+          {
+           "data": {
+            "dataType": "Float64Array",
+            "name": "PointScalarData",
+            "numberOfComponents": 1,
+            "size": 16588,
+            "vtkClass": "vtkDataArray"
+           }
+          }
+         ],
+         "vtkClass": "vtkDataSetAttributes"
+        },
+        "points": {
+         "dataType": "Float32Array",
+         "name": "_points",
+         "numberOfComponents": 3,
+         "size": 49761,
+         "vtkClass": "vtkPoints"
+        },
+        "polys": {
+         "dataType": "Uint32Array",
+         "name": "_polys",
+         "numberOfComponents": 1,
+         "size": 128896,
+         "vtkClass": "vtkCellArray"
+        },
+        "vtkClass": "vtkPolyData"
+       }
+      ],
+      "geometry_colors": {
+       "dtype": "float32",
+       "shape": [
+        1,
+        3
+       ]
+      },
+      "geometry_opacities": {
+       "dtype": "float32",
+       "shape": [
+        1
+       ]
+      },
+      "gradient_opacity": 0.22,
+      "interpolation": true,
+      "label_image_blend": 0.5,
+      "label_image_names": null,
+      "label_image_weights": null,
+      "layout": "IPY_MODEL_4193a5dee9b243b899733baac0bc46be",
+      "lut": "glasbey",
+      "mode": "v",
+      "opacity_gaussians": null,
+      "point_set_colors": {
+       "dtype": "float32",
+       "shape": [
+        0,
+        3
+       ]
+      },
+      "point_set_opacities": {
+       "dtype": "float32",
+       "shape": [
+        0
+       ]
+      },
+      "point_set_representations": [],
+      "point_set_sizes": {
+       "dtype": "uint8",
+       "shape": [
+        0
+       ]
+      },
+      "point_sets": [],
+      "rendered_image": null,
+      "rendered_label_image": null,
+      "roi": {
+       "dtype": "float64",
+       "shape": [
+        2,
+        3
+       ]
+      },
+      "rotate": false,
+      "sample_distance": 0.25,
+      "select_roi": false,
+      "shadow": true,
+      "slicing_planes": false,
+      "ui_collapsed": false,
+      "units": "",
+      "vmax": null,
+      "vmin": null,
+      "x_slice": null,
+      "y_slice": null,
+      "z_slice": null
+     }
+    },
+    "bf2ddee8d91e41698fda46f6fea7de6b": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "ButtonModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "ButtonModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "ButtonView",
+      "button_style": "",
+      "description": "Adapt",
+      "disabled": false,
+      "icon": "",
+      "layout": "IPY_MODEL_c9d8794770314d9f9477af9179f02cee",
+      "style": "IPY_MODEL_8230507bb71d4e8fb7f1a79cf5e31036",
+      "tooltip": ""
+     }
+    },
+    "c511b4eef0e74cd98b84c8c4e9b2cda5": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "c9d8794770314d9f9477af9179f02cee": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": "150px"
+     }
+    },
+    "e58a8323c0b64d82a5fa75377cf46e50": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "e8b95ef0e41c47a4a1144699015e17fd": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "IntTextModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "IntTextModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "IntTextView",
+      "continuous_update": false,
+      "description": "Maximum",
+      "description_tooltip": null,
+      "disabled": false,
+      "layout": "IPY_MODEL_c9d8794770314d9f9477af9179f02cee",
+      "step": 1,
+      "style": "IPY_MODEL_5c3a8f89501747de8a2d87347077af33",
+      "value": 0
+     }
+    },
+    "ef35542d83fd4a6eb38d062367658a23": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "TabModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "TabModel",
+      "_titles": {
+       "0": "Status",
+       "1": "Scaling"
+      },
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "TabView",
+      "box_style": "",
+      "children": [
+       "IPY_MODEL_7c6a6eaedaf1455e9e4ce6e9bb2fc7b2",
+       "IPY_MODEL_35f0646f5ded451d99e92a7c74e9486e"
+      ],
+      "layout": "IPY_MODEL_04433edc426a4ba99ba1d3a937f42d15",
+      "selected_index": 0
+     }
+    }
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/notebooks/DaskComputationCoiled.ipynb
+++ b/notebooks/DaskComputationCoiled.ipynb
@@ -1,2319 +1,758 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "8VnZ6zuBOtp3"
-   },
-   "outputs": [],
-   "source": [
-    "# Install packages\n",
-    "\n",
-    "# Remember to Restart runtime after installation\n",
-    "\n",
-    "\n",
-    "!pip install itk==5.3rc4\n",
-    "!pip install vtk\n",
-    "!pip install itkwidgets\n",
-    "!pip install icon-registration==0.3.4\n",
-    "!pip install tornado==6.1\n",
-    "!pip install coiled\n",
-    "!pip install torch\n",
-    "!pip install jupyter\n",
-    "!pip install git+https://github.com/uncbiag/mermaid.git\n",
-    "!pip install git+https://github.com/uncbiag/easyreg.git\n",
-    "!pip install git+https://github.com/PranjalSahu/OAI_analysis_2.git#egg=oai_package"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!pip install git+https://github.com/PranjalSahu/OAI_analysis_2.git#egg=oai_package"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "id": "0w5y-3zBOxkY"
-   },
-   "outputs": [],
-   "source": [
-    "# All Imports\n",
-    "\n",
-    "#import numpy as np\n",
-    "#import itk\n",
-    "#import vtk\n",
-    "import itkwidgets\n",
-    "#import icon_registration\n",
-    "#import icon_registration.itk_wrapper as itk_wrapper\n",
-    "#import icon_registration.pretrained_models as pretrained_models\n",
-    "from oai_analysis_2 import mesh_processing as mp\n",
-    "from oai_analysis_2 import dask_processing as dp\n",
-    "\n",
-    "import os\n",
-    "os.environ[\"CUDA_VISIBLE_DEVICES\"]=\"\"\n",
-    "\n",
-    "#import boto3\n",
-    "#import coiled\n",
-    "#import dask\n",
-    "#from dask import delayed, compute, visualize\n",
-    "#from dask.distributed import Client, progress, LocalCluster"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "D-E-5gV6KX8E"
-   },
-   "outputs": [],
-   "source": [
-    "# Create the environment\n",
-    "\n",
-    "if False:\n",
-    "  coiled.create_software_environment(\n",
-    "    name=\"oai6\",\n",
-    "    pip=\"coiled_requirements.txt\",\n",
-    "  )"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
     "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 69
+      "name": "DaskComputationCoiled.ipynb",
+      "provenance": [],
+      "collapsed_sections": [],
+      "authorship_tag": "ABX9TyM+NIyBHMLigQLu2Gzho2tc",
+      "include_colab_link": true
     },
-    "id": "O-pxKPFD2Ld9",
-    "outputId": "4b8d4dcc-2b5b-491d-d531-bfedad3ee87b"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Creating new software environment\n",
-      "Creating container-only software environment\n",
-      "Successfully saved software environment build\n"
-     ]
-    }
-   ],
-   "source": [
-    "# To create a software environment using docker with open gl installed\n",
-    "# coiled.create_software_environment(\n",
-    "#     name=\"oai6\",\n",
-    "#     container=\"pranjalsahu/pranjal-sahu-oai6:latest\",\n",
-    "# )"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 33,
-     "referenced_widgets": [
-      "0fdf3ebec30d4459a90be4314731236d",
-      "c511b4eef0e74cd98b84c8c4e9b2cda5"
-     ]
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
     },
-    "id": "2wQIfgkLSMRy",
-    "outputId": "f0063135-18b1-4eaa-f1ba-f5b54eddc6b5"
-   },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0fdf3ebec30d4459a90be4314731236d",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Output()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+    "language_info": {
+      "name": "python"
     },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Using existing cluster: <span style=\"color: #008000; text-decoration-color: #008000\">'oai-processing'</span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "Using existing cluster: \u001b[32m'oai-processing'\u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
-      ],
-      "text/plain": []
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "# Create Dask Client. This will also spawn dask worker and scheduler\n",
-    "\n",
-    "use_coiled = True\n",
-    "\n",
-    "if use_coiled:\n",
-    "  name = 'oai-processing'\n",
-    "  cluster = coiled.Cluster(n_workers=2,\n",
-    "                         worker_cpu=8,\n",
-    "                         worker_memory='31G',\n",
-    "                         name=name,\n",
-    "                         software='pranjal-sahu/oai6')\n",
-    "  client = dask.distributed.Client(cluster, \n",
-    "                                   serializers=['pickle', 'dask'],\n",
-    "                                   deserializers=['pickle', 'dask'])\n",
-    "  client\n",
-    "else:\n",
-    "  cluster = LocalCluster(processes=False)\n",
-    "  client = Client(cluster)\n",
-    "  client"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 161
-    },
-    "id": "YRutouN1Nu-t",
-    "outputId": "36783f91-97bc-4d87-acba-c38fdc03053d"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "    <div style=\"width: 24px; height: 24px; background-color: #e1e1e1; border: 3px solid #9D9D9D; border-radius: 5px; position: absolute;\"> </div>\n",
-       "    <div style=\"margin-left: 48px;\">\n",
-       "        <h3 style=\"margin-bottom: 0px;\">Client</h3>\n",
-       "        <p style=\"color: #9D9D9D; margin-bottom: 0px;\">Client-0cccf874-cc98-11ec-852c-0242ac1c0002</p>\n",
-       "        <table style=\"width: 100%; text-align: left;\">\n",
-       "\n",
-       "        <tr>\n",
-       "        \n",
-       "            <td style=\"text-align: left;\"><strong>Connection method:</strong> Cluster object</td>\n",
-       "            <td style=\"text-align: left;\"><strong>Cluster type:</strong> coiled.Cluster</td>\n",
-       "        \n",
-       "        </tr>\n",
-       "\n",
-       "        \n",
-       "            <tr>\n",
-       "                <td style=\"text-align: left;\">\n",
-       "                    <strong>Dashboard: </strong> <a href=\"http://3.80.217.99:8787\" target=\"_blank\">http://3.80.217.99:8787</a>\n",
-       "                </td>\n",
-       "                <td style=\"text-align: left;\"></td>\n",
-       "            </tr>\n",
-       "        \n",
-       "\n",
-       "        </table>\n",
-       "\n",
-       "        \n",
-       "            <details>\n",
-       "            <summary style=\"margin-bottom: 20px;\"><h3 style=\"display: inline;\">Cluster Info</h3></summary>\n",
-       "            <div class=\"jp-RenderedHTMLCommon jp-RenderedHTML jp-mod-trusted jp-OutputArea-output\">\n",
-       "    <div style=\"width: 24px; height: 24px; background-color: #e1e1e1; border: 3px solid #9D9D9D; border-radius: 5px; position: absolute;\">\n",
-       "    </div>\n",
-       "    <div style=\"margin-left: 48px;\">\n",
-       "        <h3 style=\"margin-bottom: 0px; margin-top: 0px;\">Cluster</h3>\n",
-       "        <p style=\"color: #9D9D9D; margin-bottom: 0px;\">oai-processing</p>\n",
-       "        <table style=\"width: 100%; text-align: left;\">\n",
-       "            <tr>\n",
-       "                <td style=\"text-align: left;\">\n",
-       "                    <strong>Dashboard:</strong> <a href=\"http://3.80.217.99:8787\" target=\"_blank\">http://3.80.217.99:8787</a>\n",
-       "                </td>\n",
-       "                <td style=\"text-align: left;\">\n",
-       "                    <strong>Workers:</strong> 2\n",
-       "                </td>\n",
-       "            </tr>\n",
-       "            <tr>\n",
-       "                <td style=\"text-align: left;\">\n",
-       "                    <strong>Total threads:</strong> 16\n",
-       "                </td>\n",
-       "                <td style=\"text-align: left;\">\n",
-       "                    <strong>Total memory:</strong> 61.48 GiB\n",
-       "                </td>\n",
-       "            </tr>\n",
-       "            \n",
-       "        </table>\n",
-       "\n",
-       "        <details>\n",
-       "            <summary style=\"margin-bottom: 20px;\">\n",
-       "                <h3 style=\"display: inline;\">Scheduler Info</h3>\n",
-       "            </summary>\n",
-       "\n",
-       "            <div style=\"\">\n",
-       "    <div>\n",
-       "        <div style=\"width: 24px; height: 24px; background-color: #FFF7E5; border: 3px solid #FF6132; border-radius: 5px; position: absolute;\"> </div>\n",
-       "        <div style=\"margin-left: 48px;\">\n",
-       "            <h3 style=\"margin-bottom: 0px;\">Scheduler</h3>\n",
-       "            <p style=\"color: #9D9D9D; margin-bottom: 0px;\">Scheduler-0760b654-375f-4759-af1f-7ce3779130c3</p>\n",
-       "            <table style=\"width: 100%; text-align: left;\">\n",
-       "                <tr>\n",
-       "                    <td style=\"text-align: left;\">\n",
-       "                        <strong>Comm:</strong> tls://10.0.0.85:8786\n",
-       "                    </td>\n",
-       "                    <td style=\"text-align: left;\">\n",
-       "                        <strong>Workers:</strong> 2\n",
-       "                    </td>\n",
-       "                </tr>\n",
-       "                <tr>\n",
-       "                    <td style=\"text-align: left;\">\n",
-       "                        <strong>Dashboard:</strong> <a href=\"http://10.0.0.85:8787/status\" target=\"_blank\">http://10.0.0.85:8787/status</a>\n",
-       "                    </td>\n",
-       "                    <td style=\"text-align: left;\">\n",
-       "                        <strong>Total threads:</strong> 16\n",
-       "                    </td>\n",
-       "                </tr>\n",
-       "                <tr>\n",
-       "                    <td style=\"text-align: left;\">\n",
-       "                        <strong>Started:</strong> 9 minutes ago\n",
-       "                    </td>\n",
-       "                    <td style=\"text-align: left;\">\n",
-       "                        <strong>Total memory:</strong> 61.48 GiB\n",
-       "                    </td>\n",
-       "                </tr>\n",
-       "            </table>\n",
-       "        </div>\n",
-       "    </div>\n",
-       "\n",
-       "    <details style=\"margin-left: 48px;\">\n",
-       "        <summary style=\"margin-bottom: 20px;\">\n",
-       "            <h3 style=\"display: inline;\">Workers</h3>\n",
-       "        </summary>\n",
-       "\n",
-       "        \n",
-       "        <div style=\"margin-bottom: 20px;\">\n",
-       "            <div style=\"width: 24px; height: 24px; background-color: #DBF5FF; border: 3px solid #4CC9FF; border-radius: 5px; position: absolute;\"> </div>\n",
-       "            <div style=\"margin-left: 48px;\">\n",
-       "            <details>\n",
-       "                <summary>\n",
-       "                    <h4 style=\"margin-bottom: 0px; display: inline;\">Worker: coiled-dask-pranjal09-152383-worker-7fd143b21f</h4>\n",
-       "                </summary>\n",
-       "                <table style=\"width: 100%; text-align: left;\">\n",
-       "                    <tr>\n",
-       "                        <td style=\"text-align: left;\">\n",
-       "                            <strong>Comm: </strong> tls://10.0.0.218:34367\n",
-       "                        </td>\n",
-       "                        <td style=\"text-align: left;\">\n",
-       "                            <strong>Total threads: </strong> 8\n",
-       "                        </td>\n",
-       "                    </tr>\n",
-       "                    <tr>\n",
-       "                        <td style=\"text-align: left;\">\n",
-       "                            <strong>Dashboard: </strong> <a href=\"http://10.0.0.218:44941/status\" target=\"_blank\">http://10.0.0.218:44941/status</a>\n",
-       "                        </td>\n",
-       "                        <td style=\"text-align: left;\">\n",
-       "                            <strong>Memory: </strong> 30.74 GiB\n",
-       "                        </td>\n",
-       "                    </tr>\n",
-       "                    <tr>\n",
-       "                        <td style=\"text-align: left;\">\n",
-       "                            <strong>Nanny: </strong> tls://10.0.0.218:32795\n",
-       "                        </td>\n",
-       "                        <td style=\"text-align: left;\"></td>\n",
-       "                    </tr>\n",
-       "                    <tr>\n",
-       "                        <td colspan=\"2\" style=\"text-align: left;\">\n",
-       "                            <strong>Local directory: </strong> /dask-worker-space/worker-2h63xzwp\n",
-       "                        </td>\n",
-       "                    </tr>\n",
-       "\n",
-       "                    \n",
-       "\n",
-       "                    \n",
-       "\n",
-       "                </table>\n",
-       "            </details>\n",
-       "            </div>\n",
-       "        </div>\n",
-       "        \n",
-       "        <div style=\"margin-bottom: 20px;\">\n",
-       "            <div style=\"width: 24px; height: 24px; background-color: #DBF5FF; border: 3px solid #4CC9FF; border-radius: 5px; position: absolute;\"> </div>\n",
-       "            <div style=\"margin-left: 48px;\">\n",
-       "            <details>\n",
-       "                <summary>\n",
-       "                    <h4 style=\"margin-bottom: 0px; display: inline;\">Worker: coiled-dask-pranjal09-152383-worker-f46a11c2fc</h4>\n",
-       "                </summary>\n",
-       "                <table style=\"width: 100%; text-align: left;\">\n",
-       "                    <tr>\n",
-       "                        <td style=\"text-align: left;\">\n",
-       "                            <strong>Comm: </strong> tls://10.0.4.47:33463\n",
-       "                        </td>\n",
-       "                        <td style=\"text-align: left;\">\n",
-       "                            <strong>Total threads: </strong> 8\n",
-       "                        </td>\n",
-       "                    </tr>\n",
-       "                    <tr>\n",
-       "                        <td style=\"text-align: left;\">\n",
-       "                            <strong>Dashboard: </strong> <a href=\"http://10.0.4.47:37427/status\" target=\"_blank\">http://10.0.4.47:37427/status</a>\n",
-       "                        </td>\n",
-       "                        <td style=\"text-align: left;\">\n",
-       "                            <strong>Memory: </strong> 30.74 GiB\n",
-       "                        </td>\n",
-       "                    </tr>\n",
-       "                    <tr>\n",
-       "                        <td style=\"text-align: left;\">\n",
-       "                            <strong>Nanny: </strong> tls://10.0.4.47:35227\n",
-       "                        </td>\n",
-       "                        <td style=\"text-align: left;\"></td>\n",
-       "                    </tr>\n",
-       "                    <tr>\n",
-       "                        <td colspan=\"2\" style=\"text-align: left;\">\n",
-       "                            <strong>Local directory: </strong> /dask-worker-space/worker-n62u0x3u\n",
-       "                        </td>\n",
-       "                    </tr>\n",
-       "\n",
-       "                    \n",
-       "\n",
-       "                    \n",
-       "\n",
-       "                </table>\n",
-       "            </details>\n",
-       "            </div>\n",
-       "        </div>\n",
-       "        \n",
-       "\n",
-       "    </details>\n",
-       "</div>\n",
-       "\n",
-       "        </details>\n",
-       "    </div>\n",
-       "</div>\n",
-       "            </details>\n",
-       "        \n",
-       "\n",
-       "    </div>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "<Client: 'tls://10.0.0.85:8786' processes=2 threads=16, memory=61.48 GiB>"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "client"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 17,
-     "referenced_widgets": [
-      "ef35542d83fd4a6eb38d062367658a23",
-      "7c6a6eaedaf1455e9e4ce6e9bb2fc7b2",
-      "35f0646f5ded451d99e92a7c74e9486e",
-      "04433edc426a4ba99ba1d3a937f42d15",
-      "54ee4db13cab4eebada9fe0ebc9dba3c",
-      "e58a8323c0b64d82a5fa75377cf46e50",
-      "89cfc99bacb3424983f0127b1065c98b",
-      "9e81c59ecf804e56af1c69f30fda8cf9",
-      "641ae4f0ec3a4d78858476edec985aa0",
-      "57cb38340f6f4d3ab264f2d2632dea0c",
-      "41aceabecac9409ca3cd650811e5b81c",
-      "5a2b742a85db450980d791c0d30ec0bd",
-      "95f476e89c704ea2b99117c533506201",
-      "67040281464e48f29e7bb370c7994cc3",
-      "1756413d3140403a8b76e05a0e866375",
-      "5af73d4418724958af448bb859c5104f",
-      "4b8ceab0cbf144be98d10b01fb4c6401",
-      "3fbd04438ff14c56b54242a5270f7abb",
-      "e8b95ef0e41c47a4a1144699015e17fd",
-      "bf2ddee8d91e41698fda46f6fea7de6b",
-      "82eade6e25264c058e9a3e00e8a291a0",
-      "c9d8794770314d9f9477af9179f02cee",
-      "6d320e968b5a41dcb994108cc4d95e50",
-      "06f88296a85a4161b62436df3bdbe371",
-      "524f7dc765484bc1bde0936c51a13fcf",
-      "5c3a8f89501747de8a2d87347077af33",
-      "8230507bb71d4e8fb7f1a79cf5e31036"
-     ]
-    },
-    "id": "qE__24JAckLS",
-    "outputId": "11f6162e-37b5-47ec-dd7f-76f26a0b3bb2"
-   },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ef35542d83fd4a6eb38d062367658a23",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Tab(children=(HTML(value='<div class=\"jp-RenderedHTMLCommon jp-RenderedHTML jp-mod-trusted jp-OutputArea-outpu…"
-      ]
-     },
-     "metadata": {
-      "application/vnd.jupyter.widget-view+json": {
-       "colab": {
-        "custom_widget_manager": {
-         "url": "https://ssl.gstatic.com/colaboratory-static/widgets/colab-cdn-widget-manager/a8874ba6619b6106/manager.min.js"
-        }
-       }
-      }
-     },
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "cluster"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "code_folding": [
-     0
-    ],
-    "id": "2HbtL8r4TiKb"
-   },
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'delayed' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m/tmp/ipykernel_186247/4048742253.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# All Function Definitions with Dask Delayed Decorator to perform parallel Computing\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 3\u001b[0;31m \u001b[0;34m@\u001b[0m\u001b[0mdelayed\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mnout\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m3\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      4\u001b[0m \u001b[0;32mdef\u001b[0m \u001b[0mregister_images_delayed\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m     \u001b[0;32mimport\u001b[0m \u001b[0mboto3\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'delayed' is not defined"
-     ]
-    }
-   ],
-   "source": [
-    "# All Function Definitions with Dask Delayed Decorator to perform parallel Computing\n",
-    "\n",
-    "@delayed(nout=3)\n",
-    "def register_images_delayed():\n",
-    "    import boto3\n",
-    "    import itk\n",
-    "    import icon_registration\n",
-    "    import icon_registration.itk_wrapper as itk_wrapper\n",
-    "    import icon_registration.pretrained_models as pretrained_models\n",
-    "    from os.path import exists\n",
-    "\n",
-    "    if 1:\n",
-    "        image_A = 'image_preprocessed.nii.gz'\n",
-    "        image_B = 'atlas_image.nii.gz'\n",
-    "        if (exists(image_A) and exists(image_B)) == False:\n",
-    "          s3          = boto3.resource(\"s3\")\n",
-    "          bucket_name = 'oaisample1'\n",
-    "          bucket      = s3.Bucket(bucket_name)\n",
-    "\n",
-    "          s3.Bucket(bucket_name).download_file(image_A, image_A)\n",
-    "          s3.Bucket(bucket_name).download_file(image_B, image_B)\n",
-    "    else:\n",
-    "        image_A = './OAIData/image_preprocessed.nii.gz'\n",
-    "        image_B = './OAIData/atlas_image.nii.gz'\n",
-    "\n",
-    "    image_A = itk.imread(image_A, itk.D)\n",
-    "    image_B = itk.imread(image_B, itk.D)\n",
-    "\n",
-    "    model = pretrained_models.OAI_knees_gradICON_model()\n",
-    "    model.to('cpu')\n",
-    "\n",
-    "    # Register the images\n",
-    "    phi_AB, phi_BA = itk_wrapper.register_pair(model, image_A, image_B)\n",
-    "    return itk.dict_from_transform(phi_AB), itk.dict_from_image(image_A), itk.dict_from_image(image_B)\n",
-    "\n",
-    "@delayed(nout=1)\n",
-    "def deform_probmap_FC_delayed(phi_AB, image_A, image_B):\n",
-    "    import itk\n",
-    "    import boto3\n",
-    "\n",
-    "    if 1:\n",
-    "        s3          = boto3.resource(\"s3\")\n",
-    "        bucket_name = 'oaisample1'\n",
-    "        bucket      = s3.Bucket(bucket_name)\n",
-    "        fc_prob_file = 'FC_probmap.nii.gz'\n",
-    "        s3.Bucket(bucket_name).download_file(fc_prob_file, fc_prob_file)\n",
-    "\n",
-    "    phi_AB1  = itk.transform_from_dict(phi_AB)\n",
-    "    \n",
-    "    def set_parameters(phi_AB, phi_AB1):\n",
-    "        for i in range(len(phi_AB)-1):\n",
-    "            transform1 = phi_AB1.GetNthTransform(i)\n",
-    "\n",
-    "            fp = phi_AB[i+1]['fixedParameters']\n",
-    "            o1 = transform1.GetFixedParameters()\n",
-    "            o1.SetSize(fp.shape[0])\n",
-    "            for j, v in enumerate(fp):\n",
-    "                o1.SetElement(j, v)\n",
-    "            transform1.SetFixedParameters(o1)\n",
-    "\n",
-    "            p = phi_AB[i+1]['parameters']\n",
-    "            o2 = transform1.GetParameters()\n",
-    "            o2.SetSize(p.shape[0])\n",
-    "            for j, v in enumerate(p):\n",
-    "                o2.SetElement(j, v)\n",
-    "            transform1.SetParameters(o2)\n",
-    "\n",
-    "    set_parameters(phi_AB, phi_AB1)\n",
-    "    image_A = itk.image_from_dict(image_A)\n",
-    "    image_B = itk.image_from_dict(image_B)\n",
-    "\n",
-    "    interpolator = itk.LinearInterpolateImageFunction.New(image_A)\n",
-    "    \n",
-    "    prob_file = 'FC_probmap.nii.gz'\n",
-    "    prob = itk.imread(prob_file, itk.D)\n",
-    "\n",
-    "    warped_image = itk.resample_image_filter(prob, \n",
-    "       transform=phi_AB1, \n",
-    "       interpolator=interpolator,\n",
-    "       size=itk.size(image_B),\n",
-    "       output_spacing=itk.spacing(image_B),\n",
-    "       output_direction=image_B.GetDirection(),\n",
-    "       output_origin=image_B.GetOrigin()\n",
-    "    )\n",
-    "\n",
-    "    output_dict = itk.dict_from_image(warped_image)\n",
-    "    return output_dict\n",
-    "  \n",
-    "@delayed\n",
-    "def deform_probmap_delayed(phi_AB, image_A, image_B, image_type ='FC'):\n",
-    "    import itk\n",
-    "    import boto3\n",
-    "\n",
-    "    if 1:\n",
-    "        s3          = boto3.resource(\"s3\")\n",
-    "        bucket_name = 'oaisample1'\n",
-    "        bucket      = s3.Bucket(bucket_name)\n",
-    "        fc_prob_file = str(image_type)+'_probmap.nii.gz'\n",
-    "        s3.Bucket(bucket_name).download_file(fc_prob_file, fc_prob_file)\n",
-    "\n",
-    "    phi_AB1  = itk.transform_from_dict(phi_AB)\n",
-    "    \n",
-    "    def set_parameters(phi_AB, phi_AB1):\n",
-    "        for i in range(len(phi_AB)-1):\n",
-    "            transform1 = phi_AB1.GetNthTransform(i)\n",
-    "\n",
-    "            fp = phi_AB[i+1]['fixedParameters']\n",
-    "            o1 = transform1.GetFixedParameters()\n",
-    "            o1.SetSize(fp.shape[0])\n",
-    "            for j, v in enumerate(fp):\n",
-    "                o1.SetElement(j, v)\n",
-    "            transform1.SetFixedParameters(o1)\n",
-    "\n",
-    "            p = phi_AB[i+1]['parameters']\n",
-    "            o2 = transform1.GetParameters()\n",
-    "            o2.SetSize(p.shape[0])\n",
-    "            for j, v in enumerate(p):\n",
-    "                o2.SetElement(j, v)\n",
-    "            transform1.SetParameters(o2)\n",
-    "\n",
-    "    set_parameters(phi_AB, phi_AB1)\n",
-    "    image_A = itk.image_from_dict(image_A)\n",
-    "    image_B = itk.image_from_dict(image_B)\n",
-    "\n",
-    "    interpolator = itk.LinearInterpolateImageFunction.New(image_A)\n",
-    "    \n",
-    "    prob_file = str(image_type)+'_probmap.nii.gz'\n",
-    "    prob = itk.imread(prob_file, itk.D)\n",
-    "\n",
-    "    warped_image = itk.resample_image_filter(prob, \n",
-    "       transform=phi_AB1, \n",
-    "       interpolator=interpolator,\n",
-    "       size=itk.size(image_B),\n",
-    "       output_spacing=itk.spacing(image_B),\n",
-    "       output_direction=image_B.GetDirection(),\n",
-    "       output_origin=image_B.GetOrigin()\n",
-    "    )\n",
-    "\n",
-    "    output_dict = itk.dict_from_image(warped_image)\n",
-    "    return output_dict\n",
-    "    \n",
-    "\n",
-    "@delayed(nout=1)\n",
-    "def get_thickness(warped_image, mesh_type):\n",
-    "    import itk\n",
-    "    import vtk\n",
-    "    import numpy as np\n",
-    "    from oai_analysis_2 import mesh_processing as mp\n",
-    "\n",
-    "    def get_itk_mesh(vtk_mesh):\n",
-    "        Dimension = 3\n",
-    "        PixelType = itk.D\n",
-    "        \n",
-    "        # Get points array from VTK mesh\n",
-    "        points = vtk_mesh.GetPoints().GetData()\n",
-    "        points_numpy = np.array(points).flatten()#.astype('float32')\n",
-    "            \n",
-    "        polys = vtk_mesh.GetPolys().GetData()\n",
-    "        polys_numpy = np.array(polys).flatten()\n",
-    "\n",
-    "        # Triangle Mesh\n",
-    "        vtk_cells_count = vtk_mesh.GetNumberOfPolys()\n",
-    "        polys_numpy = np.reshape(polys_numpy, [vtk_cells_count, Dimension+1])\n",
-    "\n",
-    "        # Extracting only the points by removing first column that denotes the VTK cell type\n",
-    "        polys_numpy = polys_numpy[:, 1:]\n",
-    "        polys_numpy = polys_numpy.flatten().astype(np.uint64)\n",
-    "\n",
-    "        # Get point data from VTK mesh to insert in ITK Mesh\n",
-    "        point_data_numpy = np.array(vtk_mesh.GetPointData().GetScalars())#.astype('float64')\n",
-    "        \n",
-    "        # Get cell data from VTK mesh to insert in ITK Mesh\n",
-    "        cell_data_numpy = np.array(vtk_mesh.GetCellData().GetScalars())#.astype('float64')\n",
-    "        \n",
-    "        MeshType = itk.Mesh[PixelType, Dimension]\n",
-    "        itk_mesh = MeshType.New()\n",
-    "        \n",
-    "        itk_mesh.SetPoints(itk.vector_container_from_array(points_numpy))\n",
-    "        itk_mesh.SetCellsArray(itk.vector_container_from_array(polys_numpy), itk.CommonEnums.CellGeometry_TRIANGLE_CELL)\n",
-    "        itk_mesh.SetPointData(itk.vector_container_from_array(point_data_numpy))\n",
-    "        itk_mesh.SetCellData(itk.vector_container_from_array(cell_data_numpy))    \n",
-    "        return itk_mesh\n",
-    "\n",
-    "    warped_image = itk.image_from_dict(warped_image)\n",
-    "    distance_inner, distance_outer = mp.get_thickness_mesh(warped_image, mesh_type=mesh_type)\n",
-    "    \n",
-    "    polys = distance_inner.GetPolys().GetData()\n",
-    "    polys_numpy = np.array(polys).flatten()\n",
-    "\n",
-    "    distance_inner_itk = get_itk_mesh(distance_inner)\n",
-    "    distance_inner_itk_dict = itk.dict_from_mesh(distance_inner_itk)\n",
-    "\n",
-    "    return distance_inner_itk_dict"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "t6irlumR7ctq",
-    "outputId": "9e1f17df-3050-4462-b196-3569b8abaf4b"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "('0.18.3',)\n"
-     ]
-    }
-   ],
-   "source": [
-    "# For checking if vtk import works properly\n",
-    "\n",
-    "@delayed\n",
-    "def check_vtk():\n",
-    "  import vtk\n",
-    "  return vtk.__version__\n",
-    "\n",
-    "@delayed\n",
-    "def check_skimage():\n",
-    "  import skimage\n",
-    "  return skimage.__version__\n",
-    "\n",
-    "t1 = check_skimage()\n",
-    "output_result = compute(t1)\n",
-    "print(output_result)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from dask import compute, visualize"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "snuntUuOBLqV",
-    "outputId": "663f29ae-b412-495d-bc20-cd6f64eaf95c"
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "marching_cubes_lewiner is deprecated in favor of marching_cubes. marching_cubes_lewiner will be removed in version 0.19\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Main execution block\n",
-    "\n",
-    "phi_AB, image_A, image_B = dp.register_images_delayed()\n",
-    "deformed_fc = dp.deform_probmap_delayed(phi_AB, image_A, image_B, 'FC')\n",
-    "deformed_tc = dp.deform_probmap_delayed(phi_AB, image_A, image_B, 'TC')\n",
-    "\n",
-    "thickness_fc = dp.get_thickness(deformed_fc, 'FC')\n",
-    "thickness_tc = dp.get_thickness(deformed_tc, 'TC')\n",
-    "\n",
-    "result = [thickness_fc, thickness_tc]\n",
-    "output_result = compute(*result)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "phi_AB, image_A, image_B = dp.register_images_delayed()\n",
-    "deformed_fc = dp.deform_probmap_delayed(phi_AB, image_A, image_B, 'FC')\n",
-    "deformed_tc = dp.deform_probmap_delayed(phi_AB, image_A, image_B, 'TC')\n",
-    "\n",
-    "thickness_fc = dp.get_thickness(deformed_fc, 'FC')\n",
-    "thickness_tc = dp.get_thickness(deformed_tc, 'TC')\n",
-    "\n",
-    "result = [thickness_fc, thickness_tc]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 1000
-    },
-    "id": "qI8mWKz8RTAx",
-    "outputId": "a370a6e5-b3de-4fab-e253-6491d7d022cd"
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAs0AAAXxCAIAAADtMjKOAAAABmJLR0QA/wD/AP+gvaeTAAAgAElEQVR4nOzdd1xT5+IG8BP2EBAZ1rpApYpMKyBLVGSqFa2Cq45Wxd5q6+1Vq7W12p92WK1aR1sVtUxlKSojFtlbQWSJoEBQQWSIbEhI8vsjvdarFhcn70nyfP/oR5LA+6TAy3PWe1hCoZACAAAAoIEc6QAAAAAgtdAzAAAAgC7oGQAAAEAXBdIB4AWuXr1aVVVFOgUthgwZMnnyZNIpAKRfXV1damoq6RR0ef/99xUU8LeMufC9Ybrffvvt1KlTpFPQwt3dnc1mk04BIP2uX7++YMEC0ino0tLSoqmpSToF/CMcN5EA7u7uQqnz4Ycfkv7/CiBbWlpaSP/e97O4uDjS/1PhxdAzAAAAgC7oGQAAAEAX9AwAAACgC3oGAAAA0AU9AwAAAOiCngEAAAB0Qc8AAAAAuqBnAAAAAF3QMwAAAIAu6BkAAABAF/QMAAAAoAt6BgAAANAFPQMAAADogp4BAAAAdEHPAAAAALqgZwAAAABd0DMAAACALugZAAAAQBf0DAAAAKALegYAAADQBT0DAAAA6IKeAQAAAHRBzwAAAAC6oGcAAAAAXdAzAAAAgC7oGQAAAEAX9AwAAACgC3oGAAAA0AU9AwAAAOiCngEAAAB0Qc8AAAAAuqBnAAAAAF3QMwAAAIAu6BkAAABAF/QMAAAAoAt6BgAAANAFPQMAAADogp4BAAAAdEHPAAAAALqgZwAAAABd0DMAAACALugZAAAAQBf0DAAAAKALegYAAADQBT0D/odQKCQdAQAkG6YReJIC6QDwYnV1dWFhYWIYqLa29tGjR+PHjxfDWBwOR0lJSQwDAYDIuXPnVFVVxTBQfHy8q6urGAYqKCgQwyjwhtAzJEBBQcGCBQtIp+h/7u7upCMAyJAVK1aIbSw/Pz+xjQUMx8IOLnhs1KhRTU1NDQ0N2NMAAK9n27Ztu3btio2N9fT0JJ0FGAHnZ8Bf8vLyqqqqWltbL126RDoLAEgkoVAYEBBAUVRISAjpLMAU6Bnwl5CQECUlJQUFheDgYNJZAEAi5eTk3Llzh6KoiIiIjo4O0nGAEdAzgKIoSiAQBAcHc7nc3t7eqKio9vZ20okAQPKcPn1adNS1p6cnJiaGdBxgBPQMoCiKSk1NffDggejfPB7vwoULZPMAgMQRCAQhISFcLpeiKHl5+aCgINKJgBHQM4CiKCokJERRUVH0bxaLFRgYSDYPAEicxMTExsZG0b97e3vj4uIePnxINhIwAXoGUDweLzQ0lMfjiT7k8/nx8fFNTU1kUwGAZBGd4/X4Q6FQGBUVRTAPMAR6BlBsNru1tfWpByMiIoiEAQBJ1NPTEx4eLjpoIiIUCrFnFCj0DKAoKjg4+PFBE5HHF6cBALyM2NjYpy4wEQgEKSkpNTU1pCIBQ6BnyLrOzs7z588/PmgiIhAIsrKy7t27RyoVAEiW4OBgBYWnF5iWl5fHnlFAz5B1UVFRPT09zz6uoKAQGhoq/jwAIHHa2touXrz41OYKRVF8Pt/f359IJGAO9AxZFxQUJCf3nB+D3t5eTBAA8DLOnTvX29v77ONCoTA/P//WrVvijwTMgZ4h0x4+fBgfH8/n8599SigUFhUVlZWViT8VAEiWoKCgf7pVFovFwp5RGYeeIdNiY2PV1NQG/JeKioqysvLjDzU1NbFgFwD0rbm5OT8/X11dXTRvqKmpKSoqDngCm80mnRFIwv1a4W8rV66sra2Ni4sjHQQAJBWbzfb09GxpadHU1CSdBRgB+zMAAACALugZAAAAQBf0DAAAAKALegYAAADQBT0DAAAA6IKeAQAAAHRBzwAAAAC6oGcAAAAAXdAzAAAAgC7oGQAAAEAX9AwAAACgC3oGAAAA0AU9AwAAAOiCngEAAAB0Qc8AAAAAuqBnAAAAAF3QMwAAAIAu6BkAAABAF/QMAAAAoAt6BgAAANAFPQMAAADogp4BAAAAdEHPAAAAALqgZwAAAABd0DMAAACALugZAAAAQBf0DAAAAKALegYAAADQBT0DAAAA6IKeAQAAAHRBzwAAAAC6oGfA37hcLo/HEwqFpIMAgKTq7u6mKKqnp4d0EGAKFv6oSD2BQHD//v2qqioOh8PhcGpraxsbGxsbG5uampqamjo7Ozs6Orhc7lOfpaCgoKGhoaKioqOjo6Ojo6urq6urO2TIEENDQwMDAwMDg6FDh8rLy5N4QwBAQHNzs2gOqa6u5nA4Tf/V2NjY3NzM4/Ha29uf/ayBAwcqKCjoPEFfX180h4wcOdLQ0FBVVVX87wXECT1DCtXV1RUWFhYUFBQWFhYVFZWWlopqhJKS0ogRI4YNG6ajo6Onp6erq6ujo6OmpjZgwABFRUWKorS0tOTk5JqbmymK4vP5ra2tXV1dj6eShoaG2tpaDocj2lJRVFQ0MjIyMzOzsLAwNzc3NzcfPnw42TcOAP2lo6OjuLj48TRSVFQkmhkoihoyZIiBgYFoAhFtgWhraysrK6upqVEUpaampqys/HjrpbW1lcvlPp5Gmpqa6urqOBzO4682bNgwU1NT0TRiZmZmbGysoKBA6l0DHdAzpAGfzy8pKUlPT8/MzMzIyOBwOBRFDR061MzMzNzc3MTEZNSoUQYGBm+//bac3JseKRMKhffv3xdt1hQXF4smoOrqatGIDg4O9vb2Dg4OlpaWmCwAJEtNTU1GRkZGRkZmZub169d7e3s1NDRMTU1FM8no0aNF+yFUVFTefKyWlhbRNFJWVvZ4i4jH46mrq0+aNEk0k9jZ2Wlpab35WEAWeoYEq6urY7PZbDY7Pj7+4cOHmpqadnZ29vb29vb2EyZM0NHREVuSlpaWgoICUcvJzMx8+PChhoaGi4uLh4eHh4fHiBEjxJYEAF5JV1dXampqXFxcXFxceXm5goKChYWF6M+8tbW1oaEhi8USTxIej1daWnrlyhXRJtOtW7fk5eWtra09PT09PDysrKzefDMJiEDPkDxlZWWhoaFRUVHXr19XVlZ2cnLy8PCYPn26iYkJE06YEAqFpaWlycnJcXFxSUlJHR0dJiYmXl5ePj4+FhYWpNMBAEVRVHNzc1RUVERERFJSUldXl7m5uYeHh5ub26RJkwYMGEA6HUVRVH19fVpa2qVLl+Li4u7du6enp+fp6ent7e3m5qakpEQ6HbwC9AyJUVFRERoaGhYWVlBQ8NZbb82dO3fmzJnTpk0THRNlpp6enrS0tNjY2LNnz1ZXV48dO9bHx2fhwoXjx48nHQ1AFrW1tUVFRYWGhsbHx8vJybm7u8+aNcvT03Po0KGko/WlqKiIzWZHRUVlZWUNHDhwzpw5Pj4+Li4uODgrEdAzmI7L5Z4/f/7YsWMJCQna2tozZ8709vb29PSUuF+wkpKS8PDwwMDAysrKiRMn+vr6Ll68mCFbTgBSLy8v79ixYyEhIV1dXba2tsuWLVuwYIHEnf1w7969yMjI8PDwzMzMt956a9myZb6+vqNGjSKdC/qCnsFcFRUVR44cCQwMfPTo0cyZM1evXu3h4cGEIyNvQiAQJCcn+/n5nT17VllZefHixWvXrjU1NSWdC0A6tbe3+/v7Hzt2rLCw0MzMbPXq1R988IG2tjbpXG+qsrLyxIkTp06devDggaur65o1a7y8vHACB0MJgXkyMjLmzZsnJydnYGCwa9eumpoa0on6X2Nj4759+8aNG8disTw8POLj40knApAqtbW1X375pba2tpqa2kcffZSVlUU6Uf/j8XhRUVEzZsyQk5MbM2bMkSNHOjo6SIeCp6FnMIhAIDh//rydnR1FUTY2NqGhob29vaRD0UsgEMTExDg7O1MUZWFhERwczOfzSYcCkGxlZWXLly9XUlIaPHjwzp07GxsbSSeiXVlZ2Zo1a1RVVXV0dLZt29bU1EQ6EfwNPYMp4uLirK2tWSzW7NmzU1NTSccRt7y8vEWLFsnLy5uYmISHhwsEAtKJACRPRUXF8uXLFRQUxo0b5+fn193dTTqRWNXX1+/YsUNHR0dLS2vHjh2PHj0inQiEQvQMJkhOTnZwcKAoaubMmXl5eaTjkFRaWrpgwQI5OTlLS8uLFy+SjgMgMe7du+fr66uoqDhmzJiAgACp3xXah9bW1v/7v/8bOHDgoEGDvv/+exxJIQ49g6SKior333+foihXV1epPHr6egoLC+fOnctisVxdXYuLi0nHAWC0zs7OnTt3qqurjxw58sSJE6JbIUJzc/PXX3+toaExYsSI06dPYxcpQegZZLS3t2/fvl1FReWdd97Bhvtz5eTk2NraKigo+Pr61tfXk44DwEQXLlwwNDRUU1Pbvn17V1cX6TiM09DQ8Nlnn8nLy9vY2GRmZpKOI6PQMwiIiooaOnSotrb2/v37uVwu6TjMxefz/fz8Bg8erKurGxAQQDoOAINUVFRMnz6dxWItX75cKi9J60dXr151cHCQk5Nbt25da2sr6TgyBz1DrO7fv+/t7U1R1NKlSxsaGkjHkQwtLS3r1q0TrV1YVVVFOg4AYb29vXv37lVTUzM1NcXx1pckEAj8/f11dXWHDx8eHR1NOo5swaom4hMQEDB+/PirV6+y2eyAgABdXV3SiSSDpqbmoUOH0tLS7t69a2pqevDgQSEWlwNZVVxcbGtr+9VXX23ZsiUvL8/W1pZ0IsnAYrGWLVt248YNJyenWbNmLV68uKmpiXQoWYGeIQ7Nzc0+Pj4ffvjhsmXLiouL3d3dSSeSPPb29vn5+Zs2bdq4caOHh8f9+/dJJwIQK6FQePDgQWtrayUlpfz8/G3btuF2Yq9KT08vKCgoNjY2PT3dwsIiISGBdCKZgJ5Bu6SkJHNz89TU1Ojo6AMHDqirq5NOJKmUlJS2b9+emZnJ4XDMzc2joqJIJwIQk/r6+tmzZ2/YsGH9+vXJycnGxsakE0kwT0/PoqKiqVOnurq6rl+/vqenh3QiKYeeQSM+n//111+7uLjY2NiUlJR4enqSTiQNrKys8vLyvLy85s6du3btWi6XSzoRAL3i4+NNTU1LS0vT0tJ+/PFHRUVF0okknpaWVlBQ0MmTJ0+dOmVnZ1dZWUk6kTRDz6BLU1PTjBkzfv75599++y0yMlJHR4d0IukxYMAAPz+/sLCwwMDAKVOm1NTUkE4EQAuhUPjDDz94enq6uLjk5+fjbIz+tWLFivz8fIqirKys4uLiSMeRWugZtLh+/bq1tfWNGzeSk5N9fX1Jx5FO3t7eubm5bW1tlpaWOM4K0qetrc3Hx+ebb7757rvvQkJCNDQ0SCeSQqNHj87MzHz//fdnzpy5ZcsWgUBAOpEUQs/of2FhYXZ2dqNGjbp27dqkSZNIx5Fm77zzTlZW1pQpUzw8PH7//XfScQD6TWVl5aRJk9LS0hISEjZv3kw6jjRTUVHx8/M7dOjQ/v3758+f39nZSTqRtEHP6Ge7d+9euHChr6/vpUuX9PT0SMeRfhoaGuHh4d98880nn3zyxRdfYHMEpEBOTo6dnZ2KikpeXp6TkxPpODJh7dq1CQkJqamp06ZNe/DgAek4UoWFpQj6C5/P/+yzz44ePfrdd99h+0P8wsPDly1bNmPGjKCgIFVVVdJxAF7TuXPnPvjgA0dHx/DwcE1NTdJxZEtlZeWMGTN6enpiY2NxUU9/wf6M/tHV1eXl5eXv7x8ZGYmSQYS3tzebzU5KSnJzc2tpaSEdB+B1/Prrr/Pnz1+xYkVsbCxKhviNGjUqPT196NChDg4OWVlZpONICfSMftDR0TFr1qysrKzExEQvLy/ScWTXlClTMjIyqqqqpk+f3tjYSDoOwKvZu3fvunXrdu7ceeTIEXl5edJxZJSuru7ly5cnT57s5uaWmJhIOo40QM94Uy0tLW5ubsXFxYmJiTY2NqTjyDpjY+P09PRHjx45OTnheleQILt37/7iiy/27du3detW0llknYqKytmzZ99///0ZM2ZgPcA3h/Mz3khzc7Orq2tdXd3ly5fHjRtHOg785d69ey4uLnw+Pzk5eejQoaTjALzAli1b9uzZc/To0VWrVpHOAn/h8/m+vr5BQUFnzpyZO3cu6TgSDD3j9bW1tbm5udXU1CQnJ48aNYp0HPgfDx48cHZ2FggEKSkp+vr6pOMA/KMdO3bs3LnT39//gw8+IJ0F/odQKFy7du2JEyeioqKwoPNrQ894TV1dXTNmzBCtxIXTkpnpwYMHU6ZMUVZWTkpKGjRoEOk4AM9x4MCB//znP7/99tuaNWtIZ4HnEAqFvr6+wcHBsbGxU6dOJR1HIqFnvA4ulzt79uzc3Nzk5GRTU1PSceAfVVdXT548+e23346Pj8dyisA0v/7667p16w4cOPDZZ5+RzgL/iM/nL1q0iM1mx8fHY+nF14Ce8cqEQuGyZcsuXLiQmJg4ceJE0nHgBcrLy52cnCZMmHDx4kUFBQXScQD+cvbsWW9v7127dn355Zeks8AL8Hi8uXPn5uTkZGVljRkzhnQcCYOe8cq++eabH3/8MTo62s3NjXQWeCl5eXlTpkxZuHChn58f6SwAFEVRubm5U6dOXbx48bFjx0hngZfS1dXl7OxcX1+flZWFU75eCXrGqzl9+vSSJUt+/fXXjz/+mHQWeAUxMTFeXl5YqhWYgMPh2NravvvuuxcuXMA+NgnS0NBgb28/aNCgpKQkNTU10nEkBnrGK0hJSXF1dd20adN3331HOgu8skOHDq1fvz48PHzevHmks4Dsam1ttbW1VVFRSU1NHTBgAOk48GpKS0sdHBw8PDxCQkJIZ5EY6Bkv6969e1ZWVqKbDrBYLNJx4HWsXbs2MDAwJycHlwgBEUKhcN68eVlZWbm5uVjZRUJdvnzZw8Njz549n3/+OekskgE946XweLxp06Y1NjZeuXIFNx2QXDweb/r06Q8ePLhy5YqWlhbpOCBzvv/+++3bt1++fHnKlCmks8Dr271799dff43v40tCz3gpH3/8cXBwcE5Ozvjx40lngTdSV1c3ceJEa2vrc+fOYb8UiFNCQoK7u/u+fftwFaukEwqFCxYsSE1Nzc3NHTZsGOk4TIee8WJnzpxZvHhxRETE+++/TzoL9IOUlBQXF5e9e/euX7+edBaQFXV1debm5i4uLjiuLx3a2tpsbGz09fUTExNx07u+oWe8wL179ywsLBYvXnzo0CHSWaDf7Ny587vvvsvJybGwsCCdBaSfUCh87733SktL8/PzceBVahQXF1tbW2/btg23vusbekZfBAKBi4vLgwcPcnNzVVVVSceBfiMQCKZPn15fX4/vLIjBgQMHNm3alJqaamdnRzoL9Kd9+/Zt3rw5PT0d64T2AT2jLz/88MO3336bnZ1taWlJOgv0Mw6HY2lpuWLFigMHDpDOAtKsqKjIxsbmyy+//Oabb0hngX4mFAo9PDyqqqry8/PV1dVJx2Eo9Ix/VFJS8u6773733XcbN24knQVoERwcvHTp0pSUlMmTJ5POAtKpt7fX1tZWWVk5NTUVR/Gl0v37983MzJYsWfLLL7+QzsJQ6BnPJxAInJycuFxuVlYWZgcp5uXldfPmzYKCAhUVFdJZQArt2bNn27Zt165dw6VqUszf3/+jjz5KS0uzt7cnnYWJ0DOe75dfftm4ceOVK1cmTJhAOgvQqLa2dvz48Z9++unOnTtJZwFpw+FwTE1Nt2zZ8vXXX5POAvRyd3evra3Ny8tTUlIinYVx0DOeo7q62tTU9N///jf+9siCw4cP/+c//8nNzTU3NyedBaSHUCh0dXWtr6/Py8tTVFQkHQfoVVlZaWZmtmXLlm3btpHOwjjoGc/h7e1dWFhYWFiorKxMOgvQTiAQ2NvbKysrp6SkkM4C0iM0NHTx4sWZmZm4EkFG7NmzZ/v27Tdu3DAwMCCdhVnQM56Wnp7u5OQUHR09Y8YM0llATPLy8mxsbM6cOePt7U06C0iDrq4uY2NjZ2fnkydPks4CYsLlcs3Nzc3NzcPCwkhnYRb0jP8hEAhsbGy0tbXj4+NJZwGxWr58eVJS0s2bN3G7Z3hz//d//7dnz57y8vIhQ4aQzgLiEx0d/d577yUnJ+O+J0+SIx2AWU6cOFFYWHjw4EHSQUDcfvjhh+bm5v3795MOAhLv3r17P/3009atW1EyZM2sWbPc3Nw+//xzgUBAOguDYH/G37q6ukaPHj1//nz0DNm0a9euPXv2VFZW6ujokM4CEszX1zc+Pr60tBQXS8ugkpISCwuLgICAxYsXk87CFNif8bdff/21tbX1q6++Ih0EyPj8889VVFT27NlDOghIMA6H4+/v/80336BkyCYTE5PFixfv2LGjt7eXdBamQM/4S0dHx08//bR27drBgweTzgJkqKurb9q06fDhww8ePCCdBSTV9u3bR4wYsXTpUtJBgJjt27dzOJygoCDSQZgCPeMvBw8e7Ozs3LBhA+kgQNK6desGDhy4e/du0kFAIt26dSskJGTHjh0KCgqkswAxo0ePXrZs2Y4dO7hcLuksjICeQVEU1dnZuW/fvvXr1+vr65POAiSpqKh88cUXv//+e0NDA+ksIHl27dplZGS0cOFC0kGAsG3btt2/fz84OJh0EEZAz6Aoivrjjz/a29s//fRT0kGAvFWrVqmrqx85coR0EJAwtbW1Z86c2bRpE+6IBCNHjly0aNFPP/2EKy0o9AyKogQCwaFDh5YvX44zM4CiKDU1tU8++eTw4cMdHR2ks4AkOXjwoLa29qJFi0gHAUbYuHFjWVkZm80mHYQ89AzqwoULZWVl69evJx0EmGLt2rWdnZ2BgYGkg4DE6Ojo8PPz++yzz3CZCYiYmpq6ubn9/PPPpIOQh/UzqKlTp2pqal64cIF0EGCQNWvWpKSklJaWslgs0llAAhw+fHjLli137twZNGgQ6SzAFPHx8W5ubtevX7ewsCCdhSRZ359RVlaWmpq6bt060kGAWdatWyf62SAdBCSDn5/f4sWLUTLgSa6ursbGxsePHycdhDBZ7xnHjh0zMDBwcXEhHQSYxczMzMbGBhMEvIzs7OyCgoLVq1eTDgKM8+GHHwYFBXV2dpIOQpJM9wwulxsYGLhy5Uo5OZn+/wDPtWrVqsjIyIcPH5IOAkx3/Phxc3Nza2tr0kGAcT788MPu7u6IiAjSQUiS6b+v586da25u/vDDD0kHASZauHChgoICFvWDvrW2toaGhvr6+pIOAkykq6s7e/ZsPz8/0kFIkumeERQU5O7u/vbbb5MOAkykoaHh7e2NlXagb+fOnevt7V2yZAnpIMBQH374YXp6OofDIR2EGNntGY8ePfrzzz+xch/0YcGCBVeuXKmoqCAdBJgrNDTU3d194MCBpIMAQ7m4uAwaNCgsLIx0EGJkt2ecPXuWxWK99957pIMAc02fPl1fX1/Gj61CH5qbmxMSEnx8fEgHAeZSVFScO3cueoYsCgsL8/T01NLSIh0EmEtBQWHOnDmhoaGkgwBDnT17Vk5ODpsr0DcfH5+8vLxbt26RDkKGjPaMR48eJSYment7kw4CTOfj45Ofn49DJ/BckZGRHh4empqapIMAo02bNk1PT+/s2bOkg5Ahoz0jPj5eIBB4eHiQDgJMN2XKFC0trbi4ONJBgHG6urpSUlJmz55NOggwnYKCgqenp8xOIzLaM+Li4uzs7LB4H7yQgoLC9OnTcTMkeFZycnJXV5e7uzvpICABPDw8MjIyWlpaSAchQBZ7hlAovHTpEnZmwEvy8PBITEzs6uoiHQSYJS4uzsLCAhfGw8twd3cXCoUJCQmkgxAgiz2joKCgtrbW09OTdBCQDJ6ent3d3WlpaaSDALPExcVhcwVe0qBBg6ytrWXz0Iks9oykpCQ9Pb0JEyaQDgKSYdiwYcbGxomJiaSDAIPcvXv39u3bbm5upIOAxHB3d5fNaUQWe0Z6erq9vT3u9w0vz9HRMT09nXQKYJCMjAxFRcVJkyaRDgISw9HRsbKysqamhnQQcZPFnpGVleXg4EA6BUgSBweH3Nzc7u5u0kGAKTIyMiwtLdXU1EgHAYlha2uroKCQlZVFOoi4yVzPqKiouH//PnoGvBIHB4eenp68vDzSQYApMjIyMI3AKxkwYIC5uXlGRgbpIOImcz0jMzNTWVl54sSJpIOAJBk9evSQIUMyMzNJBwFGaG9vLyoqsre3Jx0EJIyDgwN6hvS7du2aubm5srIy6SAgYaysrPLz80mnAEYoKCjo7e21trYmHQQkjJWVVWFhYW9vL+kgYiVzPaOwsNDc3Jx0CpA8ZmZmhYWFpFMAIxQWFmpqao4cOZJ0EJAw5ubmPT095eXlpIOIlcz1jKKiIjMzM9IpQPKYmZmVlZX19PSQDgLkFRUVmZub45o1eFXGxsaKiopFRUWkg4iVbPWM2trahoYG7M+A12Bubt7b21taWko6CJCH3aLwepSVlY2MjNAzpFlJSQlFUaampqSDgOR55513lJWVi4uLSQcB8oqLizGNwOsxMzNDz5BmFRUVWlpaenp6pIOA5FFQUBg5cmRlZSXpIEBYU1NTS0vLmDFjSAcBiTRmzBhZm0Zkq2dwOBxDQ0PSKUBSGRgYVFVVkU4BhHE4HIqiDAwMCOcAySSD04jM9QzMDvDaDA0NRX9jQJZVVVXJycmNGDGCdBCQSIaGhh0dHQ0NDaSDiA96BsDLksENEXgWh8MZMmQI1uCB1yP6GyRTWyyy1TPu3r2LrRB4bQYGBvfu3ePz+aSDAEl3797Fyhnw2kaMGCEnJ1ddXU06iPjIUM8QCoWNjY2DBw8mHUR82Gw2i8U6cOBAH6/Jzc1lsVg7duzory8oxfT19fl8fnNzM+kgQFJDQ4O+vj7pFOKDaaR/KSoqDhw4EMdNpFNrayuXy9XR0SEd5KWkp6ezWKxdu3bR9Hp4DaIfnqamJtJBgKTGxkZdXV3SKV4KphFm0tXVlalpRIF0APERfV8lZYIQGysrK6FQSDqFZBD98MjUBGuTcbEAACAASURBVAHPampqwo0Yn4Jp5JXIWs+Qof0ZjY2NFHoGvAHRD4/oBwlkVlNTk6TsFgVm0tHRQc+QTo8ePaIoauDAgWIYq7m5+ZNPPnnrrbdUVVWtrKyio6P/+OMPFosVERHx+DVCofDkyZP29vYaGhqqqqoWFhZHjhwRbRPs2rVr8uTJFEVt27aN9V99DPfC12dnZ0+dOlVdXV1HR2f58uUPHz58/NSzB1aFQuEff/zh5OQ0cOBADQ0Na2vr48eP/9MNBouKikaOHPnWW2/l5ORQTxx57WPEvt87RVF8Pv/QoUMTJ07U1tYeOHCglZXVvn37Ojs7X+ZZWikrK6upqeH8DBn36NEjTCOYRt7EoEGDZGsaEcqM8+fPUxTV3d1N90BdXV2WlpZP/k9msVgLFiygKCo8PFz0GoFAsGTJkme/HatXrxYKhTt37nyl79Q/vT4uLo6iqMWLFz91DZ6Tk9Pjz7169SpFUdu3b38cTBT1KfHx8Y+/4P79+0UvjomJ0dDQMDU15XA4okdeZsS+37tQKNy0adOzzx46dOhlnqWbtrb20aNHxTMWMJOysnJgYCDdo2AakeJpxNfX18XFRTxjMYEM9Yzw8HCKovh8Pt0D/fTTTxRFjR07NiEhoa2traqq6tNPPxX9HD+eIAICAiiKMjMzi42NbWpqam9vT0lJsbCwoCgqMzNTKBSmpaVRFLVz586XHPS5rxf9ulIU9fHHH9+6dauzszM9PV10Ze/169dFr3lqgvDz86MoSkdH5/fff79z5057e/vVq1dXrVqVnJws/N8J4pdffpGXl/f09GxtbX2lEV/43o2MjNTV1SMjIx89etTR0XH9+vWNGzeeOnVK9Ol9P0u3t9566+DBg+IZC5iJxWKFhobSPQqmESmeRj799NMnO5PUk6GeERwcrKioKIaBbGxsWCxWcXHxkw+6uro+OUFMmzZNXl6+trb2ydeIbvO2efNmYb9OEG5ubk8+ePjwYYqi/P39RR8+NUGIdpyKNjueJfqCe/bs+de//kVR1Lp163p7e191xBe+92nTphkZGfF4vOdm6PtZuo0YMWLv3r1EhgYm4HK5FEWdO3eO7oEwjUjxNLJhw4ZJkyYRGZoIGbrepKenR0lJSQwDVVRUDB061MTE5MkH3d3d4+PjH39YUlLC5/OHDx9O/XdPpugfFEXduXOnf/NMnTr1yQ9HjRpFUVRbW9tzX3zz5k1tbW0XF5c+vuDOnTtbW1u//PLL77///jVGfOF7379//7x588aMGePu7m5hYWFnZzdhwoTHX63vZ+mmrKzc09MjtuGAaUTffTHMJJhGMI1IDRk6D5TP58vLy4tnrGfPtxL+70VfAoFAFInP5wsEgse/JxRFiTaY+pGqquqz2YRvcBHarFmzBg0adPLkyYKCgtcY8YXv3cLC4ubNmwEBAYaGhmlpaR4eHiYmJo/vpNz3s3RTUFDg8XjiGQsYSLQarIKCOLbQMI30MaKkTyP/dEqsVJKhnqGoqCieb+3o0aPv3bt348aNJx98ciuEoqhx48apqak9evTo2V1MopPJ5eTkKIp6+cCv+vp/Mm7cuObm5oSEhD5eY21tnZqaKi8vP2XKlPT09NcYou/3TlGUgoKCk5PTli1bTp8+XVVV1draunLlysdfoe9nacXlcsWzVwyYSVFRkaIoMXRNTCMvHALTiKSQoZ6hpKTU7x3/uebNmycUCufPn5+cnNzR0VFdXf3555//+eefT75m5cqVnZ2dLi4u0dHRDQ0NXC63uro6JiZm3rx5ol/OQYMGURSVlpb2kpdZv+rr/8ny5cspilq0aNHx48fv3bvX0dGRl5fn6+ubkpLy5MtMTEwyMjL09PTc3NxiY2NfaYgXvnd7e/vff//9xo0bXV1dLS0tbDa7qampsrJS9Ol9P0s3LpeLG2jJMtGfBzHMJJhG+ibp04hM9QwZOg80MjKSEsv1Jp2dnebm5k/+T2axWN7e3hRFRUVFiV4jEAhWrFjx3O9IXFycUCjs7e0dOnToy3+nnvv6p64fExE9+PgKrqdO4OLz+fPnz3821XMvSKurq7O0tFRUVAwODn7yi/c94gvf+3P/kH/22WeiT+/7Wbrp6+sfPnxYPGMBM8nLy585c4buUTCNSPE0snbt2ilTpohnLCaQrf0ZlFg2RFRVVZOSktasWaOvr6+iojJx4sQLFy6MHz+eoihtbW3Ra1gs1qlTp0JDQ11cXLS1tZWUlEaNGjVnzpxz586JTp6Sl5ePiIhwdHRUV1d/mUFf9fX/RE5OLiws7NixY7a2turq6pqamjY2Nn5+fk+dkyUyePDg5ORkW1vbDz744MiRIy85xAvfe05Oztq1a8ePH6+qqqqrq+vg4ODn57d//37Rp/f9LN2wPwPEs2cU00jfMI1IEJZQZhalT0hIcHFxaWpqEu0bFCeBQGBlZXX9+vWGhgasWCzRVFRU/Pz8PvjgA9JBgBgdHZ3vv/9+zZo1Yh4X04jUWLp0aVtbW1RUFOkgYiJD+zPEebPNDRs2BAUFVVdXd3Z2Xr9+3cfHJz8/f+rUqZgdJFpbW1tPTw9ukSPjBg0ahGkE3kRjY6NMfRNlaP2Mxz3DyMiI7rHKysr27dv35CMDBgx46pFXcv369T4u7/by8pKdakyQ6K+LTE0Q8Cyx3QQL04i0amxsNDMzI51CfGRof4Y4b7a5f//+FStWjBkzRllZWU9Pb/78+VlZWU/drQAkjuiHBz1Dxontpt6YRqSVrN3yV4b2Z6iqqqqqqoqnZxgZGZ06daofv6ClpaXsnEnDWKIfHhw3kXE6OjqYRuBNNDY2ytQ0IkP7MyiKGjx48IMHD0inAElVX1+voqKioaFBOgiQpK+vX1dXRzoFSKrOzs62tjY9PT3SQcRHtnrGyJEjq6urSacASVVVVTVy5MhnV4MGmYJpBN4Eh8OhKMrAwIBwDjGSrZ5hYGAg+h4DvAYOhyNTswM8l4GBQWNj4z/dQgygb1VVVRR6hhQzMDAQfY8BXkNVVZWhoSHpFECY6C8EdmnA6+FwODo6OpqamqSDiI9s9QzRDk+cCQWvp6qqSqa2QuC5RF0TWyzwemRwc0W2eoaRkVFXV9edO3dIBwHJ09nZWVNTI4bFV4Dh1NXVhwwZUlZWRjoISKTy8vIxY8aQTiFWstUzzM3NWSxWYWEh6SAgeYqLi/l8/lO3tgLZZG5uXlRURDoFSKTCwkJZm0Zkq2doamqOHDkSEwS8hqKiInV19VGjRpEOAuSZm5tjcwVeQ0tLy507d2RqMVBK1noGhQ0ReF1FRUUmJiZycjL3KwPPMjMzKy0t5fF4pIOAhCkuLhYKhdifIeXMzMwKCgpIpwDJU1RUJGtbIfBPzM3Ne3p6ysvLSQcBCVNUVKSlpTV8+HDSQcRK5nqGlZVVWVlZc3Mz6SAgSfh8fl5enpWVFekgwAjjx49XU1PLyckhHQQkTHZ2tpWVlayt9SdzPcPR0VEoFGKCgFdSWFjY0tLi6OhIOggwgqKiorW1dUZGBukgIGHS09MdHBxIpxA3mesZurq6Y8aMwQQBryQjI2PgwIHjx48nHQSYwsHBAdMIvJIHDx5UVFSgZ8gETBDwqjIyMuzt7XESKDzm4OBQXl7e0NBAOghIjPT0dHl5+UmTJpEOIm6yOG86OjpeuXKlp6eHdBCQGGlpaTK4FQJ9sLOzY7FY6enppIOAxEhLSzMzM9PS0iIdRNxksWe4ubl1dHRggoCXVFRUVFNT4+rqSjoIMIi2tvbEiRP//PNP0kFAYly6dEk2pxFZ7BnDhw83NjZms9mkg4BkYLPZurq6EydOJB0EmMXT0zMmJoZ0CpAMHA7n5s2bnp6epIMQIIs9g6IoT0/PuLg40ilAMsTFxXl4eODkDHiKh4fH3bt3S0tLSQcBCRAXF6eurm5vb086CAEyOnV6eHiUlJTgzs7wQu3t7ZmZmR4eHqSDAOPY2Njo6OhgiwVeRlxcnIuLi7KyMukgBMhoz3ByctLU1Dx//jzpIMB0MTExfD7f3d2ddBBgHHl5eQ8Pj6ioKNJBgOna29sTEhJmzpxJOggZMtozlJWVZ8+eHRYWRjoIMF1oaKizs7Ouri7pIMBE3t7eGRkZNTU1pIMAo128eJHL5c6ZM4d0EDJktGdQFOXj45OZmXnnzh3SQYC52tra2Gz2ggULSAcBhvLw8NDQ0AgPDycdBBgtNDTUxcVFT0+PdBAyZLdnuLu7a2trR0ZGkg4CzHX+/Pne3l6Z3QqBF1JWVvby8sKeUehDW1vbpUuXZHlzRXZ7hpKS0uzZs8+cOUM6CDBXaGioq6vroEGDSAcB5vLx8cnOzuZwOKSDAEOdO3dOIBB4eXmRDkKM7PYMiqKWLVt25cqV69evkw4CTHT//n02m718+XLSQYDR3N3dhwwZcvLkSdJBgKH8/Pxmz56tra1NOggxMt0zpk6damRkhAkCnuvEiRNaWlqyvBUCL0NBQWHZsmUnT57k8/mkswDjlJeXp6enr1q1inQQkmS6Z7BYrJUrVwYGBnZ2dpLOAswiFAr/+OOP5cuXy+b17vBKVq9eff/+fSykAc86fvz4sGHDXFxcSAchSaZ7BkVRK1as6OjoiIiIIB0EmOXy5csVFRUrV64kHQQkwKhRo6ZNm3bs2DHSQYBZuFxuQEDAqlWr5OXlSWchiSUUCklnIGzhwoW3b9/Ozc0lHQQYZNasWW1tbSkpKaSDgGSIiIhYsGBBWVnZmDFjSGcBpvD391+9enVlZeWwYcNIZyEJPYPKzc21trZOSkqaOnUq6SzACDdv3jQxMYmKinrvvfdIZwHJwOfzx44d6+7ufuTIEdJZgCksLS0tLCz8/f1JByEMPYOiKMrJyUlLS+vixYukgwAjrFy5MiMj48aNG7h3Gry8Q4cObdmypbq6GqvHAkVRcXFxM2bMyM/Pt7S0JJ2FMEyjFEVRGzZsiImJuXHjBukgQN6DBw9CQkI2bNiAkgGvZOXKlaqqqr///jvpIMAIP//8s5ubG0oGhZ4h8t57773zzju7d+8mHQTI27t3r5aW1tKlS0kHAQmjpqa2Zs2agwcPtre3k84ChOXk5CQkJGzYsIF0EEZAz6AoipKTk9u2bVtwcHBpaSnpLEBSXV3dr7/+umXLFhUVFdJZQPL85z//6enpOXToEOkgQNi2bdvs7e3d3NxIB2EEnJ/xF4FAYGlpaWJicvr0adJZgJjPPvssIiKioqJCVVWVdBaQSNu2bTt8+HBVVdXAgQNJZwEyMjIyHB0dExISnJ2dSWdhBPSMv4WHhy9cuPDatWsWFhakswABtbW1Y8aM2bt37yeffEI6C0iqlpYWQ0PD9evXb9++nXQWIGPatGm9vb1paWmkgzAFesbfhELhu+++O2zYMFx4IptWrlyZkJBQXl6upKREOgtIsF27du3Zs6e8vHzw4MGks4C4sdlsT0/PtLQ0R0dH0lmYAj3jfyQmJk6fPj0uLs7Dw4N0FhCr/Px8Kyur4ODghQsXks4Ckq2rq2vcuHFubm7Hjx8nnQXEqre319LScuzYsZGRkaSzMAh6xtPmzJlTXl5eUFCgqKhIOguIz5QpU3g8XkZGBovFIp0FJF5wcPCyZctycnKsrKxIZwHx+eWXX7744ovi4mIjIyPSWRgEPeNplZWV48eP37Nnz6effko6C4jJmTNnlixZkp2dbW1tTToLSAOhUOjk5CQQCNLT09FcZcTDhw/feecdX1/f77//nnQWZkHPeI7NmzcfP368tLQUh1dlQVtbm4mJiYuLy8mTJ0lnAelx5coVOzu7gICAJUuWkM4C4uDr6xsdHV1WVqahoUE6C7OgZzxHZ2enmZmZtbX1mTNnSGcB2n322WchISE3btzQ19cnnQWkyr/+9a+IiIgbN27o6emRzgL0Sk1NnTp16pkzZ3x8fEhnYRz0jOcTnTMcFRXl5eVFOgvQ6MqVK/b29idPnly2bBnpLCBtWltbTUxMnJ2dcSct6dbT0zNhwgRDQ8OYmBjSWZgIPeMfLV26NDExsaSkBOvtSKve3l5ra2ttbe2EhAQcRAc6xMTEzJo1i81mu7u7k84CdPn6668PHjxYUlIyfPhw0lmYCD3jHzU2No4fP3727Nl+fn6kswAtvv766/379xcVFY0aNYp0FpBaPj4+OTk5BQUF2GKRSrm5ufb29vv27Vu3bh3pLAyFntGXqKiouXPnhoaG4pCb9ElPT586derhw4c//vhj0llAmjU2Npqbmzs4OISHh5POAv2so6Nj4sSJw4cPv3TpEu7w/E/QM17A19c3IiLi+vXrI0aMIJ0F+k1LS4ulpaWxsXFMTAyOmADd4uPj3d3d/f39cR9gKbN69erIyMiCggIcMekDesYLdHR0vPvuu8OHD//zzz9RV6XGokWLUlJSCgoKcCEAiMfnn39+8uTJ69evGxoaks4C/ePs2bPz5s07e/bs3LlzSWdhNPSMF8vNzXVwcPjyyy937NhBOgv0g99//33t2rWxsbE4NQ/Epru7e9KkSYqKiunp6SoqKqTjwJu6ffu2tbW1j4/P0aNHSWdhOvSMl/Lbb7+tXbs2MjISvVXSZWdnT5069csvv8TtNEHMOByOlZWVp6dnYGAg6SzwRrq6uhwcHIRCYWZmpqqqKuk4TIee8bJWrlx59uzZq1evjhkzhnQWeE0PHjywsrIyNjaOi4uTl5cnHQdkTnR0tJeX15EjR3D2sURbvnx5dHR0bm4ujoK9DPSMl9XV1eXo6Njb25uRkTFgwADSceCVcblcNze3u3fv5ubmamtrk44DMmr79u27d+9OTEy0t7cnnQVex/79+zdt2hQbG+vm5kY6i2RAz3gFHA5n0qRJVlZW58+fV1BQIB0HXoFQKFyxYsW5c+fS09PNzc1JxwHZJRAI5syZk52dnZWVNXr0aNJx4NWcP39+3rx533///RdffEE6i8RAz3g1ubm5U6dOXbRo0fHjx0lngVewY8eOXbt2nT17dvbs2aSzgKzr7Ox0dnZubGzMysrCFU8SJC8vb8qUKQsXLsTija8EPeOVRUdHz5kz58cff9y4cSPpLPBSTp8+vWTJksOHD3/yySekswBQFEXdv3/fzs5uxIgR8fHxysrKpOPAi3E4HFtb2wkTJly8eBH7s18Jesbr2L9//8aNG0+ePLl8+XLSWeAFoqOj33///f/85z8//vgj6SwAfyspKXFwcHB2dg4LC8PfLYarq6tzcnJSV1dPTU3Fbd9fFXrGa9q6detPP/0UFBS0cOFC0lngHyUmJs6cOXPBggUnT57EMmvANFlZWW5ubh4eHmfOnMEFUIz16NEjZ2fntra21NTUIUOGkI4jedAzXt/GjRsPHjwYGRn53nvvkc4Cz5GTk+Pq6urm5hYaGopJHJgpISFh1qxZixYtOnHiBJbAZ6DW1lYXF5e6urrU1FQDAwPScSQSesbrEwqFq1atCgkJiYqKwsqSTHPlyhV3d3cnJ6eIiAhFRUXScQD+0YULF+bPn79mzZqDBw+iajBKa2vrrFmzbt++nZqaipWTXhv2JL8+Fot17NgxHx8fLy+vqKgo0nHgbykpKS4uLg4ODmFhYSgZwHCzZ88OCQk5evTo6tWr+Xw+6Tjwl4cPH7q4uNy+ffvy5csoGW8CJx+9EXl5+T/++ENbW3v+/PknTpzAaaFMEBcXN2/ePNHhEpzJDxJh/vz5ampq8+fPb29vDwwMRDkm7sGDB+7u7s3NzSkpKUZGRqTjSDbsz3hTLBZr//79n3/++UcfffT777+TjiPrwsPD58yZs2DBgsjISJQMkCAzZsyIjo6OiYmZP39+V1cX6TgyjcPhODk5dXV1paeno2S8OfSMfsBisfbs2fPtt99+8sknX375JU55IWXv3r0LFy7817/+dfLkSZz4CRLH2dn50qVL6enpzs7O9fX1pOPIqKtXr9ra2qqpqaWkpAwfPpx0HGmA80D7U1hY2PLly2fOnBkYGIib+IkTn89fv379r7/++s033+zYsYN0HIDXV1FRMWPGDB6PFxMTY2xsTDqObGGz2T4+Pra2thEREZqamqTjSAnsz+hPPj4+MTExCQkJrq6u2BwRm9bWVi8vr1OnTkVGRqJkgKQbPXp0enr64MGDHR0dk5KSSMeRIQcOHBBdYxwbG4uS0Y/QM/qZs7Nzenr6/fv3J06cmJ2dTTqO9CspKbG2tr527VpiYuLcuXNJxwHoB3p6eomJidOnT3dzc9u7dy/2OtOts7Pzgw8+2Lhx4/fff3/06FEsz9q/0DP6n4mJSX5+vpWV1eTJk3fv3k06jjQ7f/68g4ODnp5ebm7upEmTSMcB6DeqqqphYWFHjhzZunXrnDlzWlpaSCeSWrdv37azs2Oz2TExMbgLKx3QM2ihqakZGRm5devWrVu3Ll++vL29nXQiadPT0/P555/PnTt32bJlSUlJb7/9NulEAP3P19eXzWZnZWXZ29sXFRWRjiOFzp49a21traCgkJubi+UWaYKeQRc5Oblvv/32woULcXFxEyZMyMnJIZ1Iety4cWPSpEknTpwIDAw8ePAgFhsAKebs7JyXl6etrW1jY/PLL7/gGEp/6ejoWL169bx587y9vTMyMrCmOH3QM+g1c+bM4uLisWPHOjo67tixA4v9vbmAgAAbGxtlZeVr164tWbKEdBwA2g0fPjwlJWXHjh2bNm1yc3Orra0lnUji5ebmvvvuuxEREadPnz527JiKigrpRNIMPYN2+vr6Fy9e3LNnz+7dux0dHUtKSkgnklRVVVVubm4fffTRhg0bMjIysBIwyA55efnNmzenpqZWVVVZWFgEBQWRTiSpuru7v/76a3t7+xEjRhQXF+OG22KAniEOLBbr3//+99WrV4VC4bvvvrt9+/aenh7SoSQJn8//+eefTU1Na2tr09PTv/32W5wQDjLI1tY2Pz9/wYIFy5cv9/T05HA4pBNJmNTUVEtLy4MHD/7888+XLl0aOnQo6USyQQhi1Nvbe+DAgQEDBhgbGycnJ5OOIxmuXr06ceJEZWXlb7/9tqenh3QcAPIyMjLGjx+vrq6+b98+LpdLOo4EaGxsXL16NYvFmjlzZnV1Nek4sgX7M8RKXl5+/fr1xcXFo0aNmjp1qre3N7ZI+nD//v2PPvpo0qRJampq+fn533zzjZKSEulQAOTZ29tfu3Zt48aNW7duNTc3j4uLI52IuXg83sGDB42MjC5evBgSEhIdHT1ixAjSoWQM6aIju2JiYsaOHauiorJ169a2tjbScZilq6vrhx9+0NDQGDFixJkzZwQCAelEAExUWVk5b948iqI8PT1LS0tJx2EcNpttbGysrKy8efPm1tZW0nFkFHoGSVwu9+jRo7q6ujo6Oj/++GNHRwfpRORxuVx/f39DQ0M1NbXNmzejgQG8UFJSkqWlpZycnLe3961bt0jHYYTMzMzp06dTFDVr1qzbt2+TjiPT0DPIa2xs/OKLL9TV1YcMGXLw4MHu7m7Sicjg8XgnT540NDRUUlJau3ZtTU0N6UQAEqO3t9ff33/06NGKiopr1qy5c+cO6UTE5OTkiFbcmjJlSmpqKuk4gJ7BGA0NDZs3b1ZVVR08ePD27dubmppIJxKf9vb2o0ePjh07VlFRcenSpdj4AHg9PB5P1DaUlJSWLl1aVFREOpFYpaWlzZo1i8Vi2draXrhwgXQc+At6BrPU1NRs2rRJS0trwIAB//73v6uqqkgnotf9+/e/+uqrQYMGqampffLJJxUVFaQTAUi8np6e48ePGxsbs1gsT0/PhIQE0ono1dPTExAQYG5uTlGUi4sLm80mnQj+B3oGE7W2th44cGDEiBFycnIuLi5hYWFSdukan8+Pj49funSpqqqqnp7e9u3bGxoaSIcCkCoCgSA+Pn7WrFkURY0dO/bHH3+sr68nHaqflZeXb968efDgwfLy8rNmzcrJySGdCJ6DJcRq+UzF4/HOnz9//Pjxy5cvDx48eMWKFUuXLjU2Niad641UVlYGBQWdOnWKw+FMnjx51apVPj4+WPQXgD7Xrl07fvx4SEhIT0/P3LlzV6xYMX36dIle6a6trS0qKurEiROpqanDhw//6KOPVq5cOWzYMNK54PnQMyQAh8M5efLkqVOn7t27Z2Zm5uPjs2DBAiMjI9K5XsGdO3fCwsLCwsKuXr2qr6+/bNmylStXjhs3jnQuAFnR0dERFhbm5+eXmZmpq6s7b948Hx+fKVOmyMvLk472sjo6OqKjo8PCwmJjYwUCwaxZs1atWuXu7i4nh4WgGA09Q2IIBIL09PTQ0NDIyMgHDx5YWFjMmDHDw8PD3t6emZsmAoHg6tWrbDY7Njb26tWrAwcOnDt37oIFC5ydnZkZGEAWVFZWhoWFhYaGXr9+ffDgwaJpxNXVVVtbm3S056uurmaz2Ww2+88//+Ryuc7Ozj4+PnPnzh00aBDpaPBS0DMkD5/PT0lJOXfuHJvNvn37tpaWlqur67Rp0xwdHU1NTclWe6FQePPmzYyMjKSkpD///LOxsXH48OEeHh5eXl6urq5YzROAOcrLyyMiIuLi4rKzs4VCoa2trZub2+TJk21sbNTV1clmq6+vz8zMTE1NvXTp0o0bN9TV1Z2dnWfOnPn+++/r6emRzQavCj1Dst26dUvU9NPT01tbW7W0tOzt7e3s7CZMmGBqampgYCCGDDU1NcXFxfn5+ZmZmZmZmU1NTerq6nZ2du7u7h4eHqampmLIAACvrbm5+fLly2w2OyEhobq6WkFBYcKECfb29tbW1mZmZuPGjRPDFkJbW1txcXFRUVF2dnZmZmZZWZmcnJypqamrq6unp6ejo6OysjLdGYAm6BlSgs/nFxcXp6enZ2ZmZmVlVVVVURSlpaVlZmZmYmJiaGhoaGhoYGBgYGCgr6/fx9fp7e3t46DGw4cPq6qqOBxOVVVVVVXVIwoCuwAAIABJREFUjRs3CgsLHz58SFHUsGHDbG1tHRwcHBwcJkyYgCMjAJKopqYmPT09IyMjMzOzqKiIy+UqKiqOGzfOxMTknXfeEc0hhoaGw4YN6+N3nMfjKSoq/tOz3d3dojlE9N/y8vKioiLRNfwaGhoTJ050dHS0t7e3t7fX0tKi512CWKFnSKeWlhbRxkFBQUFpaWlVVVVNTQ2fz6coSkVFRee/9PX1Rb/JWlpacnJy9fX1HR0dhoaGFEU1NzdTFNXa2tr4X01NTV1dXRRFycnJDRkyxNDQ0NjY2MzMzMzMzNzcHMdKAaQMj8crKysrKioqLCwsLi6urKysqqp6PAmI5hDRbRN0dHQUFBTU1NREex2ys7NtbW0piuro6OByud3d3U1NTU1NTY2NjQ0NDS0tLaKvr62tbWBgYGRk9HgaMTAwYLFYBN8y0AE9Q1bweLy7d++KCkfTfz3+nW9paREIBNXV1Vwu18jIiMViDRw4kKIoDQ0NXV1dPT090VQiqhcjRozAPkwA2VRXV8fhcO7cudPQ0ND0hN7e3q6uru7u7o6OjvLycgsLCzk5uQEDBigqKj65baOrqzt48OCRI0caGhpid4WMQM+AvwgEgrfeeku0A2PAgAGk4wCARPr0008PHz58+vTphQsXks4CjIDLjuEvycnJDQ0NXC43KiqKdBYAkEh8Pj8kJISiqKCgINJZgCnQM+AvISEhioqKcnJymCAA4PUkJCSITgy/dOlSU1MT6TjACOgZQFEUxeVyw8LCeDwen8+/fPlyfX096UQAIHlEmysURQmFwrNnz5KOA4yAngEURVFxcXHt7e2if7NYrMjISLJ5AEDidHd3R0RE8Hg8iqKEQmFAQADpRMAI6BlAURQVHBz8+Gp4gUCACQIAXlVMTExnZ6fo3wKBICMjo6amhmwkYAL0DKA6OjouXrwo2gqhKEogEOTk5HA4HKKhAEDCBAcHP3lXNgUFhbCwMIJ5gCHQM4A6d+4cl8t98hEFBYXw8HBSeQBA4rS2tsbExPT29j5+pLe319/fn2AkYAj0DKCCgoKeuvsaj8fDBAEAL+/s2bNPlgyKooRCYUFBQXl5OalIwBDoGbLu4cOHCQkJT00QFEWVlJSUlJQQiQQAEicwMPDZJcOVlJTOnDlDJA8wB3qGrAsLC3vumrCKioqhoaHizwMAEqehoSElJUV0B6Uncblc7BkF9AxZFxgY+NyewePx/vjjDyxLDwAvdObMmX+6/1llZWV+fr6Y8wCjoGfItHv37mVlZQkEguc+e/fu3dzcXDFHAgCJExgY+OyxVxEWi3X69Gkx5wFGUSAdAEjKysoyNzd/vLfz4cOHfD5fT09P9KGcnNyVK1esra3JBQQApmtqauLz+aampqIPu7u7Gxoahg0b9ngPx61bt8ilA/Jwv1b428qVK2tra+Pi4kgHAQBJxWazPT09W1paNDU1SWcBRsBxEwAAAKALegYAAADQBT0DAAAA6IKeAQAAAHRBzwAAAAC6oGcAAAAAXdAzAAAAgC7oGQAAAEAX9AwAAACgC3oGAAAA0AU9AwAAAOiCngEAAAB0Qc8AAAAAuqBnAAAAAF3QMwAAAIAu6BkAAABAF/QMAAAAoAt6BgAAANAFPQMAAADogp4BAAAAdEHPAAAAALqgZwAAAABd0DMAAACALugZAAAAQBf0DAAAAKALegYAAADQBT0DAAAA6IKeAQAAAHRBzwAAAAC6oGcAAAAAXdAzAAAAgC4KpAPAC1RWVtbX14tnrPr6+kePHmVnZ4tnuIEDB44bN048YwHIspaWltLSUvGMdfPmTYqirl69qq6uLp4Rra2t5eXlxTMWvAaWUCgknQH68tFHH506dYp0Clq4u7uz2WzSKQCkH5vN9vT0JJ2CLi0tLZqamqRTwD/C/gwJMGXKlICAANIp+tmmTZtaWlpIpwCQISUlJQMGDCCdoj+lpKQsW7aMdAp4AfQMCaCiojJixAjSKfqZuro6egaAOA0bNkzKtvv19PRIR4AXw3mgAAAAQBf0DAAAAKALegYAAADQBT0DAAAA6IKeAQAAAHRBzwAAAAC6oGcAAAAAXdAzAAAAgC7oGQAAAEAX9AwAAACgC3oGAAAA0AU9AwAAAOiCngEAAAB0Qc8AAAAAuqBnAAAAAF3QMwAAAIAu6BkAAABAF/QMAAAAoAt6BgAAANAFPQMAAADogp4BAAAAdEHPAAAAALqgZwAAAABd0DMAAACALugZAAAAQBf0DAAAAKALegYAAADQBT0DAAAA6IKeAQAAAHRBzwAAAAC6oGcAAAAAXdAzAAAAgC7oGQAAAEAX9AwAAACgC3oGAAAA0AU9AwAAAOiCngEAAAB0Qc8AAAAAuqBnAAAAAF3QMwAAAIAu6BkAAABAF/QMAAAAoAt6BgAAANAFPQP+1t3d3djYSDoFAEi2e/fukY4ADKJAOgC8WEtLS3Z2thgGSk5ObmxsnD9/vhjGamhoEMMoAPBYbm6umpoa3aNwudyvvvpqz549dA9EUdTNmzfFMAq8IfQMCZCdnW1nZye24X7++WfxDOTu7i6egQCAoqjp06eLbSxxTlnAcCyhUEg6A/Tl4cOH7e3tYhioo6PDwsKit7c3LS1t+PDhYhhRVVVVT09PDAMByLju7u76+nrxjLVy5crLly9/9dVXvr6+4hlx+PDhLBZLPGPBa0DPgL8EBAR8+OGHcnJyO3fu3LJlC+k4ACB5Hj16pK+vz+PxzMzMCgsLSccBRsB5oPCXgIAAFovV29vr7+9POgsASKTIyEiBQEBRVFFR0Y0bN0jHAUZAzwCKoqiGhobk5GQ+n09R1M2bN4uLi0knAgDJExgYKPqHoqJiWFgY2TDAEOgZQFEU9eSMoKSkdObMGYJhAEAS1dXVpaWliTZXeDzeqVOnSCcCRkDPAIqiqICAgMdn6nC53FOnTuHEHQB4JaGhoXJyf/9NuXPnTm5uLsE8wBDoGUDduXPn6tWroqOqIrW1tTk5OQQjAYDECQgIeHIaUVRUPH36NME8wBDoGUCFhITIy8s/+YiSkhImCAB4eRUVFfn5+U/2DB6PFxAQIDqMArIMPQOogICA3t7eJx/hcrmBgYFPPQgA8E9Onz6toPD0wo+NjY2pqalE8gBzoGfIutLS0tLS0mcfb25uTkpKEn8eAJBEAQEBPB7vqQcVFRVDQkKI5AHmQM+QdcHBwYqKis8+jgkCAF5SQUHBrVu3nn2cx+OFhob29PSIPxIwB3qGrAsMDHx2K4SiKB6PFxYW1tXVJf5IACBZTp8+/dzNFYqi2tvb//zzTzHnAUZBz/h/9u47IIprfxv4LCxNQECwIIqAqAjSVKQqUgXU2DHWoCgaNWpiriS58YLX3J8l1mhs2CvVqCggAgqydEWKKEgXsYFK77vvH3tfL0GEBXb3bHk+f8mwc86zwB6/c+bMjFhLTk4uLS2l0+kyn5GSkqqvrw8PDyedEQAEGovFunTpUltb26fRQ1pa+tO/KYrConIxh+e1ijUWi7Vr165PXwYHB1dXV69cufLTFkVFRRK5AEBofPz48bvvvvv0ZV5e3pkzZ7Zv384uMiiKkpeXJxQNBAKeowb/4+npWV5ejjkMAOi1iIgIV1fXqqqq/v37k84CAgHnTQAAAIBXUGcAAAAAr6DOAAAAAF5BnQEAAAC8gjoDAAAAeAV1BgAAAPAK6gwAAADgFdQZAAAAwCuoMwAAAIBXUGcAAAAAr6DOAAAAAF5BnQEAAAC8gjoDAAAAeAV1BgAAAPAK6gwAAADgFdQZAAAAwCuoMwAAAIBXUGcAAAAAr6DOAAAAAF5BnQEAAAC8gjoDAAAAeAV1BgAAAPAK6gwAAADgFdQZAAAAwCuoMwAAAIBXUGcAAAAAr6DOAAAAAF5BnQEAAAC8gjoDAAAAeAV1BgAAAPAK6gwAAADgFTrpAEDAx48fWSxWXV1dc3MzRVEfPnygKKqpqamuro7JZDIYDFlZWYqilJSUJCQk6HS6oqIiRVHKyso0Go1scgAQEOwBpLm5ua6ujqKo2tralpYWFov19OlTdXX1+Pj4wYMHUxQlJyfXfjzp16+fjIwM4ejAXzQWi0U6A3BTS0tLWVlZUVFRaWnpu3fv3r17V/mZtra2XrRMo9FU/05NTU1VVXXw4MHDhg3T0tIaMWKEtLQ0198RAPDfmzdviouLi4uLX79+/Wno+DSeVFRUNDY29q5lBQUFtf+v/XjCHka0tLSUlJS4+16ALNQZQqympiY7OzsvL6+4uLioqIg9KJSVlbHLCDk5uUGDBn36MHf4SNNoNEVFRTqdTqPRlJWVKYqSkpJSUFCgKKq+vr6pqYmiqKqqKiaT2dbWVl1dTVHU+/fvKyoqOpQs7969e/v2LfuARkJCYujQoVpaWtra2uzxYtSoUYaGhuz2AUAAtba25uXl5eTktB9GioqKGhoaKIqi0+kDBw78dFzx6d/sL6WlpWVkZPr160dRlIKCgpSUFEVRKioq7GZramooimpoaGBXJNXV1W1tbfX19exhhF2ytB9S3r17x46koqLSfhgZOXKkgYHBiBEjCP2EoK9QZwiT8vLyhw8f5uTkPHny5OHDh8+ePWMymdLS0sOGDdPR0dHR0VFXVx86dCj731paWhISfFp/8+HDh/Ly8levXhW2k5eXxx5o1NXVDQwM9PX1J0yYYGBgMG7cOEycApDy4cMH9gDCHknS09Pr6+spilJRUdH5jKamJp3Op9Przc3NZWVlnwaQT0NKUVERi8Xq37//qFGjPg0jpqamqqqq/AkGfYQ6Q6C9evWKwWAwGIzExMSsrKz6+npJScmRI0caGxsbGhoaGhoaGRlpa2sL7LKJkpKS7OzszMzMzMzMrKys3Nzc1tZWGRkZAwMDS0tLKysrGxsbTU1N0jEBRFl9fX1KSkp8fHxiYuLDhw/fvHlDUdTgwYONjIyMjIzYI4mBgYHAVv9VVVVZWVlZWVkZGRlZWVnZ2dnV1dU0Gk1bW9vMzMza2tra2trIyIhv9RD0FOoMwcJkMp88eRIfH5+QkMBgMIqKiiQlJY2MjKytrU1NTY2MjAwMDOTk5EjH7KXm5uYnT55kZWU9fvyYPeS1tLQMGzbM2traysrK2tra2NgYgwVA35WXl7MPURISEtLT01tbW4cPH25jY2NmZmZoaGhsbDxw4EDSGXuJxWIVFxezD12SkpISEhI+fPigoKBgbm7OHkksLS379+9POib8D+oMgfDixYuIiIiIiIjo6Oiqqqr+/ftbWFiw/+u1sLBgL5sQPQ0NDampqeyi6tNgYWtr6+rq6uLiMnLkSNIBAYRJXV1dTExMeHh4ZGRkQUEBnU5nH6KwJw6HDRtGOiBPsFisnJychIQE9kiSn58vKSlpYmLi4uLi6upqYWEhKSlJOqO4Q51BTHNzc3x8fERERHh4eHZ2dr9+/ezt7adNmzZ58uRx48aJ22eDPVjEx8dHRkZGRUVVV1ePGjXK1dXV1dXV1tZWeKdwAHgtJycnPDw8IiLiwYMHLS0t48ePd3FxmTp1qrm5uageonThzZs3CQkJUVFRERERhYWFKioqTk5OLi4uLi4u6urqpNOJKdQZ/Pbx48fr169fv349Ojq6trZWT0+P/b/p5MmT2VeZQ0tLS0JCAnvozMjIkJOTs7W1nTVr1rx584R3sheAi9ra2u7fvx8UFBQREVFSUqKqqurs7Mz+33TQoEGk0wmK3Nxc9oFcbGxsU1OTsbHx9OnT3d3djYyMSEcTL6gz+KS6uvrmzZuBgYGRkZEURTk5Obm5ubm6umppaZGOJtDKy8vZBUdYWFhTU5O9vb27u/vcuXMHDBhAOhoAvzGZzAcPHgQEBISEhLx9+9bU1HTmzJmurq5mZmbiNgPaI/X19ffv3w8PD79582Zpaamenp67u/vChQv19fVJRxMLqDN4q6GhISoqKigo6Nq1a42NjRYWFgsWLFiyZImamhrpaEKm05/k4sWLMcMB4uDhw4cXLlwIDg4uLy/X19dfsGDBokWLxowZQzqX8Hny5ElQUNCFCxeKiorYP8mvv/5aT0+PdC5RhjqDVx48eODn5xccHNzS0uLg4ODu7j5nzhz2HWygL2pqakJDQwMCAu7cuUNR1MyZM1evXu3o6Mi3m4UA8E1paenp06fPnj374sULfX39hQsXuru74z/FvmM/YCEwMDA4OPj169cTJkxYtWrV4sWLcaEKL6DO4LJ3795duHDh1KlTz549mzhxoqen54IFC3A/GV6oqqq6fv366dOnHzx4oKWl5enpuWLFCg0NDdK5APqqpaUlNDT01KlTd+7cGTRo0DfffLN06dJx48aRziWC2tra4uLizp8/HxQURKPR3N3dV69ebWlpSTqXSEGdwR0sFovBYFy8ePHixYtSUlJff/31mjVrxo8fTzqXWMjLyztz5szZs2crKirs7e29vLzmzJmD+3CAMHrx4sWVK1f+/PPPly9fsv+YZ8+ezb6fN/BUdXW1v7//iRMnHj16pKen5+Hh4enpiRPc3MGCvqmpqTl06BD7Zg9WVlZnz56tq6sjHUocNTY2+vv7s0+gaGho7Ny58/3796RDAXCEyWRGREQ4OTnRaLRhw4b961//Ki4uJh1KTKWkpHh5eSkqKsrKyq5YsSIrK4t0IqGHOqP3Xr58+dNPP6moqMjLy69bty47O5t0ImCxWKyCgoKtW7cqKysrKChs3LixsLCQdCKAL2psbDxz5gz7nIiTk1NoaGhrayvpUMCqqak5efKkvr4+jUabNm3a3bt3SScSYqgzeiMjI8PLy0tWVnbQoEE+Pj4VFRWkE0FHNTU1J06cGDVqlISExIwZMxgMBulEAH9TVVV18ODBYcOGSUlJLViwICUlhXQi6MSDBw9mzJhBo9GMjIxOnDjR0NBAOpHwQZ3RM9HR0c7OzjQazcDA4PTp042NjaQTQVdaWlquXr06ceJEiqImT54cGhpKOhEAq6SkZMOGDfLy8srKyt7e3mVlZaQTQTcePny4ePFiKSkpDQ2NPXv21NTUkE4kTFBncOrBgwdTp06lKMre3j4sLIzJZJJOBD1w79499kHJpEmTIiIiSMcBMfXy5csNGzbIyMiMGDHiwIED1dXVpBNBD5SWlm7ZskVRUXHgwIF79+6tr68nnUg4oM7oXnJy8owZMyiKsra2jomJIR0Hei8zM3PBggU0Gs3S0jIqKop0HBAj79698/b2lpOTGzZs2MGDBzEVKrwqKip8fHz69+8/cODAXbt24UxKt1BndCUrK4v935KFhcXNmzdJxwHuSEpK+lQ43rt3j3QcEHGVlZXt/1vCQbBo+FQ4Dh8+HIVj11BndC4/P3/+/Pk0Gm3ChAm3b98mHQe4LzY2dsqUKRRFubq64loh4IX6+vodO3b0799fTU1tz549uOJd9JSVla1bt05aWlpHR+fKlSs4n94p1BkdVVdXe3t7y8jIjB079q+//sLfjWiLjIycMGECnU5fv349rhsCbmEymf7+/pqamoqKiv/+97+xDkO0FRcXr1ixQkJCwsrKCtcNfQ51xv8wmczz588PGTJERUVl165dTU1NpBMBP7B/7+rq6vi9A1c8fPhw8uTJNBptwYIFpaWlpOMAnzx69GjKlCns33tJSQnpOAIEdcZ/JScnW1hYSEhILFu27M2bN6TjAL/V1tb6+PjIysqOHj0al79C75SXl3t5eUlKSk6aNCkhIYF0HCDg5s2b2tra8vLyPj4+WCLKhjqD9fLlS3d3dxqN5uTkhPP0Yq6goGDOnDkURbm5uRUUFJCOA0KjpaVl9+7dioqKmpqaV69exflWccZelyMvL6+trX39+nXSccgT6zqDyWSeOHFCSUlp5MiRN27cIB0HBEV0dPS4ceP69ev3+++/t7S0kI4Dgi4tLc3ExERWVtbX1xeLPYGtrKxsyZIlFEXNnz//1atXpOOQJL51Rn5+voODA51O37hxI27uBh00Nzfv2rVLVlbW2Ng4NTWVdBwQUPX19d7e3nQ63cbG5unTp6TjgMC5f//+6NGjlZWVT5w4IbazXBKknhNLUGtr66FDh4yNjd+9e5eQkHDo0CEFBQXSoUCwSElJeXt7Z2VlDRgwwNLSctOmTXV1daRDgWCJi4szNTU9fvz43r17Y2Nj9fT0SCcCgWNra/v48eM1a9asW7fO1tY2NzeXdCICxK7OyMjIsLS0/Omnn3788cfU1FQzMzPSiUBw6erqRkdHnz59+tKlS8bGxtHR0aQTgUD4+PHjmjVrpk6dOmrUqOzs7E2bNklIiN1YChySk5PbtWtXWlpafX29qampr69vS0sL6VB8JUafjdbW1t27d5uZmcnJyaWnp/v6+kpLS5MOBYKORqMtX748OzvbxMTEyclpzZo19fX1pEMBSezlOzdv3jx37lxoaOiwYcNIJwIhYGJikpSUtHPnzr1791pbWz9//px0Iv4RlzqjsLBwypQp27dv379/P2Y4oafU1dWDg4MvXrwYEBBgYWGRnZ1NOhEQ0NTU9MMPPzg5OdnY2OTk5Cxfvpx0IhAmdDp906ZNaWlpbW1t48ePP3v2LOlEfCIWdUZQUNCECROqq6uTkpI2bNhAo9FIJwKhtGTJkszMTBUVFTMzs927dzOZTNKJgH+ePn1qaWl56tSp48eP+/v7q6iokE4EQklPTy85OXnLli2rVq2aN29eZWUl6UQ8J+J1RlVV1dKlSxcuXLh8+fKHDx8aGRmRTgTCTVNTMyYmxtfXd9u2bdOmTSsvLyedCHiOxWKdPHly4sSJUlJSjx498vLyIp0IhBudTvf19Y2KikpJSRk3blxERATpRLwlynXG/fv3DQ0N7927FxkZeejQIRkZGdKJQBRISkp6e3s/ePCgqKjIxMQkNDSUdCLgoTdv3ri5ua1fv37r1q0MBkNXV5d0IhARdnZ2GRkZNjY206dP37p1qwgvDhXNOoPFYv3++++Ojo4TJ07MzMx0dHQknQhEjbm5eXp6+vTp02fNmvXLL7+0tbWRTgTcl5iYOGHChLy8vLi4OB8fHzqdTjoRiJQBAwYEBQX5+fkdO3bMzs5OVOdHRbDOqK2tXbhw4c8///yf//wnJCREVVWVdCIQTYqKimfPnr1w4cKhQ4ccHR3fvHlDOhFw08mTJ6dOnWpsbJyWlmZpaUk6DoislStXpqWlffjwwcTEJCYmhnQc7hO1OiMvL8/S0vLevXsRERHe3t5Y8gm8tnTp0vj4+JKSkokTJyYnJ5OOA1zQ2Ni4atWqtWvXfv/996GhoVjyCbw2ZsyYpKSkKVOmTJs2bffu3aTjcJlI1RmhoaHm5ubS0tJpaWk4VwJ8Y2pqmpqaqq+vb2tre+rUKdJxoE9evHgxZcqUoKCga9eu7dq1CzfgAv5QVFQMCgr67bff/vnPfy5evFiUbkAsIh+htra2n3/+edasWe7u7gkJCSNGjCCdCMSLqqpqWFjY5s2bvby81q5d29zcTDoR9MadO3dMTU2bmpoePXo0e/Zs0nFAvNBoNG9v79u3b0dGRlpZWRUUFJBOxB2iUGfU1dXNmzfv4MGDp06dOnHiBK4rASIkJSV37doVHBx85coVZ2fnDx8+kE4EPXP06NHp06dPmzYtMTFx5MiRpOOAmJo2bVpaWpqkpKS5uTmDwSAdhwuEvs54/fq1nZ3dgwcP7ty5s3LlStJxQNzNnTs3ISGhqKho0qRJYnVrYaHGYrF8fX03bNjw66+/Xr58uV+/fqQTgVjT0tJKSEhwcHBwcHC4cuUK6Th9Jdx1Rk5OjqWl5fv37xMSEqZMmUI6DgBFUdS4ceOSkpKUlJQsLS3j4+NJx4FuNDU1LV68eOfOnRcuXPD19SUdB4CiKEpWVtbf3/+nn35aunSpsP9ZCnGdERMTY21tPWTIkMTExDFjxpCOA/A/6urqsbGxVlZWTk5OAQEBpOPAF1VWVjo6Ot65c+fOnTtLly4lHQfgf2g0mq+v7/Hjx//zn/94enoK7428hLXOOH/+vKurq6OjY0xMzMCBA0nHAehIXl7+r7/+WrVq1aJFi4T9cERU5efnW1lZvXz5MiEhYerUqaTjAHTCy8srNDQ0KCho+vTpVVVVpOP0hlDWGTt37lyxYsUPP/wQGBgoJydHOg5A5yQlJQ8fPrxnz54dO3b88MMPLBaLdCL4n5SUFHNz8wEDBiQlJeEBziDIXFxcYmJisrKy7Ozs3r59SzpOj9GEbuz75z//uWvXrsOHD69bt450FgCOBAQELFu2zMPD4/jx47gfgyCIi4ubMWMG+z4ZOFYBoVBcXOzk5ESn06OiojQ0NEjH6QFhqjNYLNaWLVv++OMPPz+/FStWkI4D0AO3b99esGDBrFmzLly4ICUlRTqOWLt3795XX31lb28fGBiIy+BBiLx+/drZ2bm6ujoqKkqIHuknNIdWTCbTy8vryJEjV69eRZEBQmf69Onh4eG3b9+eO3duY2Mj6Tji69atW25ubl999VVISAiKDBAuQ4YMiY2NHTx48OTJk7Ozs0nH4ZRw1BltbW0rV668ePFiYGDgggULSMcB6A1bW9vo6OiEhAQ3N7fa2lrSccSRv7//3Llzv/nmm4sXL+LhqyCMVFRUIiMjdXR0HBwcHj9+TDoOR4Sgzmhqapo/f35wcPDt27dxJ2AQamZmZpGRkZmZmdOnT6+uriYdR7ycOnVqyZIlGzduPHbsGFbJgPBSUlK6c+eOgYGBvb19SkoK6TjdE/T1GS0tLQsWLLh///7t27etra1JxwHgguzsbCcnJ11d3YiICHl5edJxxMLZs2c9PT23bdu2fft20lkAuKChoWH+/PkMBiM6OnrChAmk43RFoOsMJpO5bNmy69evh4eH43afIEpyc3NtbW3HjRt369YtWVlZ0nFEXEhIyNdff/3TTz/t2LGDdBYArmlubp4zZ05KSsq9e/fGjRuf78ZYAAAgAElEQVRHOs4XCW6dwWKx1q5de+7cuRs3bri4uJCOA8BlGRkZdnZ2kydPDg4OxhUovHPz5s358+d/++23hw4dIp0FgMsaGhpcXV2fPn0aGxsrsLeBEdw648cff/zjjz+uXbs2Y8YM0lkAeCIpKcnZ2dnZ2TkgIEBSUpJ0HBEUHR09Y8aMRYsWnT59mkajkY4DwH3V1dVOTk6vXr2Ki4vT0tIiHacTAlpn/PLLL3v27Ll06dLXX39NOgsAD8XExEyfPn3hwoVnzpzB4kTuSkxMdHZ2nj179vnz5/GzBRH28eNHBweH6urquLg4dXV10nE6EsTP3n/+85/du3efOXMGRQaIPHt7++Dg4KtXr37//feks4iU1NRUFxcXZ2fns2fPosgA0aasrBwWFiYpKens7FxZWUk6TkcCN59x5syZVatWHT16dO3ataSzAPBJUFDQokWLfvvtt59++ol0FlFQUFBgaWk5ceLE69evS0tLk44DwA9lZWWTJ08eOnRodHS0QK0uF6w64/79+9OmTfP29v73v/9NOgsAX504ceLbb7+9cOECnk7eR+/fv7eyspKXl4+NjVVQUCAdB4B/nj17ZmVl5eDgEBAQIDjTeAJUZ+Tk5FhbW0+bNu3q1atYsQVi6Pvvvz969GhERISdnR3pLMKqubnZ1dU1Nzc3KSlp2LBhpOMA8FtcXJyzs/OmTZt2795NOst/CUqd8erVK0tLS01Nzbt37+KhAyCemEzm/Pnz4+LiEhISRo8eTTqO8GGxWN98882NGzcePHhgZGREOg4AGf7+/osXLz58+PD69etJZ6EoAakz6uvr7ezsKisrExMTBw4cSDoOADENDQ329vZv375NTEwcNGgQ6ThC5tdff92zZ8/t27ednJxIZwEgafv27Tt27Lh27dpXX31FOosA1BltbW3z5s1jMBgJCQmjRo0iGwaAuIqKCktLywEDBty7d69fv36k4wiNM2fOeHp6Hjt2DEvIAVgs1sqVK0NCQuLi4kxMTMiGIV9nbNmy5dixYzExMRYWFmSTAAgI9lqlGTNmXLx4kXQW4fDgwQMHB4etW7f+9ttvpLMACAT2WqW8vLyHDx+SnRwlXGf4+/svWrTo7NmzHh4eBGMACJqoqCgXF5eDBw9u2LCBdBZB9/r16wkTJrCvYsUScoBPPnz4YGZmpqmpGRkZSafTScUgWWc8e/Zs0qRJK1aswHMHAD63Y8eOHTt2REdHT548mXQWwdXS0uLg4PDmzZuUlBQlJSXScQAES2ZmpqWl5bp1637//XdSGYjVGTU1Nebm5srKyvfv38eNdAA+x2Kx5s+fn5CQ8PDhw6FDh5KOI6DWr19/4cKFpKQkAwMD0lkABNHly5eXLVvm7+/v7u5OJACZOuPTAJqWlqahocH/AABCAeV414gPoABCYcOGDefPnydVjpOpMzAhDMAh9unFlStXHjx4kHQWwZKRkWFlZbV+/fo9e/aQzgIg0MieXiRQZ0RGRrq6uh46dAgL3AA4cfXq1SVLlly5cgVPFvzk48eP48eP19bWvnPnDsEFbgDCory8fMKECVZWViEhIXzumt91xrt374yMjOzs7K5cucLPfgGE2saNGy9cuPD48WMtLS3SWQTCokWLYmNjHz9+jLuZAXAoNjbWwcHhzz//XLNmDT/75XedMWvWrEePHmVmZqqoqPCzXwCh1tTUNGnSJEVFxdjYWElJSdJxCLtw4YKHh8etW7fc3NxIZwEQJv/85z8PHjz48OFDPT09vnXK1zrj2LFjGzZsiI6Onjp1Kt86BRANT548MTMz+/nnn7dt20Y6C0lFRUUmJiaenp779+8nnQVAyLS2tk6ePLm5uTkxMZFvS8v5V2fk5+ebmppu3rx5x44d/OkRQMQcOnToxx9/jIuLs7S0JJ2FDCaTaW9vX1FRkZqaKicnRzoOgPApKCgwNTVdt27drl27+NMjn+qMlpYWGxubtra2xMREKSkpPvQIIHpYLNbMmTOfPn2anp7ev39/0nEI2L59+86dO1NSUvA4VoBeO336tJeX1927d+3t7fnQHZ/qDG9v7z///PPhw4djxozhQ3cAourt27dGRkZubm5nzpwhnYXfUlNTra2t9+7du3HjRtJZAITb119/HR8fn5GRoaqqyuu++FFnPHjwYOrUqSdPnvT09OR1XwAi79atW1999VVISMicOXNIZ+Gf+vp6Y2NjXV3dsLAwPMQEoI/ev39vbGw8efJkPlz7yfM6o7Gx0dTUVEdH5/bt2zztCEB8eHp6RkREPHnyRFlZmXQWPtm6devJkydzcnJwC3YAroiIiHB1dQ0NDZ0xYwZPO+J5nfHrr78ePHgwKytLW1ubpx0BiI+qqip9ff0ZM2acOHGCdBZ+yMjIMDMzO3LkiJeXF+ksAKJj6dKl9+7dy8nJ4elNQnlbZ2RlZU2YMGHfvn3fffcd73oBEEMBAQGLFi26e/eug4MD6Sy81draam5urqCgcP/+fZwxAeCiyspKfX19d3f3w4cP864XHtYZTCbTxsaGyWQyGAzcWQiA62bPnp2Tk5ORkSHaV3ju2rXL19c3PT197NixpLMAiJqLFy96eHjExsba2NjwqAsJHrVLURT7pmOnT59GkQHAC0ePHn337t1vv/1GOggPPX/+/N///rePjw+KDABeWLZsmZub26pVqxobG3nUBa/mM0pKSsaNG7dlyxZfX19etA8AFEX9+eefmzdvTk5OHj9+POks3MdisZycnN69e5eWlob77gDwCK//v+ZVnTF9+vTi4uJHjx7JyMjwon0AoCiKyWROmTKltbU1MTFR9NYunDt3btWqVUlJSRMnTiSdBUCUHTx40NvbOzMzkxf3uOJJnREWFjZ9+vTIyEgnJyeuNw4A7T158sTExOT06dPLly8nnYWbampqxowZM2fOnD///JN0FgAR19bWNn78+OHDh9+6dYvrjXO/zmhtbTUxMdHT0wsODuZuywDQqbVr116/fj0vL0+Ubkb+008/nTx5Mi8vT01NjXQWANF37949e3v78PBwFxcX7rbM/XWgR44cef78Od8e0AIAO3bsaGpq2rNnD+kgXFNYWHjo0CFfX18UGQD8YWdnN3v27B9++KGlpYW7LXN5PuP9+/ejR4/28vL6v//7Py42CwBd279//z//+c+cnBzRuCHe3Llznz59mpmZieWfAHxTWFior6+/Z88e7j5CiMt1xrp1665duyZi87cAgq+lpcXQ0NDQ0DAoKIh0lr5iz9+GhYW5urqSzgIgXry9vf38/Lh7vpKbdUZOTo6xsbGfn5+Hhwe32gQADt26dWvmzJn379+3tbUlnaX3mEzmpEmTBg8ejCciAfAfe/313Llzjxw5wq02uVlnuLi4VFZWJicnS0jw8PZfAPAlLi4u7LtNCO81rqdPn/72228zMzP19PRIZwEQR2fOnFmzZk1mZia3bo7HtTrjwYMHU6ZMiYmJsbOz40qDANBTmZmZpqamAQEB8+fPJ52lN5qamkaPHj19+vSjR4+SzgIgpphMprGxsb6+fkBAAFca5FqdYWdn19bWFhcXx5XWAKB3Fi5c+OTJk8zMTGGcVjxy5Mg//vGP58+fDxs2jHQWAPEVEhKyYMGC9PR0Y2PjvrfGnTojKirKyckpNjZ2ypQpfW8NAHotLy/PwMDg/PnzixcvJp2lZxobG3V1dRcsWHDgwAHSWQDEGovFMjc319DQ+Ouvv/reGnfqDCsrKyUlpfDw8L43BQB9tHz58qSkpJycHDqdTjpLD+zbt8/Hx6egoGDw4MGkswCIO/a68uTk5EmTJvWxKS7UGbdv354xY0ZSUpK5uXkfmwKAvisoKBg7duzJkyeF6Mqvuro6HR0dDw+P3bt3k84CABRFUZaWlioqKmFhYX1sp691Bnt2RV1d/caNG32MAgDcsmrVqqioqLy8PGlpadJZOLJz587/+7//KygoGDRoEOksAEBRFBUZGTlt2rS4uLjJkyf3pZ2+1hl//fXXvHnzHj16ZGJi0pd2AICLSkpKRo8e/ccff6xZs4Z0lu5VV1dra2uvW7dux44dpLMAwP9MmTJFWlo6KiqqL430tc4wNzcfNmxYSEhIXxoBAK779ttv7969m5ubKykpSTpLN37//ffffvutpKREWVmZdBYA+J+YmBgHB4c+rtLoU50RFxdna2ubkJBgaWnZ60YAgBcKCwtHjx7t7+8v4PfSaGlpGTlypLu7+969e0lnAYCOzM3NtbS0+nIvjT7VGbNmzaqsrIyPj+91CwDAO3Pnzi0rK0tJSSEdpCuXLl1asWJFQUGBpqYm6SwA0NHVq1eXLVuWm5s7cuTI3rXQ+zojLy9v7NixwcHBc+bM6V0LAMBTDAbDxsYmPj7e2tqadJYvGj9+/NixYy9fvkw6CAB0oq2tbfTo0TNnzjx48GDvWuh9nbF27dq7d+/m5eUJ/tlfALFlZWU1ZMiQa9eukQ7SuejoaEdHR65cow8APHLgwIFt27aVlJSoqqr2Yvde3pm4srLy0qVLW7ZsQZEBIMh++OGHGzduPHv2jHSQzu3bt8/Ozg5FBoAgW7VqlZSUlJ+fX+9272WdceTIERkZmW+++aZ3uwMAf8yZM0dHR+fw4cOkg3Ti2bNnERERW7ZsIR0EALqiqKjo5eV1+PDh5ubmXuzemzqjubn52LFj69atk5eX78XuAMA3kpKSmzZtOnfu3IcPH0hn6Wj//v1jxoxxc3MjHQQAurFx48aKioreXXXSmzrj+vXrFRUVXl5evdgXAPjMw8NDUlLy0qVLpIP8TW1trb+///r162k0GuksANANDQ2NWbNmnTx5shf79qbO8PPzc3NzGz58eC/2BQA+U1BQcHd37/W5VR65cuVKa2vrkiVLSAcBAI6sWrUqPj4+Jyenpzv2uM4oKiqKiYlZvXp1T3cEAFJWr16dlZWVnJxMOsj/+Pn5zZ8/X0VFhXQQAOCIk5PTyJEjz5w509Mde1xnnDp1avDgwa6urj3dEQBIMTc3NzExOXXqFOkg/5WZmZmWlobDFQAhQqPRPDw8zp0719TU1KMde1ZntLa2njt3ztPTk06n92hHACBr5cqV/v7+1dXVpINQFEUdP358zJgxNjY2pIMAQA94enpWVVX19PHsPaszbt269erVKw8Pjx7tBQDELVu2jMlk9uUhBdzS0NBw9erV1atXYwUogHBRV1d3dXXt6WKvntUZfn5+zs7Ovb7JOQCQoqysPHfuXEFYDRoQEFBfX79s2TLSQQCgx1avXh0dHZ2fn8/5Lj2oM169enXnzh1PT8+eBwMA8latWpWampqdnU02xrlz52bNmjVo0CCyMQCgF1xdXdXV1S9evMj5Lj2oM4KDg/v16zdjxoyeBwMA8qZMmaKpqRkYGEgww6tXr+Lj43E5K4CQotPp7u7uPToD24M6IzAwcNasWXJycj0PBgDk0Wi0efPmkV2iERgY2K9fv2nTphHMAAB94e7unpubm5GRweHrOa0zysrKEhIS3N3dexsMAMhzd3fPy8t7/PgxqQCBgYGzZ8+WlZUlFQAA+sjCwkJLS4vzmVFO64ygoKD+/fs7Ozv3NhgAkGdubt6jAYK7Xrx4kZiYiMMVAKFGo9Hmz5/v7+/PYrE4eT2ndQb7pImMjEwfsgEAYewBIiAggMMBgrsCAwOVlJScnJz43zUAcJG7u3thYeGjR484eTFHdcaLFy+Sk5NxFAIgAno0QHBXYGDgnDlzcLgCIOzMzMxGjhzJ4cwoR3WGv7+/srKyo6Nj34IBAHlmZma6urr8P3VSWlqampqKwxUA0cD5qROO6ozr16/Pnj1bWlq6z8EAgLx58+Zdu3aNz52GhIQoKys7ODjwuV8A4IUFCxaUlpamp6d3+8ru64wPHz4kJydPnz6dG8EAgDw3N7f8/Pwe3dGv78LDw52dnaWkpPjZKQDwyPjx44cOHRoREdHtK7uvM+7cuUOj0XAUAiAyrKyslJWVw8PD+dZjXV3dgwcP8JxnAJFBo9GcnZ25U2eEh4ezRyVuBAMA8uh0uoODAycDBLfcu3evqakJF8YDiBIXF5eEhIT37993/bJu6gwWi3X37l0chQCIGBcXl3v37jU0NPCnu4iICFNTU3V1df50BwB84OzsTKPRYmJiun5ZN3VGenr6q1evUGcAiBgXF5fGxsa4uDj+dBcREYFhBEDEqKioTJo0qduZ0W7qjPDw8CFDhhgZGXEvGACQN2zYsHHjxvHn1EleXl5BQYGLiwsf+gIAfnJ1dQ0LC+v66tbu6wxXV1cajcbVYABAnqurK3+WgoaHhysrK1tYWPChLwDgJxcXl1evXmVlZXXxmq7qjJqamuTkZByFAIgkFxeX3Nzc0tJSXnd09+5dR0dHOp3O644AgM/Gjx8/aNCgyMjILl7TVZ2RmJjY2to6efJkbgcDAPIsLCykpaXj4+N52guLxUpMTLS1teVpLwBAhISEhI2NTdfDSFd1RkJCwsiRI7FEHEAkycnJmZqaMhgMnvaSk5Pz/v17a2trnvYCAKRYW1szGIwulmh0VWcwGAyMDgAizMbGhtd1BoPBkJeXNzQ05GkvAECKtbV1RUVFXl7el17wxTqjra0tOTnZysqKN8EAgDxra+usrKyqqiredcFgMCwsLLA4A0BUjR8/vl+/fl0csXyxzsjMzKypqcF8BoAIs7a2ZjKZSUlJvOsC06IAok1KSsrMzKw3dQaDwVBWVtbX1+dNMAAgb9CgQaNGjeLdqZM3b94UFBSgzgAQbV2fge2qzrC0tJSQ4OjB8QAgpNhruHjUOIPBkJCQMDc351H7ACAIrK2t8/Ly3r592+l3v1hGJCUlYXEGgMiztrZOTk5ua2vjReOJiYnjxo1TUlLiReMAICAsLS1pNNqXzsB2Xme8f/++uLh44sSJvAwGAORNmDChrq7u+fPnvGg8PT0dwwiAyFNWVtbR0Xn8+HGn3+28zmDfQxSXogGIPH19fTqdnpmZyYvGs7KyMIwAiANDQ8Mv3X288zojMzNzwIABGhoavEwFAOTJyMiMGjWq68cT9M7r16/fvn2LpzACiAMjI6MvHa58cT4DowOAmDA0NOTFfAa7TcxnAIgDQ0PD/Pz8urq6z7/1xfkM1BkAYqKLCc++yMzMVFdXHzhwINdbBgBBY2hoyGQyc3JyPv9WJ3UGk8l88uQJjkIAxISRkVFxcXF1dTV3m8W0KID40NXVlZeX7/SIpZM6o6CgoLa2FgMEgJgwNDRksVjZ2dncbRbTogDiQ0JCQl9fn9M6IzMzU0JCwsDAgPfBAIA8LS2t/v37c3eJRmtr69OnTzEtCiA+vrTSq5M6Iy8vT1NTU15envepAIA8Go2mp6eXm5vLxTaLi4ubmprGjh3LxTYBQJDp6+s/e/bs8+2d1BlFRUU6Ojq8jwQAgkJbW7u4uJiLDRYVFbGb5WKbACDItLW1X7161djY2GF7J3VGcXGxlpYWP0IBgGDQ1tZmVwbcUlRUpKioqKqqysU2AUCQaWlpsVis0tLSDttRZwAApaWlxd06o6SkBJMZAGKF/ZH/fCTpWGcwmczS0lLUGQBiRUtLq7q6+sOHD9xqsKioCMMIgFhRUVFRUlL6/AxsxzqjvLy8qakJByIAYuVLByK9hmlRADHU6cxoxzqDXYlggAAQKyNGjJCQkOBinYH5DAAx1OmK8o51RlFRkbS09NChQ/kUCgAEgIyMjLq6OrcuOWlsbHzz5g2mRQHETacryjvWGaWlpZqamhISnT/3BABEFRcvbS0pKWGxWCNGjOBKawAgLLS0tLqfz3jz5s2QIUP4lAgABMbgwYPfvn3LlabY7airq3OlNQAQFkOGDKmoqGAyme03dqwzKisr1dTU+JgKAASCmppaZWUlV5qqqKigKGrAgAFcaQ0AhIWqqiqTyexw5VrHOqOiogK31gEQQ6qqquz6oO8qKyv79+8vLS3NldYAQFiw5yk6HLFgPgMAKIqiVFVVuTifgWEEQAyx5yk6HLFgPgMAKIqi1NTUuDifgWEEQAxxOp+BAQJADKmqqjY2NtbV1fW9KUyLAognWVlZeXn5ruYzmpqaamtrMUAAiKFOD0R6B9OiAGLr8zOwf6sz2N/DAAEghtgffK7UGZjPABBbn1+59rc64+PHjxRFqaio8DVUH5w7d45GowUHB3O+S2Nj49atW3V0dOh0Oo1Gq62t5V08wREREUGj0Q4ePEg6CHf09PeelpZGo9F8fX15Gap7vfhz5Sf2ZahceZRaVVWVsrJy39vhG4wkHMJIgpGkWyoqKh2GEXr7LxobGymKkpGR4Wso/tq5c+fvv/9OOgWAwGF/8JuamvreVGNjo2gPIxRGEoAvkJGR6TCM/G0+o7m5mRL1OuPGjRtKSko5OTltbW0sFktBQYF0IgCBwL7dBVfqjKamJtEeRiiMJABfICMjw64lPvnbfAZ7iBHtu+uUlZWNGTNm7NixpIMACBYpKSkJCYkOA0TvNDc3i/YwQmEkAfgCaWnp7uczBHaA+Pjx44YNG9TV1eXk5CZOnHjr1q3PX8Nisc6cOWNlZaWoqCgnJ2dsbPznn3+yWCyKojZv3kyj0SorK1NSUmg0Go1GW7t2LXuvhoaG7du3jx07VlZWVklJycHB4c6dO5/a/HRKMjY21tbWVlFRceLEie2337t3z8rKSl5efvjw4bt27WLvdfjw4TFjxsjKyurp6QUFBXHyBj81GB0dbWVl1a9fv0GDBq1evfrdu3fdhun6LXzCScs9fTtxcXFLlizR1dWVkZEZOHDgzJkzGQxGj95U1/r4e+9UF5kTExNpNNqGDRs67BIYGEij0fbu3cthj5zEFjSfDxC909TUJLDDCIWRpMswGEkwkvTR5+dNKFY7oaGhFEXV19ezBE9DQ4OJiUn75DQabeHChRRFBQUFsV/DZDKXLFny+dtevXo1i8XatGlTh+1r1qxhsVhNTU3W1tYdvkWj0Y4dO8ZuNjw8nKKoBQsW0On/nf4xNTX9tH3hwoWftrPt379/69at7bdISEikp6d3+x4/dSQpKdl+dz09vZqami7CcP4Wum25p2/n1atXn/28KTqdHhsby3nXPP29s1is1NRUiqJ8fHw4zGxmZqaoqNghnq2trby8/IcPHzjpkZPYAqh///5+fn59b0dOTu78+fN9b4cXMJJ0EQYjCUaSvlu1apWzs3P7LX+rM0JCQiiKam1t5W8qjuzZs4eiqDFjxkRFRdXU1BQWFq5bt479c//0475w4QJFUYaGhmFhYZWVlbW1tbGxscbGxhRFJSQksF+jpKRkbm7evuV9+/ZRFKWpqRkaGlpVVVVaWurr6yshISErK/vq1SvW///7pihq5cqVubm5n34+n7Zv3ry5uLi4trY2ODhYSkpKSUlJUVHx1KlTb9++rays3LJlC0VRy5cv7/Y9fmrQw8Pj+fPntbW1cXFxhoaGFEX9+uuvHV7TPgznb4GTlnv0dl6/fu3k5BQaGvrixYvm5uY3b94EBgbKy8u7urpy/qZ4/XvvMDp0m/nixYsURR09evRTjCdPnlAU9e2333LYIyexBdDAgQPZx1J9JCkpefXq1b63wwsYSTq8BiMJRhLuWr9+va2tbfstf6szrly5IikpyddEHDM3N6fRaNnZ2e03Ojg4tP9x29nZSUpKlpeXt38N+/fq7e3N/vLz0cHCwoKiqMTExPYbvby8KIo6ceIE6///fVtYWDCZzPavYW93cXFpv3HevHkURe3bt+/TltbWViUlpYkTJ3b7HtkNTpo0qX1HBQUFUlJSenp67V/TIQyHb4GTlnvxdtLS0hYsWDB06ND2hy/Dhg3j/E11gSu/9w6jQ7eZm5qahgwZMm7cuE+vX79+PUVROTk5HPbISWwBpKGhsX///j420tLSQlFUSEgIVyJxHUaS9q/BSIKRhOu+//57CwuL9ls6rs8Q2LOq+fn5GhoaBgYG7Te6uLi0//LJkydtbW3Dhw+n0+mSkpISEhISEhLsXUpLS7toWVVVlf0B+2TGjBnsb33a4ujoSKPRPt/d1ta2/ZcjRoygKGrKlCmftkhKSmpoaLx584aDd0lRFOXs7Ny+Ix0dndGjRxcUFLR/TYcwHL4FTlru6dtJSEiwsrIKCgoqLy9vbW399LKGhoaevqlO8eL33m1maWnptWvXZmdnx8XFURRVW1t78eJFZ2fnT4v+uu2Rk9gCqJMTqz0n4Mu8MJK0fw1GkvZfYiThis+vN/lbncFisSQkOj7xRIgwmUyKotra2tra2j7VvOxvdb2KvtOPfQdfuk2qrKzs5019vpGdjVs+D8PJW+BET9/Orl27mpubfXx88vPzGxoa2D/2MWPGcCUMh3r6e+ck89q1a6WlpY8ePUpR1MWLF6urq9ufle/1X5qAk5SU7PsfKrsFjCRfgpGk/UaMJD3qUShISEi0tbX9bUv7L6SkpAT2venq6r58+ZI9ofRJRERE+y/19PT69ev38ePHz2dyurh1mq6ubkVFRUpKSvuNYWFh7G9x9U1wJDIyktVusXFhYWFeXt7IkSO72IXDt9CLlrtVWFg4ePBgX1/fkSNHysrK0mi0goKC58+f9/1NsfHi985J5sGDBy9cuPDatWuvX78+duzYqFGjXF1dOe+Rk9gCiCv3vWDPZGAkYcNIwiGMJCIzkjQ3N3cYRv5WZ8jIyLS0tHC3XuaWefPmsVisefPmxcTE1NbWFhUVrV+/Pjo6uv1rPD096+vrHR0db9269e7du+bm5pKSktu3b8+bN6/DK9tbsGABRVELFy4MCwurrq4uKyvbsWPHyZMnZWRkvvrqK56/sc+kpKR4enrm5+fX1dXFx8fPmTOnpaVl/vz5XezC4VvoRcvd0tTUfPv27ZEjR6qqqqqqqsLCwtzc3D7/E+p117z4vXOYedOmTS0tLStXrszKyvruu+/aH04f90wAACAASURBVOd12yMnsQUQV65HlZaWptFoAltnYCTpYheMJBhJ+q6Tw5X2BdSNGzcoimpsbPy8tiKOw6uSPDw8On3n4eHh7Nd8vnqrqanJysrq8106XMp14MCBDpE63c5eRJ2VldV+o4GBgYaGRrfvkd3g/Pnzu71mrEOnHL6FXrTc7du5fv16h05NTU3HjRunqqrKeddd4MrvvcPqrW4zf8L+qfbv37+6urr99m57FMar0VgsloqKCnu5Xx/JyMhcvHix7+3wAkaSLjrFSIKRpO/WrFnj4ODQfkvH+QyKSzce5jpZWdl79+6tW7du8ODBsrKypqamf/31V4flMDQa7ezZswEBAY6OjioqKtLS0jo6OrNnz/7rr78cHR2/1LK0tHRUVJSPj8+YMWOkpaUVFRXt7OzCw8M/3XuHz6ytrcPDwydNmiQnJ6empubp6RkXF9f1XY05fAu9aLlbs2bNunz5spGRkZycnLq6+po1a6Kjoz+fe+9117z4vXOYmaIo9g9w5cqVioqKPeqRk9gCiFv3C+fW/b54ASNJF7tgJMFI0nfdzGfExMRQFPXu3Tv+Vj/wX1863BFqQv2m2Hd+zM/PJx2ET+h0Olfue6Gmptb+ngHAZ0L9ofsSoX5TYjWSLF68eM6cOe23/O1+bewaRGBPrALwTVtbW1RU1LFjx6ZMmdLHBW7Cgslktra2cuV6VGlpaQwjAJRYjiSfz2f87byJgC8UF3aPHz+mfdns2bNJByRAMH8mvr6+dDrdxcWlqanJ29ubSAb+Y5/p4Mp5k88voAcuEsxPDVmC+TMR25Gkw+GK0KzPAOCzoUOH7t+/v/1FaKKNi/fX4sr9vgBEgxiOJB2GERqr3bXIxcXF2traKSkpZmZmfM8GACSVlpaOGDEiKSnJ3Ny8j01NmjRp6tSp7EczAIBYsbCwsLGx+fRAWqrDfIaamhpFURUVFfzOBQCksT/47EGgj1RVVSsrK/veDgAIncrKyg73mf1bnaGgoCArK4sBAkAMsT/4X7ordo+oqanhcAVAPFVUVHRVZ1AUNWDAAAwQAGKooqKCTqcrKSn1vSnMZwCIp9bW1qqqqm7qDAwQAOKpsrJywIABXHmMlqqqKg5XAMTQ+/fvWSxWh9OvHesMNTU11BkAYqiiooIrizMoHK4AiCv2AUb38xk4EAEQQ5+v3uo1NTW19+/fd3g2NACIvE6Xk3cyn4E6A0AMcXc+g8lkfvz4kSutAYCwYE9kDhgwoP1GzGcAAEVxez6Doqh3795xpTUAEBYVFRX9+/fv6n6gFEUNHz68pKSEj6kAQCAUFxcPHz6cK02x2yktLeVKawAgLEpKSjQ1NTts7FhnaGlpVVdXf/jwgV+pAIA8Fov14sULbW1trrQ2YMAAJSWl4uJirrQGAMKiuLhYS0urw8aOdQZ7oCkqKuJPJgAQBOXl5Y2NjZ8PEL02YsQI1BkA4qaoqOjzw5WOdcaIESMkJCQwQACIFfahBbfmM9hN4XAFQNwUFRV1P58hIyMzZMgQDBAAYqWoqEhaWnro0KHcalBLSwuHKwBipbGx8fXr193PZ1AUpa2tjaWgAGKluLiYPZfJrQZRZwCIm5KSEhaL1f18BkVRWlpamM8AECudznb2hZaW1ps3b+rr67nYJgAIsi+dfu28zsCBCIBYKS4u5uLiDIqitLW1WSwWZkYBxEdRUZGSkpKysnKH7Z3UGaNGjcrPz8c9gwHER15enq6uLhcbHDlyJI1Gy83N5WKbACDInj9/PmrUqM+3d1JnjBs3rrGx8fnz57xPBQDkvX///uXLl4aGhlxsU0FBQVtbOysri4ttAoAgy8zMNDIy+nx753UGnU7PzMzkfSoAII/9Ye90gOgLIyMj1BkA4iMrK6vTw5VO6gwZGZlRo0ZhgAAQE5mZmQMGDODiRa1sRkZGOFwBEBOvX79++/Ytp3UGhQECQJxkZWUZGxtzvVlDQ8P8/HxccgIgDthzEz2oMwwNDTGfASAmvjTb2UdGRkZtbW05OTlcbxkABE1mZuaQIUMGDRr0+be+OJ9RXFxcXV3N42AAQBiTyXzy5Akv6gxdXV15eXnMjAKIg6ysrC+t8frifAaLxcrOzuZlKgAgr7CwsLa2luuLQCmKkpCQ0NfXx8wogDjoYlq08zpjxIgRSkpKjx8/5mUqACAvMzOTXRDwonEjIyMMIwAir6Wl5enTpz2rM2g0mrm5eWJiIi+DAQB5DAbD0NBQQUGBF41bWFikpqa2trbyonEAEBCPHj1qaGiwtLTs9LtffGyStbU1g8HgWSoAEAgMBsPGxoZHjVtbW9fV1WVkZPCofQAQBAwGQ01NrdObgVJd1xlFRUUvX77kWTAAIKyhoSE9Pd3a2ppH7evp6ampqeGIBUC0sQ9XaDRap9/9Yp1hYWFBp9Nx6gRAhKWkpDQ3N/OuzqDRaBYWFqgzAERbQkJCF8PIF+sMeXl5IyMjDBAAIozBYGhoaGhqavKuC2tr6/j4eN61DwBk5efnv379ujd1BoUlGgCijsFgTJ48maddWFtbl5eX4wHxAKIqPj5eRkZm/PjxX3pBN3VGenp6bW0tD4IBAGEsFispKYl3J03YJk6cKC0tjSMWAFHFYDAmTZokIyPzpRd0VWdYWVm1trampqbyIBgAEPbkyZP3799bWVnxtBc5Obnx48fj1AmAqGIwGF0frnRVZwwfPlxXV/fu3bvcTgUA5EVGRg4YMIAXT1DrwM7O7s6dO7zuBQD4r6ys7NmzZ/b29l28pqs6g6IoV1fX8PBwrqYCAIEQHh4+bdo0SUlJXnfk6upaWFiYn5/P644AgM/Cw8NlZWW7vgdPN3WGi4tLRkZGeXk5V4MBAGF1dXUPHjxwcXHhQ1+WlpbKyso4YgEQPREREfb29nJycl28pps6w87OTlZWFnOeACLm3r17zc3NTk5OfOiLTqc7ODigzgAQMa2trdHR0d0ernRTZ8jJyU2ZMiUiIoJ7wQCAvPDwcFNTU3V1df505+rqev/+/YaGBv50BwB8wGAwqqqq+lpnUBTl6up69+5dPAkJQJTcuXPH1dWVb925ubk1NjbGxcXxrUcA4LXw8PBRo0bp6up2/bLu6wwXF5cPHz4kJydzKRgAEJabm1tQUMCfxRls6urqhoaGOHUCIEoiIiI4OVzpvs4YM2aMjo5OWFgYN1IBAHkRERHKysoWFhb87NTV1RXDCIDIKC8vz8zMnDZtWrev7L7OoChq5syZ165d63MqABAIISEhbm5udDqdn53OnDnz+fPnWVlZ/OwUAHjk2rVrCgoKdnZ23b6Sozpj4cKFz549y8jI6HMwACDs1atXDAZj4cKFfO7XyspqxIgRgYGBfO4XAHghICDgq6++6vqKVjaO6gwLCwsMEACiISAgQEFBwdnZmc/90mi0efPmXb16lc/9AgDXlZeXJyQkuLu7c/JijuoMGo02f/58f3//vgUDAPICAwNnz54tKyvL/67d3d0LCgrS09P53zUAcFGPDlc4qjMoilq4cGFhYeGjR4/6EAwACHvx4kVSUhL/T5qwmZubjxw5EjOjAMIuMDBwzpw5HB6ucFpnmJmZYYAAEHYBAQFKSkqOjo6kAsybNy8gIIDFYpEKAAB99OLFi+TkZA5PmlCc1xkURc2fPz8wMBADBIDwCgwMnDt3rrS0NKkA7u7uRUVFDx8+JBUAAPooICBAWVmZ88OVHtQZ7AEiJSWlV8EAgLDCwsK0tDTOj0J4YcKECSNHjsRiLwDhxT5pwvnhSg/qjPHjxxsYGJw5c6ZXwQCAsHPnzg0ZMsTBwYFsjKVLl166dKmlpYVsDADohaysrNTU1KVLl3K+Sw/qDIqiPD09r1y5UlNT08NgAEBYW1vbuXPnPDw8+Hx7rs95enpWVFSEhoaSjQEAveDn56ejozN16lTOd+lZnbF8+fLW1tagoKCe5QIA0sLCwsrKylauXEk6CDV8+HBnZ2c/Pz/SQQCgZxobGy9fvuzl5UWj0Tjfq2d1hqqq6pw5czBAAAidU6dO2dvbd/tkRf5YvXp1ZGRkSUkJ6SAA0AMhISHV1dXLly/v0V49qzMoilq9enVSUhLuQQ4gRF6/fh0eHr5q1SrSQf5r5syZQ4YMwWIvAOHi5+f31Vdfqaur92ivHtcZU6dOHTVqFAYIACFy+vTp/v37z549m3SQ/6LT6cuXLz9z5kxbWxvpLADAkYKCgri4uF4crvS4zqDRaJ6enhcuXKivr+/pvgDAfywW6+zZs8uXLydyr/EvWb16dXl5eXh4OOkgAMCREydOaGho9OLRSD2uMyiK8vDwqKurw2pQAKEQGRlZUFAgOCdN2HR0dOzs7I4fP046CAB0r7Gx8fz5856enpKSkj3dl9a7+3suXbo0MzMzIyOjR4tOAYD/2McfkZGRpIN0dOPGjTlz5mRnZ+vr65POAgBd8fPz++6774qKinq6OIPqdZ2RmZlpYmISERHB/6dLAwDnsrKyjI2Nw8PDp02bRjpLRywWy8DAwMbG5uTJk6SzAMAXsViscePGWVpanjp1qhe797LOoCjK0dFRUlLyzp07vdsdAPhg+fLl6enpmZmZgjn1ePz48c2bNxcXFw8ZMoR0FgDoXGho6KxZs7KysgwMDHqxe2/WZ7Bt2bIlMjLy8ePHvW4BAHjq5cuXAQEBW7ZsEcwig6IoDw8PZWXlY8eOkQ4CAF+0b98+V1fX3hUZVF/qDBcXFyMjo4MHD/a6BQDgqUOHDqmpqS1evJh0kC+SlZVdu3btkSNH6urqSGcBgE6kpaXFxsZu2bKl1y30vs6g0WibNm26cuVKWVlZrxsBAB6pqalhL90i+BR4Tqxfv76hoeHChQukgwBAJ/bu3WtsbGxnZ9frFnpfZ1AUtWTJElVV1SNHjvSlEQDgBT8/v9bW1jVr1pAO0o2BAwcuW7bswIEDTCaTdBYA+Jvi4uKQkJB//OMffTn32qc6Q0ZGZuPGjceOHausrOxLOwDAXQ0NDfv27Vu1apWKigrpLN374YcfCgsL/f39SQcBgL/ZtWuXhoaGu7t7XxrpU51BUdR3330nKyu7d+/ePrYDAFx07NixDx8+/OMf/yAdhCNjxoxZtGiRr69va2sr6SwA8F8lJSVnz57dtm2blJRUX9rpa52hoKDw448/Hj58+M2bN31sCgC4oq6ubs+ePRs2bBg6dCjpLJzy8fEpKiq6fPky6SAA8F++vr7Dhw/v6dNZP9fXOoOiqA0bNigrK+/Zs6fvTQFA3/3xxx91dXU//vgj6SA9oKur+8033/j6+jY3N5POAgDU8+fPL1265OPj08fJDIordYacnNzWrVuPHj2KC08AiKuurt67d+/mzZsHDRpEOkvP/Otf/3r16tW5c+dIBwEAysfHR0dHZ9GiRX1vigt1BkVRa9asGThw4K5du7jSGgD02oEDB9ra2r7//nvSQXpMU1Nz5cqVv/32W1NTE+ksAGLtyZMnAQEBO3bsoNPpfW+NO3WGjIzML7/84ufnV1RUxJUGAaAXPn78eOjQoS1btgwYMIB0lt7Ytm1bRUWFn58f6SAAYs3Hx0dfX3/+/Plcaa33zzfpoLm5WU9Pz9bW9uzZs1xpEAB6ytvb+/Tp04WFhf379yedpZe+//57f3//vLw8RUVF0lkAxFFqaqq5ufm1a9dmz57NlQa5VmdQFBUQELB48eLExMRJkyZxq00A4FBBQYGBgcHevXs3bNhAOkvvvX//fvTo0atXr965cyfpLABih8ViTZkyhclkxsfHc+u5SNysMyiKsrW1bWlpYTAYAvvcJgBRNWvWrOfPn2dkZPR9fThZhw4d2rp1a3Z29qhRo0hnARAvly9fXr58eXJy8sSJE7nVJpfrjPT09IkTJ166dIkri1QBgEMxMTEODg7h4eEuLi6ks/RVa2uriYnJmDFjQkJCSGcBECMNDQ16enrOzs7cXSPF5TqDoqiVK1fevXv32bNn8vLy3G0ZADrV1tZmamqqpaV18+ZN0lm4IyoqysnJKTIy0snJiXQWAHHh4+Nz4MCB3NxcdXV1LjbLnetN2tu5c2dNTQ3uRA7AN8ePH8/NzRWlD52jo6Obm9v333+PO5ED8EdZWdm+ffu2bdvG3SKD4sV8BkVRu3fv3r59+9OnT0eMGMH1xgGgvQ8fPowePdrDw+P3338nnYWb8vPzDQwM/vjjD8F/5CyACPj666/T0tKePHkiIyPD3ZZ5Umc0NTXp6+tPnDgxICCA640DQHsbNmwICgrKy8tTUlIinYXLvv/++8uXLz99+lRVVZV0FgBRFhsba2dn99dff82aNYvrjfOkzqAoKiwsbPr06aGhoTNmzOBF+wBAUVRiYqKNjc2ZM2e++eYb0lm4r6qqSl9f39HR8fz586SzAIisxsZGExMTXV3dW7du8aJ9XtUZFEUtWbLk/v37OTk5oneYBSAImpubx48fP2jQoOjoaFG9kvzWrVszZ868c+eOs7Mz6SwAounXX389ePBgVlaWtrY2L9rn/jrQTw4dOtTS0vLrr7/yrgsAcbZz586ioiI/Pz9RLTIoipoxY8a8efO8vLxqa2tJZwEQQVlZWXv27Nm5cyePigyKp/MZFEVduHBhxYoVsbGxNjY2vOsFQAzl5uaamJj89ttvW7ZsIZ2Ft16/fq2vr79y5UpRuqAGQBAwmUwbGxsmk8lgMCQlJXnUC2/rDIqiXFxciouLHz9+LCsry9OOAMQHk8m0tbWtra1NTU3lygMVBdypU6fWrFkTHx9vaWlJOguA6Dh48KC3t/ejR48MDAx41wsPz5uwnThx4uXLl3hkPAAXHT9+PCkp6fTp0+JQZFAU5enpaW9vv3bt2paWFtJZAEREaWnptm3bfv75Z54WGRQf5jOo/18xpaSkGBsb87ovAJFXXFxsbGy8bt06sXrS2PPnz42NjX/66ad//etfpLMACD0WizVt2rSysrL09HSu3zCjA37UGUwm09HR8c2bN2lpaXJycrzuDkCEMZlMe3v7ioqK1NRUcfs0HTp06Mcff4yLi8PZE4A+2r9/v7e3d3x8vLm5Oa/74kedQVFUWVmZsbHx4sWLDx8+zIfuAETV9u3bd+7cmZKSYmRkRDoLv7FYrJkzZz59+jQ9Pb1///6k4wAIq+zsbDMzs23btv3yyy986I5PdQZFUcHBwe7u7jdu3Jg5cyZ/egQQMampqdbW1nv37t24cSPpLGS8ffvWyMjIzc3tzJkzpLMACKXGxsZJkyYpKSndv3+fd9eYtMe/OoOiqOXLl0dERGRmZg4ZMoRvnQKIhtra2vHjx+vo6ISHh4vwDTO6FR4ePn369CtXrnz99dekswAIn/Xr11+5cuXx48d8ewAZX+sMDJQAvfbNN9+Eh4ejTKco6ttvv/X398/IyNDU1CSdBUCYREREuLm5Xb58edGiRXzrlK91BkVRCQkJtra2Bw4c2LBhAz/7BRBq/v7+ixcvvnnzJh4YRFFUfX39hAkT1NXVo6KiJCR4fnE+gGh4/fq1sbGxi4sLnx8YJOnr68vP/oYPH85kMn18fKZNm6ahocHPrgGEVG5u7qxZs1atWrV582bSWQSClJSUlZWVr69vS0uLnZ0d6TgAQqC1tXX27NmNjY03b97k9YWsHfB7PoOiKCaTOWPGjOzs7IcPHw4cOJDPvQMIl9raWgsLC3l5+bi4OD6PDgLuxIkT3377bXBw8Ny5c0lnARB0P/74459//slg/D/27jMuiqt/G/jMNnrvRQFBqiCICIgdMGjEaBSMPTaMqCjRBI0mECuaxK4RLLcgRTGW2EDAhoCKgAoiC0gTUGnS67bnxdx/Hm4r6s6cLb/vi3wisHMuQHevnXPmTNqQIUMoHhpBz8Aw7PXr105OTsbGxteuXZOSDQ0B+AwCgeC77767fv16ZmamsbEx6jgiZ/HixXFxcffv37eyskKdBQDRdf78+WnTph0/fvz777+nfnQ0PQPDsMePHw8fPnzFihU7duxAEgAA0ffHH3+sX7/+6tWrcFf0d+rs7Bw1alRLS0tGRoaSkhLqOACIooKCgmHDhs2bNw/V/lXIegaGYVFRUfPmzTt9+rSPjw+qDACIrJs3b44fP3779u1r165FnUV0PX/+fOjQoe7u7rGxsaizACByWlpanJ2dVVRUbt++zWKxkGRA2TMwDFu2bFlUVNS9e/fIvo8LAOKloqJi6NChw4cPP3fuHFwE/mHXr1//6quv/vjjj8DAQNRZABAhAoHAx8cnNTU1KysL4YUXiHtGd3f36NGjGxoa7t69q6amhjAJAKKjo6NjzJgxLS0t9+/fh+mAvti+fftvv/2WkJDg7u6OOgsAomLz5s2bN29OTk4eNWoUwhiIewaGYS9evHB2djYzM7t27RqqszoAiA4+n+/j43Pr1q309HQLCwvUccSDQCCYOXPmtWvXUlNT4eQoABiGxcTEzJkz58CBA/7+/miToO8ZGIbl5eWNGDHCy8srJiYGThEDKbdmzZoDBw7Ex8ePGzcOdRZx0t3d7eXlVVpaevfuXdgyFUi5O3fueHp6rly58o8//kCdRTR6BoZh165dmzRp0oYNGyjeNwwAkXLkyJGlS5dGRETMnTsXdRbxU19fP3z4cCUlpdu3bysoKKCOAwAaxcXFrq6uzs7OFy5coOZOaR8mKj0Dw7Bjx44tWbLkP//5z/z581FnAQCB+Pj4yZMnh4SEbNiwAXUWcVVSUuLq6urk5PTvv/+KwjMsABSrq6sbPnw4cTtWEWnbItQzMAxbv379X3/9dfXqVQ8PD9RZAKBUdnb26NGjfX19jx07hjqLeMvIyBg7duzcuXMPHz6MOgsAlOro6PDw8Hj58uXdu3d1dHRQx/kv0eoZAoFg1qxZCQkJd+7cGTRoEOo4AFCkrKzMzc3NxsbmypUrTCYTdRyxFxcXN3PmzD///BOudAXSg8fj+fr6iuASctHqGRiGdXZ2Tpgwgc1mp6SkDBw4EHUcAEj34sWLUaNGEasKlJWVUceRELt27Vq7du2RI0cWLVqEOgsApBMIBAsXLjx9+vS1a9dGjhyJOs7/ELl7i8jKyl6+fNnLy2vcuHEpKSkmJiaoEwFAorq6uvHjx9Pp9Pj4eCgZQvTjjz82Nzf7+fnJycnNmjULdRwAyLV27dqYmJhz586JWsnARPB8BqGpqWncuHFNTU0pKSn6+vqo4wBAiqamJnd399ra2jt37vTv3x91HAkUFBT0119/xcbGws0NgARbv379H3/8ERMT4+vrizrLO4hoz8AwrLa2dsyYMTwe7/bt26KzngUAYWlvb/fy8iopKUlJSRkwYADqOJJJIBD4+/sfP378/PnzEydORB0HAOHbsmXLb7/9JspThKLbMzAMq6qqIuatb9y4oa6ujjoOAELT3d39zTffZGVl3bp1y9raGnUcSSYQCJYsWRITExMfHz969GjUcQAQpv37969atergwYPLli1DneW9RLpnYBhWUlIyatSo/v37x8fHq6iooI4DwJdqbGwUCARz5sy5e/fuzZs3Bw8ejDqR5ONyuTNmzEhOTk5ISDA2NtbT00OdCAAhOHz4sL+//86dO0X8ls401AE+YsCAAcnJyeXl5e7u7vX19ajjAPCleDyekZHR9evX9+zZAyWDGgwG4++//zYyMhoxYgRsqgEkw65du/z9/Tdt2iTiJQMT/Z6BYZilpWVaWlpjY+PIkSOrqqpQxwHg8zU1NX3zzTc0Gq2rq2v+/PmDBg06ePBgY2Mj6lwSSyAQ3Lp1a+7cuf3798/NzdXU1NyxY8eFCxdQ5wLgi+zYsWPt2rV//PHHxo0bUWfpA4GYePHihY2NjYmJSXFxMeosAHyO169fDxs2TFdXNzc3d8yYMTiO4zhOp9OZTObMmTNv3rzJ5/NRZ5QcVVVV27ZtMzIywjCMuBE0jUbLzs5etGgRi8U6c+YM6oAAfA4+n7927Vocx/ft24c6S1+JTc8QCATV1dWDBw/u379/YWEh6iwAfJqXL1/a2toaGRkVFRUJBIK8vLzed98g9gDV1dUNCgoqKytDHVaM8Xi8pKSkb7/9lk6nMxiM3j/hZcuWCQQCPp+/evVqOp1+/Phx1GEB+DR8Pj8gIIBOp584cQJ1lk8gTj1DIBA0NDS4uLjo6Ojk5OSgzgJAX5WXlw8cONDCwqKioqLngytWrHh7i3EGg4Hj+NixY+Pi4rq7uxFmFjuFhYXBwcF6eno4jvduGAQlJaXa2tqeLw4ODsZxfO/evQgDA/BJuFzuggULWCzW2bNnUWf5NGLWMwQCQVNT06hRozQ0NO7cuYM6CwAf9+jRIwMDg8GDB1dXV/f+eH19vaqq6jtnM4m2oa6uHhQUVFVVhSq5uIiKinJzc8Nx/H23hqHRaG+fZN6yZQuO4yEhITBdBURfa2urt7e3vLz8tWvXUGf5ZOLXMwQCQXt7+7fffisjIxMTE4M6CwAfEh8fr6SkNG7cuIaGhrc/e+jQIRrtvWuxcRy3tLRsamqiPrZ4+euvvz6wBI1Op1tYWHA4nLcfGBYWxmAw5s+f39XVRX1sAProxYsXjo6OWlpa6enpqLN8DrHsGQKBgM/nE2c+g4ODUWcB4N2OHj3KZDI/8DLG5XJtbGzePslPvDqqqqo+e/aM4sxiatmyZb3Xu7zhA28BExMTVVRU3Nzces+qACA6njx5YmRkZGpqWlBQgDrLZxLXnkEIDw9nMBgLFiyAmWwgUnr34A+flk9NTcVx/O0zGSwW6+7du5QFFndcLtfLy+vteRMmkzllypQPPzYnJ6d///4DBw6EBeZA1CQnJ6uqqrq6utbU1KDO8vnEu2cIBIKEhARlZWV3d3dim0UAkOvs7Jw5cyaLxYqMjOzL10+bNu3tF8iQkBCyc0qY6urqfv36vfGTZDKZJSUlH31sVVXVkCFDNDU1U1NTKYgKQF/85z//YTKZ06dPN1BstgAAIABJREFUb29vR53li4h9zxAIBJmZmXp6era2trC1BkDuxYsXrq6uampqN27c6ONDnj9/Lisr2/tkxujRo2VkZODCy757/vz5kCFD1NXV1dTUeiZQGAzGxo0b+3iE5uZmLy8veXl52FoDIMflctetW4fj+C+//CIB65QloWcIBIKysjJ7e3s1NbUrV66gzgKk1507d/T09AYOHPj06dNPemBwcDDx6kin07///vueaRc/P793LmAEvaWnp+vq6pqbm7PZ7MzMTFlZWWIPNG1t7dbW1r4fh8Ph+Pv74zj+008/wY8doFJXVzd+/HhJeqchIT1DIBB0dHQsWrQIx/GgoCAej4c6DpA6YWFhLBbr66+/fuelJR/W1tZG3NxrzJgxPYuNTp06JS8vP378+M84oPSIiYmRk5ObMGFCz8zpP//8Qyx5iY6O/owDRkVFycvLjxo16uXLl0JNCsDHZWdnm5iYGBoa3rt3D3UWoZGcnkEgnusnTpz4+vVr1FmAtOjo6FiwYMEXdtzTp09bWVm9USmys7P79+9vZmb2qSdIpAGXyw0KCsIwLCAg4I0fe2hoqKur62efcH748OGAAQMMDAxgKS6g0smTJ+Xl5UePHv3q1SvUWYRJ0nqGQCB48OCBkZGRmZnZ48ePUWcBki8pKWno0KHq6uoJCQlfeKh3PrlUVVU5OzsrKytfunTpC48vSZqbmydPniwjI/O+DZi/8GxEfX29l5eXjIzMzp07S0tLv+RQAHxUZ2dnQEAAjuMBAQGSN2cngT1DIBC8fPly1KhRCgoK4rUJPBA758+fZ7FYOjo6bDabvFE6OzvnzZtHp9NDQ0PJG0WMFBUVWVtb6+npkXpumcfjzZkzB8MwX1/fT1rnAcAnKS0tJd5LiN2G4n0kmT1DIBBwOJw1a9bgOD5jxgyY3gZC19bWtnTpUmJFBYZhpqamZG/Vt2fPHhqNtmjRIinfvDIxMVFNTc3e3r68vJy8UZqbm3/44Qccx83MzDQ0NMzNzR88eEDecEBqRUVFqaio2Nra5ufno85CFontGYTk5GQDA4N+/frdunULdRYgOXJzc21tbVVUVGJiYpqamphMJo7jNBpt9erVbW1t5I179epVFRWV4cOHS9j0bd+FhYUxmcwZM2aQ+nNOTEw0MDAg9mnduXPnq1evJkyYwGAwgoODuVwueeMCqdLU1DR37lzisjJS/z4jJ+E9QyAQ1NbWfvPNN8S8l5S/EQRfjs/n79mzh8VijR07tufmqxMnTiSuSmUwGP369ev7zhmfoaCgwMLCwtDQMDMzk7xRRBCHw1m+fHlftlj9Ek1NTYsXLyZaI7EJB7H1O/F7l5GRcXV1hX16wJe7e/euqamptrb25cuXUWchneT3DEJERISiouLQoUPFd4t4gNzLly+9vLzefl974sSJnpclOp2O4/iSJUtaWlpIilFfXz9u3DgFBQVJnc19W11d3dixYxUVFc+fP0/eKPHx8bq6ur13FLWxsen9Bbm5uXZ2dioqKlFRUeTFAJKNw+EQ++WMHz/+xYsXqONQQVp6hkAgyM/PHzJkiKKi4r59+2CDDfCpTpw4oa6ubmFh8faJhIaGhjfuhcZgMAwMDJKSkkgKw+FwiNXpQUFBEn8mPzs729jYeMCAAbm5uSQN0djY+MZpDGLP8i1btrzxlW1tbcuWLcNxfPbs2XDrNfCpcnJyhg0bJicnd/DgQQnY6LOPpKhnCASCrq6ujRs3MplMV1fXJ0+eoI4DxENxcbGnpyeNRlu5cuX7rjsYN27cG/cL7TmxQd6N3SMiIuTk5Ly8vOrr60kaArnIyEg5ObkxY8ZUV1eTNMSVK1d0dHTevsUMhmHv27bk8uXLhoaGmpqaJ0+eJCkVkDAdHR0bNmwgXn2kbTsc6eoZhNzcXBcXFyaTGRQU1NnZiToOEF08Hi8sLExRUdHGxubDl5OEhYW9877kTCZTW1v74sWLJCXMysoyNjbu379/RkYGSUOg0rOjAHnnbBoaGhYvXoxhWO/TGD3MzMw+8Ni2tragoCA6ne7l5QUbbIAPS01NtbKykpeXDw0NlfgTkG+Txp4h+L/XDyUlJTMzM1JX7QHx9fjx42HDhvWxj1ZXV7/ztYp4DcNxfPHixSRtv1NbW+vh4SErK3vs2DEyjo9EZWWli4uLkpLSP//8Q9IQ165d09DQeGPCqweLxerLPdjS0tKsra2l9vUDfFRjY2NAQACNRpswYUJZWRnqOGhIac8glJaWenl50Wg0f39/2Kcc9GhtbQ0KCmIwGG5ubn0/w+nm5vbOqsFgMMhewEjswE1cICcBF1WlpKQQ90UjdXKzpqZm7Nix72uHGIY9fPiwL8fp7Oz87bffWCzWsGHD+vgQICXOnDmjr6+vra0dExODOgtKUt0zCCdPntTS0tLU1Dx06BC8I5FyfD4/MjLSwMBARUXl4MGDn7ReeN++fW+/OWYwGIMGDSKujSTbhQsXlJWV3dzcxHoRO7FDxuTJk3vui0YePp8fGhpKo9Hebhv9+vX7pEPl5ua6urrS6fQlS5aQt5QEiItHjx6NHTsWx/H58+fX1dWhjoMY9AyBQCBoaWkJDg6WkZGxtLS8evUq6jgAjQcPHhDnJObOnfsZG2FVVlYStwntbdq0ae3t7WSkfSc2m21lZaWtrS2Os4EdHR3z58+n0+mk7pDxths3bigqKvZeB8pisYKCgj71OHw+Py4uzsjISEFBITg4GNZ+Saf6+vqAgAA6ne7o6Hjnzh3UcUQC9Iz/r7Cw0MfHB8MwDw8PaVsPLOWqqqr8/PxoNNqYMWO+5NS3o6MjUTUYDAaLxdLS0nJ3d6f4JFlzc/O3337LYDDE62YoRUVFtra2Ghoa165do3jo8+fP4zg+cODA3it5P3tdbVtbW2hoqKKiopmZWVxcnHCjAlHW3d29Z88eVVVVfX39sLAw2D2hB/SMNyUkJFhbW8vIyPz8889wYxSJ19raunnzZgUFBRMTky9fcvjHH38wGAwGgzFw4MCnT58+evRITk7ut99+E0rUvuuZDpg9e7ZY7Gd85coVNTU1BweHkpISiocuKytTV1f38/PjcDhr167FcRzHcV1d3S88oVJWVubr64thmKenZ05OjrDSApF18eJFCwsLWVnZX375hbw9+sQU9Ix34HA4+/btU1dXV1NT27JlS3NzM+pEQPg6Ojp2796to6OjqKi4devWjo6OLz9mSUkJhmGzZs3q2Wbj77//ptFo8fHxX37wT3X16lV1dXV7e3tR3ie7pxLNmTOH+krU2dnp6OhoZ2fXM7d14cIFJSWlVatWCeX4KSkpQ4YModFoM2fOJPWOvgChpKQkV1dXDMOmT58OVzi/E/SM92ppaQkNDVVVVdXQ0AgODoa2ITG6u7vDwsIMDAxkZGT8/PxevnwpxIO/vVXGvHnz1NXVkVzSVlxcPHjwYA0NDdG8h0Jtbe3EiRNZLNbff/+NJMDSpUuVlJTeaADFxcVCvM6Fz+dfvHhx8ODBNBrNx8ensLBQWEcGyKWlpY0bN46Yar9//z7qOKILesZH1NfXBwcHKysra2lphYaGUrmmDwgdh8OJiIgwNTVlsVh+fn5VVVUUDNra2mptbe3i4oLkitO2trbvv/8ex/GffvqJpA08Pk9qamq/fv2MjIzu3r2LJEBsbCyO4+Ttz9Ebj8eLi4szNzdnMplz584V5TNMoC/u3bs3adIkDMPc3NzEcc01xaBn9El1dXVgYKCcnJyhoeGBAwfEYs4b9NbZ2Xn8+HEzMzMmk+nn5/f8+XMqR2ez2UpKSmvWrKFy0N4iIiIUFBScnJyoXwDxNuLep0wm09vbG9WO6QUFBUpKSoGBgVQOyuFwjh07ZmxsLCMjs3z5clH4XYBPlZaW1tMwrl+/jjqOeICe8QmqqqpWrFghJyenoaGxcePGz7j0EVDv9evX27Zt09PTY7FYCxYsQPXkHhMTg+M4wjus5ufn29raqqioUPMO/n3q6uomTpxI3PMW1YJ84gyTs7MzkjNMXV1dhw4dMjIyotPpvr6+cL5dLPB4vLNnzxLrMFxcXJCsuBJf0DM+WW1tbWhoqL6+PovFmjt3LtyPTWSVlpYGBQWpqKgoKysHBARQfA7jbUuWLFFVVaVmz6536ujoIO4YEhAQgOQl9v79+8bGxv369UtLS6N+9B7Eihm0S/Z4PN7FixddXFwwDHN0dIyIiIBNAkVTZ2dnRESEpaUljUabNGkSeTdhlmDQMz5Te3v74cOHLSwscBz/+uuvYYpOpNy/f9/X15dOpxsZGe3evVtE1vB2dHQMGTKk99UNSCCZQxGFuRJCWFgYqiuA3unmzZtff/01juPm5uaHDx+GFWCi49WrV7/++qumpqacnNwPP/xQUFCAOpG4gp7xRfh8flJSEjFdZ2FhERoaWlNTgzqU9GpqagoLC3Nzc8MwzN7ePiIiQqRWPgoEgmfPnqmoqPzwww9oY1A8h0JcV4J2roTw+PFjOTm5vtwgjWJFRUUBAQFycnIqKip+fn7Z2dmoE0kvHo+XlJTk4+NDbLUXFBQk1hv5iwLoGcKRlZX1ww8/KCsry8jIzJgxIzk5mcqNk0FaWtqCBQsUFBTk5eXnz5+fmpqKOtF7/fvvvziOR0REoI1B2RyKiMyVCASC5uZmCwuLMWPGiOwMRXV19Y4dO8zNzTEMGzZs2JEjR2DHJypVVlZu2rTJ2NgYw7CRI0dGREQIZVsdAD1DmFpbW48fP06sFTI1Nd22bRsUYVLV1dXt3r3b2tqaOIFx8OBBCm6+9eVWr16toKCQl5eHOgi5cyiiM1dChJk2bZqOjo7o/5Pk8/k3b96cPXu2rKyskpLSkiVLYK0oqTgczr///jtp0iQ6na6lpbVmzZr8/HzUoSQK9AxS5OfnBwUFaWlp0Wg0Nze3PXv2wMUpQtTY2BgRETFp0iQWi6WkpOTn5yde9yvq7u52c3OzsLAQhYUjPXMoZ86cEeJhRWeuhPDXX3/R6fTk5GTUQT5BY2NjWFiYvb09hmHGxsYBAQHi9fdcxPF4vDt37gQEBOjq6tJoNA8Pj4iICFgfQwboGSTq6Og4c+aMj4+PvLw8g8EYP3780aNHkb+xE1/Nzc1RUVGTJ0+WkZGRkZHx9vaOiorq2eFbvFRUVGhqan733XeogwgEveZQ/Pz8hLI3THJysoGBQf/+/ZHPlRDu3bvHYrG2b9+OOshnun//fmBgYL9+/TAMs7KyCgkJgRs9fjYej3f79u3ly5fr6OgQ50G3b98O+4WTCnoGFVpbW2NjY6dOnSorK8tkMidOnHjs2DHhbnctwerq6qKjo3v/9E6cOCEBt7hLTk6m0+nh4eGog/xXdHS0ioqKjY3No0ePPvsgHR0dgYGBOI7PmDFDRH5H9fX1xsbGEydOFIXTKl+Cz+enpqYGBATo6+tjGGZra7t58+aHDx/CUrC+6OrqunHjxhs/PbiEhBrQMyhFvCP39vaWlZXFcdzBwWH9+vUpKSmidlkEcjwe7/79+yEhIc7OznQ6nclkSuTZoA0bNsjKymZlZaEO8l/l5eWjR49mMpmfN9mRl5dnb2+vrKwcFhZGRrzPwOPxvLy8+vXrV1tbizqL0PB4vFu3bvn7++vq6mIYpq+vv3Dhwri4OBEpdiKlrKzs8OHDU6ZMUVJSwjDM2to6ODhYFJZGSRXoGWi0tbVdvnx5+fLlpqamGIapqqpOnz796NGjlZWVqKOhVF1dffLkyVmzZmlqamIY1q9fvyVLlpw9e7apqQl1NFLweDxPT09TU1PRWb5KLN5ksVjjxo2rqKjo+6PCwsLk5eWdnZ2LiopITfhJNm3axGQyRWT6Ruh4PF5mZuaWLVvc3NzodDqDwRgxYsTWrVuzsrLE/eTNl+jo6EhKSlqzZg2xQlxBQcHb2/vgwYNwWxlUcIFAgAGkSkpKkpOTk5OTExISWlpa9PT0RowY4ebmNmLECAcHBxqNhjoguUpKSlJTU9PS0lJTU/Pz8+l0urOzs7e3t4eHx5AhQ3AcRx2QXDU1NQ4ODo6OjsT1rqjj/FdmZuacOXNevXp16NChWbNmffiLq6urFy1adO3atTVr1mzevJnJZFIT8qNu3brl4eGxZ8+eFStWoM5CutbW1ps3b16+fPnq1auVlZWKioouLi5ubm6Ojo6jRo1SUVFBHZBczc3NGRkZPc8knZ2dAwYM8PDwmDRp0vjx42VkZFAHlGrQM0RIR0dHeno68U/l3r17LS0tqqqqw4cPHz58+IgRI+zt7cXryUIgELzzhbO1tTUnJyctLS0tLS09Pb22tlZeXt7JyWnkyJHDhw8fOXKkoqIi9WkRun37toeHx86dOwMDA1Fn+f86OjrWrVu3f//+6dOnh4eHq6qqvvPLEhISFixYICsrGxUVReyQJiKqq6sdHBxGjBgRFxeHOgulBAJBbm5uSkoK8WRSUVHBZDIdHBzc3Nzc3NycnJz69+//zkeJTs3tCx6PV1hYeO/evdTU1PT0dDabTaPRrK2tiW9z9OjR7/w2ARLQM0QUj8djs9lEN09LSyspKcEwTE9Pz8bGxtra2tHR0cbGxsbGRlZWFnXS97p48aK9vX3//v1fvHiRlZX19OnTvLy8rKwsNpvN5/N1dHScnJyIMzdOTk5S/oZj+/btwcHBN2/eFKmXagzDrl27tmDBAhkZmZMnT44YMaL3p4gism/fvrlz5x46dEik2iGPx/vqq6/Ky8szMzPFq50L3cuXLzMzM4lnkoyMDA6Ho6ysPHDgwJ6nEXt7e01NzQMHDoj4WZ+GhgbiCYR4Jnn48GF7ezuTybSzsyPO/o4bN05DQwN1TPAO0DPEQ2Vl5ePHj3Nzc4n/FhQUcLlcFotlbW1tZWVlbGxsYmJibGxsbGxsZGTEYrGQhORwOJWVlaWlpWVlZaWlpRcuXHj16lVbW1tHRwedTjczM7Ozs7O1tbW1tR08eLCJiQmSkKJJIBBMnTo1Kyvr4cOHxNoU0VFTU7No0aKEhITe0yKZmZmzZ8+uqak5dOjQzJkzUWd807p16/bu3Zuenu7g4IA6iwhpaWnp/TTy5MmT5uZmHMf19fVramqWLVtmYmLS80yCsJ9VV1cTzyHEf4uLi3NycmprazEM09XVtbW17XkmsbW1FZ15OvA+0DPEUnd399OnT3Nzc4nOQfxrbGlpwTCMRqPp6+sTzxdaWloaGhrEfzU0NDQ1NYn/YTAYnzEoj8er/191dXW1tbW1tbXl5eWlpaVVVVVcLhfDMHl5eRMTE+JTmzZt8vLysrGxkZOTE/JPQbI0NDQ4OjoOGDDg2rVrdDoddZz/IRAIjhw5EhgYOGjQoMjIyISEhJ9//pnYmNnAwAB1ujdduXLF29v72LFjCxYsQJ1FpAkEgrKystzc3B9//LG4uNjBweHly5evXr0iPquurk68gdHX19f4P5qamj3PJ/Ly8p83bnNzc93/6f1kUlFRQXSL9vZ2DMMYDIahoaGxsbGpqamNjY2dnZ2dnZ2WlpbQvn9AFegZkqO+vr7nHUBZWVl5eXltbW19fX1tbW1zc3Pvr1RRUaHRaPLy8sRshZqaGoZhLBZLQUEBw7COjo7Ozk4Mw5qamvh8PofDaW1txTCsoaGh90GUlJSIEqOpqdm/f/+ecyomJiba2toYhunq6lZXV3t7e1+8eJGiH4GYe/DgwciRIzdu3Lhx40bUWd4hLy9v+vTpRUVFNBotNDSU2CcDdag3VVRUODg4eHl5RUVFoc4iHm7cuOHu7o5h2Llz56ZOndrR0dH7XEJZWdmrV6962gCPx+t5oJycHLGlDTFlpqCgwGKxcBwnlvLweDziaae9vb2rqwvDMOKiqtbWVg6H03MQGRmZnhJjaGjY8xxC3BPn894RAVEDPUMqcDicN05F8Pn8nj5BFIiuri7ibYSsrCxx7kFVVRXH8Z7+8cZJkQ/Pzrx+/bpnrjQ1NVXUlh2IrP37969evTohIcHT0xN1lv/B5/P379//yy+/KCoq1tXVeXh4HDlyRNSW2nE4nDFjxjQ3N9+/f/+z321LFYFA4OTk9PjxYxqNtn79+pCQkA9/fUNDQ++TEJ2dnVwulziT2tbW1t3dzefzm5qaMAyj0WjEzMsb72cUFRWJpxHimUSklvUAsiC4lhZIgevXrxN/wRgMhouLC+o44mT27Nna2tpVVVWog/x/xcXFY8aMYTAYQUFBXV1d9+7ds7KyIvbjEqnNKFesWKGoqAh7cvfdmTNniH+nOI57e3ujjgMkk4TvzQBQefz4MbE+i8vl3rt378qVK6gTiY3Dhw+rq6vPmjWLWOyClkAgCA8PHzx4cH19/f3790NDQ1kslrOzc3Z29rJly/z9/b28vJ4/f446JoZhWFxc3IEDB/7++28rKyvUWcQDj8dbv349sUOPQCDIzs5GnQhIKNRFB0im+fPn98yt0ul0S0tLad6g8FPl5OTIy8uvW7cObYyCgoIRI0YwmcyQkJDu7u63v+Du3buWlpbKysrh4eFoT2wUFhYqKyuvWLECYQaxExYW1nsbQBzHYedyQAboGYAUxI6/PWg0WmRkJOpQ4uTYsWM4jp8/fx7J6N3d3Vu3bpWVlXVwcPjwbdU6Ojp++uknOp0+ZsyYwsJCyhK+kcHBwcHJyamzsxNJAHHU3t6uo6PzxkrelJQU1LmABIJ5EyB8XC63qKio90cEAsG6deuIZeegLxYuXPj9998vXLiwtLSU4qEfPnzo6uq6ZcuWoKCge/fuDR48+ANfLCsru3PnzszMzNbWVjs7O+LMB2VRCf7+/mVlZadPn5by3d4+yd69e+vq6gS9rgNgMpmPHj1CGAlILNRFB0ignJyct/+m0en0PXv2oI4mTqh/m97W1hYUFESn00eNGsVmsz/psRwOZ8+ePYqKira2tnfv3iUp4duioqIQnvgRUw0NDcrKym/8C2UwGIsWLUIdDUgg6BlA+CIjI995+zdVVVVJvfMqSYhlBytXrqRgrCtXrhgZGamqqn7JVSTFxcXjx4/HcdzPz6+5uVm4Cd+Wm5srLy8fFBRE9kAS5ueff37nNpp2dnaoowEJBD0DCN+aNWveubsGg8H47bffUKcTM6dPn8YwLCoqirwhysrKvv32WwzDZs2aVV1d/YVH4/P5J06cILZdOn36tFASvlNLS4uVlZWrq+s716iC96mqqnrfBBOLxeJwOKgDAkkDPQMI39ixY983TycnJ/flr2TSZvny5SRtC9HR0bF582Z5eXlzc/Nr164J8cg1NTULFy7EcXzcuHF5eXlCPHKPOXPmaGtrV1ZWknFwCbZ48eIPbGxP0i8LSDPoGUD4iI3/3nif1PPUhvxyTbHT3d3t6uo6aNCgtrY2IR42OTnZyspKXl4+ODiYpCUgmZmZLi4uDAYjICBAuFNm+/fvp9FoiYmJQjymNCgrKyPONeI4LiMj80bhoNFoMTExqDMCSQM9AwjZixcvej9tqaurq6iorFmzJjw8/Pbt2zU1NagDiqXy8nINDY2FCxcK5WgVFRVz587FMGzSpEllZWVCOeb78Hi8iIgILS0tPT29iIgIoWyzkZGRISMjs2nTpi8/lBTq7OzMyck5c+bMli1bnJycFBUVe9/jEBa7AKGD+5sAISsqKoqLi7OwsLCwsDA3N79y5YqPj09LSwvcb+ILCeU2pB0dHTt27NixY0f//v337dv31VdfCTHhBzQ0NISEhBw8eNDNzW3//v12dnZfciiRvbGt2Pnhhx/YbPatW7eqqqrYbHZBQYG8vPz333+POheQLKiLDpBweXl5GIY9fPgQdRBJ8PPPP8vKymZnZ3/ewy9evGhiYqKgoEDeRMmHZWVlDR8+nMFg+Pn5EZs3fCo+nz9lyhRDQ0M4MSYUo0ePXrp0KeoUQMLBPl2AXGZmZgwGg81mow4iCbZu3Tps2LAZM2YQd9zuu2fPnk2aNGny5Mk2Njb5+fkhISFItrQaMmRIamrqsWPHLly4YGFhsXfvXj6f/0lH2Llz5+XLl2NjY7W0tEgKKVXYbLaFhQXqFEDCQc8A5GKxWCYmJgUFBaiDSAIGgxEXF9fa2rpkyZI+PqS9vT0kJMTW1vbZs2eJiYmXLl3q168fqSE/DMfxefPmFRQUzJ49e82aNc7OzhkZGX187N27d3/99dcdO3aMGDGC1JBSorGxsbq62tLSEnUQIOGgZwDSWVpaQs8QFh0dnejo6LNnzx44cODDXykQCGJjY62srPbs2RMaGvrkyRNPT09qQn6Uqqrq3r17Hzx4ICMjM3z48GXLltXU1Hz4ITU1NT4+Pl5eXoGBgdSElHjEWUY4nwHIBj0DkM7S0hLmTYRo7Nixv/32248//nj37t33fU1KSoqzs/OcOXPc3d0LCgpWrVrVc/tc0eHg4HDnzp3jx49funTJzMxs69at7e3t7/xKPp8/Z84cBoNx4sSJN279BT4bm82WlZU1MjJCHQRIOOgZgHQWFhYFBQWfOhMPPmDjxo3u7u7fffddfX39G58qLCz09fUdPXq0iopKVlbW8ePHdXR0kITsC2IapbCwcMOGDTt37jQ3Nw8PD+fxeG98WUhISEpKytmzZ9XV1ZHklEgFBQXm5uZwzQ4gG/QMQDpLS8v29vaKigrUQSQHjUaLjo7GcXz+/PmC/7s0vb6+ft26dba2tk+ePImLi0tKSrK3t0ebs4+Ie5QUFxdPmzZt+fLldnZ2ly9f7vns9evXt23btnfvXkdHR4QhJQ+bzYbFGYAC0DMA6aysrDAMgyUawqWurn769OmkpKSdO3e2t7fv2LHD1NT05MmT+/fvz83N9fHxQR3wk2lqau7du/fJkyc2Njbe3t6enp6PHz+urKycOXOmj4/P0qVLUQeUNHCxCaAG9AxAOnV1dU1NTViiIXTOzs7btm375ZdfTE1NN2/eTOy55OfnJ9Znwi0sLOLi4tLf23s2AAAgAElEQVTT09vb24cMGeLg4KCoqBgeHo46l6ThcrklJSXQMwAFoGcAKsAlJ2RITk6Ojo4WCASNjY1paWmhoaFKSkqoQwmHq6tramrqhAkT6uvrX758uXXr1k/dMgR8WHFxcXd3N8ybAApAzwBUgEtOhCs/P9/X19fT01NDQ+POnTsGBgaBgYFvL58Ua5cvX7569erRo0dDQ0PDwsJMTU337t3L5XJR55IQbDYbx3E4nwEoAD0DUMHCwgJ6hlCUlZUtWLDA1ta2pKTk5s2bSUlJbm5u586du3fv3u+//446ndCUl5d///33fn5+CxcuXLVqVVFR0axZs3766afBgwefPXtWAHdl+mJsNtvQ0FBRURF1ECD5oGcAKlhaWr548QJOfX+JFy9eLF++3MLC4s6dOxEREQ8ePBgzZgzxKTs7u927d2/dujUhIQFpRuHo6uqaNm2aoaHh7t27iY8QS0Tz8vIGDRrk6+s7dOjQq1evog0p7goKCuBkBqAG9AxABeIZDZZofB7iglUzM7OLFy/u3LkzLy9v9uzZb2xXtXTp0jlz5syePbu8vBxVTmEJCAgoLCyMi4vrfb9yDMMGDhx4+vTpnJwcU1PTSZMmubq6Xr9+HVVIcVdQUACLMwA1oGcAKgwYMEBGRgamTj5VS0sLccHqsWPHgoODCwsLV61a9b5boB06dEhXV3fGjBnd3d0U5xSiU6dOHTly5D//+c/73m3b2NjExcXdvXtXU1PTw8NjxIgRt2/fpjikBIDzGYAy0DMAFeh0upmZGZzP6Lu2trYdO3YYGRnt3Llz9erVxcXFQUFBb7y/f4OCgsL58+efPn26fv16ynIKV2FhoZ+fX2Bg4LRp0z78lc7OzpcuXUpNTWUymWPGjPH09MzKyqImpASoqampr6+H8xmAGtAzAEXgkpM+6u7uDg8PNzMz27Jli5+fX3FxcUhIiLKycl8eS+zbvXv37rNnz5KdU+ja2tqmTp1qbW29ffv2Pj7Ezc2NWAzb2Njo5OTk7e39+PFjUkNKBuJfIvQMQA3oGYAicMnJR3E4nPDw8AEDBgQEBEyePPnZs2ehoaGqqqqfdJDvvvtuyZIlCxYsELuzR/7+/q9evTp16hSLxfqkB3p4eDx48CAxMbGysnLIkCG+vr5FRUUkhZQMBQUFCgoKBgYGqIMAqQA9A1DEwsKiqKgI9j94Jy6Xe+LECQsLi5UrV06dOrW0tDQsLOyz73+2b98+c3NzX1/fjo4O4eYkT1hYWFRUVHR0tLGx8ecdwcPDIysrKzIy8uHDhzY2Nj/88APcUud9iEWgcOdbQA3oGYAilpaW3d3dZWVlqIOIlu7u7qNHj1pYWCxZsmTcuHGFhYX79+/X09P7kmPKyMicPXu2srIyMDBQWDlJlZOTExgYuGHDBi8vry85Do1Gmz17dn5+/qFDh+Lj483MzPz8/EpLS4WVU2LAHdQAlaBnAIoQ759g6qRHd3d3ZGSktbW1v7+/m5tbXl7e0aNHjYyMhHJwIyOjEydOhIeHR0ZGCuWA5GlpafH19XVxcQkODhbKARkMxuLFi589e3bkyJFbt26ZmZn5+vrCX7ze4A5qgErQMwBFlJWV9fT04Okew7Curi5iHcaSJUuGDx+en58fGRlpbm4u3FG8vb1Xr17t7++fl5cn3CMLkUAgWLBgQWNjY3R0tHBv/8ZkMufNm8dms0+dOpWbm0vcAzY7O1uIQ4iprq6usrIyOJ8BKAM9A1DHwsJC7BYnCldra+vevXtNTEx+/PHHadOmlZSUREZGmpqakjTczp07HRwcvv3225aWFpKG+EK7d+++cOFCdHT0F04VvQ+NRvPx8cnLy7tw4cKLFy+GDh3q7e394MEDMsYSF0VFRTweD3oGoAz0DEAdab5rK7HjlpGR0caNG318fIqKivbu3Uv2gn8GgxEbG9vQ0ODn50fqQJ/n/v3769ev37p1q7u7O6kD0Wg0b2/vzMzMf//9t7q6etiwYZ6envfv3yd1UJHFZrNpNJqZmRnqIEBaQM8A1JHOS1vr6+tDQkKMjIy2bt26ZMmS8vLyvXv3kvT2/W2GhoaxsbFnzpwJCwujZsQ+ev369YwZMzw9PX/++WdqRsRx3NvbOyMjIykpqbW11cXFZcSIEVK4czmbzTY2Nv7wnm8ACBH0DEAdS0vL2tra+vp61EEo8urVq59//tnY2PjgwYNr166trKwMDQ1VV1enOIa7u/svv/yyatUq0dkxk8/nz549WyAQREREUH91pYeHx927dxMTE2k0moeHx9ixY5OTkynOgBDc2QRQDHoGoA7x7CYNpzSI/bONjY1PnjwZEhJSVlb2yy+/9HFPTzKEhISMGjVq2rRpr1+/RpWht61bt16/fv3UqVMaGhqoMnh6eqakpNy6dYvBYHh6eg4dOjQuLo7H46HKQxm4qBVQDHoGoE7//v3l5eUle4nGw4cP582bZ21tff369R07dpSUlKxZs0ZBQQFtKhqNFhUVxeVyv//+e4FAgDbMzZs3f//99127drm6uqJNgmHY6NGjk5KSHj58aG1tPXv27IEDB+7du7e9vR11LhIVFhbCRa2AStAzAHVwHDc3N5fUnpGamurt7T1kyJAnT54cP36cuLeq6MyCa2trnzlzJiEhYffu3QhjVFdXz549e9q0aStWrEAY4w329vaRkZGFhYXe3t7r1683NjYOCQkRkXM/wlVVVdXc3Aw9A1AJegaglOTdTY3P51+6dMnJyWnkyJENDQ0XL17Mzs6eN2+ecHeDEApXV9fNmzcHBQWlpqYiCcDj8WbPnq2oqHjkyBEkAT7MxMRk79695eXl/v7++/fvNzIyWrVq1fPnz1HnEia4gxqgHvQMQClJuuSkra0tPDzc0tJyypQpurq6GRkZxCkN1Lk+5Oeff540adLMmTNra2upH33Dhg1paWmnT59GuFTlo7S0tEJCQsrLy7ds2XL+/HkzM7N58+Y9efIEdS7hYLPZqqqqn33rHAA+A/QMQClLS8uSkpKuri7UQb5IXV0dcalqQECAi4sLm80mTmmgzvVxOI4fP36cyWTOnDmT4jWPV65c2blz56FDhxwcHKgc9/MoKiquWrWquLj46NGj2dnZtra2I0aMuHTpEupcX6qgoMDKygp1CiBdoGcASllaWnK53JKSEtRBPlNRUdGqVauMjIwOHjy4ePHi0tLSyMjIgQMHos71CdTU1E6fPp2amrpt2zbKBn3+/Pn8+fNnzZq1YMECygb9csTm5bm5uRcvXpSTk5s8ebKjo2NkZCSHw0Ed7TPBnU0A9aBnAEqZm5vTaDSxmzoRCASJiYkTJkywsLCIj4/fuXNnWVlZaGgoZdttCZeTk9Off/4ZEhKSmJhIwXAcDue7777T09MLDw+nYDihIzb4SkpKSktLMzExWbhwoamp6c6dOxsbG1FH+2QFBQXQMwDFcOQXuQGRcu/evdWrV5M6RGVlpZqaGpJLPW/cuCEvL/9JD+nq6jp9+vSff/6Zm5vr5ua2atWqb7/9VtTWeLq7u7e1tX3qo0pLS9XU1FRVVcmI1BuXyy0tLe3Xr5+srOynPnbDhg2ituSlrKzs8OHD4eHhHA5n1qxZq1ev/oyZiK1btyKZhaHgX5+rqyvaa5qAqIGeAf5HQkLChAkTli9fzmKxUGcRprKysvPnzzc1NfV9BWJNTc1//vOfffv21dXVffPNN2vWrHF2diY15GdTUlJydXUdNGgQ6iBCduDAgb///nvRokWog7xDS0tLbGzsrl27ioqKxo0bFxAQMGnSpL7vbbpw4cKbN29OnTqV1JDUS0xMNDQ0TEhIQB0EiBIBAL3Ex8djGNbU1IQ6iJB90vf16NEjPz8/OTk5LS2toKCgiooKsuN9IUVFxaNHj6JOIXyi/33xeLyLFy96eHhgGDZ48OCwsLCOjo6+PHDBggVfffUV2fGoJ6nfF/gSsD4DgP/i8/mXL192d3e3t7dPTU0ltlIIDQ01NDREHQ2IKOJOsElJSRkZGdbW1itWrBgwYMDWrVuRXDYMgGiCngEA1tzcHB4ePmjQIG9v766urosXLz558mTJkiWis5snEHFOTk4xMTHPnz/38/PbvXt3v379fH1909PTUecCAD3oGUCqFRQUrFq1Sl9ff+3atSNHjszNzSX22qL+JqJAAujq6oaEhFRWVoaHhxcUFLi5uQ0dOjQ8PLyjowN1NACQgZ4BpBGxWbinp6eVldXVq1d//fXX8vLysLAwyVtKCagnKys7b968x48fZ2ZmEpMpJiYm69atq6ioQB0NAASgZwDp0tjYuHfv3gEDBkyZMgXDsH///bewsDAoKEhNTQ11NCBpiE29ysvLAwMDo6KiTExMvL29k5OTUecCgFLQM4AUWbZsmZ6e3u+//z59+vSioqKkpCSYIgFk09PTCwoKKi4uPn78eHV1taen55AhQwoLC1HnAoAi0DOAFHnw4EFoaGhFRcWff/45YMAA1HGAFJGRkZk3b15GRkZmZqaTk5P4br0PwKdioA4AAHUyMzNF+U6hQBo4OjqGhYV1d3e/fPkSdRYAqADnMwAAgGowWwekB/QMAAAAAJAFegYAAAAAyAI9AwAAAABkgZ4BAAAAALJAzwAAAAAAWaBnAAAAAIAs0DMAAAAAQBboGQAAAAAgC/QMAAAAAJAFegYAAAAAyAI9AwAAAABkgZ4BAAAAALJAzwAAAAAAWaBnAAAAAIAs0DMAAAAAQBboGQAAAAAgC/QMAAAAAJAFegYAAAAAyAI9AwAAAABkgZ4BAAAAALJAzwAAAAAAWaBnAAAAAIAs0DMAAAAAQBboGQAAAAAgC/QMAAAAAJAFegYAAAAAyAI9AwAAAABkgZ4BAAAAALJAzwAAAAAAWaBnAAAAAIAs0DMAAAAAQBboGQAAAAAgC/QMAAAAAJAFegYAAAAAyAI9AwAAAABkgZ4BULpz5w7qCODTwK9M7NTW1rLZbNQpgPRioA4ARJG7uzudTid7FA6Hk5+fb2dnR/ZAGIY1NTVRMApC27ZtO3LkCAUD5efnGxkZycvLUzBWe3s7BaOgcu/ePRcXFwoGqq6u5nA4hoaGFIxVUlIyZMgQCgYCYgR6BvgfJiYmgYGB1Iz16NGjjo4OU1NTHR0dCoabMGGCjIwMBQNRb+XKlZ2dnRQM1NrampGRISsrO3z4cAqGGz58uK2tLQUDUe+rr75SVVWlZqxTp061trZS9iuztLSkYCAgRnCBQIA6A5BSQ4cOzcrKWrNmzZ9//ok6C+iTv/76a+3atXp6elVVVTiOo44DPq6iosLIyEggENy7d8/Z2Rl1HCCNYH0GQKO0tDQ7OxvDsKioKD6fjzoO6JOoqCgcx1++fJmeno46C+iT2NhYBoPBZDJjY2NRZwFSCnoGQCMmJobBYGAYVl1dDUsLxcKzZ88ePXokEAjgRUuMREREcLlcDocTFRXF4/FQxwHSCHoGQOPkyZMcDgfDMCaTGRMTgzoO+Ljo6Ggmk4lhGIfDiY6O5nK5qBOBj2Cz2U+fPiUmx+vr62/duoU6EZBG0DMAAjk5OQUFBcT/czic2NjY7u5utJHAR0VFRRHVEMOwxsbG5ORktHnAR/VUQwwKPUAHegZAIDY2tufpD8Ow1tbWxMREhHnAR2VnZz979qznj/CiJRZ6zhpiGMbhcE6dOkXNdUkA9AY9A1BNIBD0fmeMYRidTo+OjkYYCXxUbGwsi8Xq+SOHw/nnn386OjoQRgIflpGRUV5e3vsjHR0dCQkJqPIAqQU9A1AtPT29srKy90e4XO6FCxdaW1tRRQIfxufzT548+cbcVmdn5+XLl1FFAh/1RjXEoNADRKBnAKq9MWlC6O7uhhctkXXnzp3q6uo3Pkin06OiopDkAR/F5/Ojo6PfqIZcLvfixYvNzc2oUgHpBD0DUIrL5cbGxvaeNCHgOA4vWiLr7XfGGIZxudz4+PjGxkYkkcCH3bx5s7a29u2Pc7ncf//9l/o8QJpBzwCUun79+uvXr9/+OI/HS0hIqK+vpz4S+LAPXBDE5/PPnz9PfSTwUTExMW9XQwwKPUABegagFLE74Ts/JRAIzp07R3Ee8FGJiYnvO9MuEAhOnjxJcR7wUd3d3WfOnHlnNeTxeNevX3/nqQ4ASAI9A1Cns7Pz3Llz79vfic/nwy6TIugDvxQ+n5+SkvLq1Ssq84CPio+Pb2lped9neTzemTNnqMwDpBzcRw1Qp6Oj4+nTpz1/TE9PDwgIuH37toKCAvERGo3m4OCAKB14t7y8vN6bLowaNWrNmjXffPNNz0fMzMxUVFRQRAPv9uLFi5cvX/b8cdOmTXV1dfv27ev5iIaGhrGxMYJkQCrBfeEBdeTk5BwdHXv+SJy8tbe3V1ZWRhcKfISNjU3vP9LpdCMjo96/RyBq9PX19fX1e/6oqanZ3d0NvzKACsybAAAAAIAs0DMAAAAAQBboGQAAAAAgC/QMAAAAAJAFegYAAAAAyAI9AwAAAABkgZ4BAAAAALJAzwAAAAAAWaBnAAAAAIAs0DMAAAAAQBboGQAAAAAgC/QMAAAAAJAFegYAAAAAyAI9AwAAAABkgZ4BAAAAALJAzwAAAAAAWaBnAAAAAIAs0DMAAAAAQBboGQAAAAAgC/QMAAAAAJAFegYAAAAAyAI9AwAAAABkgZ4BAAAAALJAzwAAAAAAWaBnAAAAAIAs0DMAAAAAQBboGQAAAAAgC/QMAAAAAJAFegYAAAAAyAI9AwAAAABkgZ4BAAAAALLgAoEAdQYgyXg8Xtn/qaqqqv8/XC63ra2trKzMysqKRqPJyspqaGhoaGhoaWkZGhqamJiYmJjo6+ujji+lqqurS0tLy8rKKioqampqiF9Ze3s7hmFsNltHR0dNTY1Op6urqxO/NX19fWNjY2NjYxMTEyaTiTq+NGprayspKSkrKystLSV+ZXV1dY2NjRiGvXjxgsPhGBkZYRimrKxM/CvT0tIifmUDBgxQVlZGHR9IMugZQMh4PF5eXl5aWlpmZubjx4/z8vI6OzsxDJOXl+/fv7+GhoampqaGhgaDwcAwTFFRsbW1FcOwzs5O4pmxpqamqqqqu7sbwzBVVdXBgwfb2dk5Ozu7ubkZGxsj/c4kWVVVVXp6+r179x4/fvz48eO6ujoMwxgMhr6+vq6uLlEm5OXlMQxTUFBob28XCAR8Pr+uro6oIJWVlc3NzRiGsVgsKysrOzs7R0dHNzc3e3t74hcNhK61tTUjIyM9Pf3Ro0ePHj0qLS3l8/kYhmlraxO/Mi0tLVVVVQzDmEwmjUbr6urCMKy5ubmurq62trampubly5fEoYyNje3s7Ozt7V1dXV1dXVVUVBB+X0DyQM8AwlFWVpaQkBAfH3/r1q3m5mZlZWUnJyc7Ozs7Oztra2tjY2Ntbe0+HorP51dVVZWUlDx58iQnJ+fx48cPHz7s7u7W19cfP368l5fX+PHj1dTUSP12pEFLS8v169fj4+MTExPLysoYDIatra2Dg4OdnZ2tre2AAQMMDQ373hJev35dVlaWn59P/MoePHjw+vVrBQWFESNGTJgwYcKECebm5qR+O9KAx+M9ePAgPj4+ISEhOzuby+UaGRkNHTqU+JWZm5ubmJgQdbAvOjs7y8rKioqKcnNzc3JysrOzi4qKaDSanZ2dl5eXl5eXm5sb1ETw5aBngC9SX19/6tSpkydP3r9/X1FR0d3dffz48SNGjLCxsaHT6cIapaOjIzMz886dOwkJCXfv3sUwzN3d3cfHZ+rUqerq6sIaRUpwudyEhITIyMhLly51d3c7OTl5eXmNHj3ayclJUVFRWKMIBAI2m52WlpaUlJSUlNTQ0GBtbe3j4+Pr62ttbS2sUaRHbm5uZGRkTEzMixcvjIyMvLy83N3dhw8fbmBgIMRRampq0tPTb9y4kZCQUFRUpK6uPnXqVF9f33HjxkHhAJ9PAMCn6+rqOnfu3JQpU1gslqKi4rx5865du9bV1UXB0A0NDbGxsVOnTpWVlZWRkZk5c+aNGzf4fD4FQ4u7rKysVatWaWtr4zg+atSoo0eP1tbWUjAuh8NJSUkJCAggFtw4OzsfPXq0paWFgqHF3atXr3bt2mVvb49hmImJya+//vrkyRNqhi4qKvrjjz+cnJwwDNPT0/vll19KSkqoGRpIGOgZ4NM0NTVt375dW1ubRqN5eHhERka2trYiSdLc3Hzs2DEXFxcMw2xsbKKiorhcLpIkIo7P51+4cIF4wTA3N9+0aVNpaSmSJDwe78aNG7NmzZKVlVVRUdmwYQM1RUccPX36dN68eQwGQ0VFZdGiRbdv30ZVpouLizdu3Kivr0+j0b799tusrCwkMYD4gp4B+qquru63335TU1NTVlZev359RUUF6kT/9fjx4zlz5jAYDFNT0yNHjlBzWkUscLncmJgYW1tbHMenTJmSlpaGOtF/1dXVbd26VUtLS0FBITAwsKqqCnUiEZKdnT19+nQajWZlZXXixAli1S1yHA7n7NmzQ4cOxTBswoQJd+7cQZ0IiA3oGeDjXr9+vXbtWkVFRU1NzU2bNjU0NKBO9A7FxcV+fn4yMjKGhob79+/ncDioE6HE5/NPnDgxcOBAOp0+a9as3Nxc1Ineoa2tbffu3QYGBjIyMj/88MOLFy9QJ0IsKyvr66+/xnHcwcHhn3/+4fF4qBO9Q0JCwsiRIzEMGz16dEpKCuo4QAxAzwAfQrxcaWtr6+jo/Pnnn6I/p15RUbFq1SpZWVk7Ozupfcv18OFDV1dXBoOxaNGioqIi1HE+orOz8/Dhw0ZGRsrKynv27JHOgtjQ0LBixQo6ne7q6nrlyhXRX290+/ZtDw8PHMfnzp376tUr1HGASIOeAd6LzWZ7eHjQaLS5c+fW1dWhjvMJnj17NnHiROJJsLq6GnUc6rS2tgYFBTEYjKFDh2ZkZKCO8wna29uDg4NlZWUHDx4sOvM71IiLi9PR0VFXVw8LCxP9htHbxYsXjY2NVVVV9+zZA6ujwPtAzwDv0N7e/uOPPzIYDGdn5+zsbNRxPtM///xjaGgojk/fn+f06dN6enqamprHjh0T0++3oKDA09MTx/FFixaJ5vSccLHZ7NGjR9NoNH9//9evX6OO8zlaW1vXrVvHYrEcHR0zMzNRxwGiCHoGeNPTp09tbW3V1NTCw8NFc4a471paWtauXUun06dOnSrBr1ttbW0LFy7EcXzJkiX19fWo43wpojCZmJjcv38fdRYSRUZGKioqOjo6PnjwAHWWL/X06dMxY8awWKw9e/aIaccF5IGeAf4H8dw3dOjQ4uJi1FmE5vbt2wYGBv3795fIE/L5+fl2dnYqKipnzpxBnUVoamtrJ0yYwGAwgoODxb3svq2joyMgIADH8YCAAIm5PIrP5+/Zs4fJZE6ePFkCyi4QIugZ4L/a29sl77mvh6S+bkVERCgoKDg5OUneHko9r1ve3t6S9LqVn59va2srYb2wB9Hp+/XrJ5GdHnwe6BlAIBAIKisrbW1tNTQ0Ll26hDoLWXg83rZt2xgMhq+vb2dnJ+o4X4rL5fr7++M4/tNPP3V3d6OOQ5aUlBQDAwMTExM2m406ixD8+++/CgoKw4cPf/78OeosZKmpqfHy8mIymcePH0edBYgE6BlAwGazjYyMrK2ty8vLUWch3Y0bN1RUVMaNG9fU1IQ6y+fr7OycPn26rKzsuXPnUGchXU1NjYuLi6amprgv1zh+/DiDwfDz85P4a3f5fP769etxHA8NDUWdBaAHPUPaPXjwQEtLy8nJSXp2gM7NzTUwMLC1tRXTbShbWlrGjx+vqqp6+/Zt1Fko0tbWNnHiRAUFhatXr6LO8pn27NmD43hQUBDqINQ5cOAAjUZbuXKlJM1Ugs8APUOqXb9+XVlZ2cPDo7m5GXUWSpWWlhI30S4sLESd5dO8evVqyJAhurq6Dx8+RJ2FUhwOZ9GiRQwGQ+zOxvP5/J9++gnH8T///BN1FqqdPXtWVlZ29uzZEjy1Bz4Keob0unr1KovFmjNnjnQ+BRAv2Pr6+mK0grKmpsbCwsLMzEySrgbqOz6fv2bNGhqNduLECdRZPsHSpUtZLFZsbCzqIGgkJiYqKipOmTIFNvKSWtAzpNTdu3cVFBTmz58vzRe7NzU1OTg4DBw4UCz2DG1ubh46dOiAAQOk/D4g69evZzAYly9fRh2kT3799VcGg3HhwgXUQVBKTU2Vl5dfvHixND/bSDPoGdKosLBQW1t70qRJEr8e7aOIMwR2dnYivotXd3f3V199paWlVVBQgDoLYnw+f/HixXJycqJ//5pDhw7hOH706FHUQdC7fPkyg8HYsGED6iAAAegZUqeystLIyMjFxaW1tRV1FpFQXFysp6c3duxYkb3YlcfjzZgxQ1lZOSsrC3UWkcDlcqdNm6aiovLo0SPUWd4rNjaWRqPBBRc9Tp48ieP4rl27UAcBVIOeIV2ampqsra0HDRokpjdTIMnDhw9VVFRmzZqFOsi7rV69WlZW9saNG6iDiJD29vaRI0caGhqK5izSzZs3WSxWYGAg6iCiZceOHTQa7Z9//kEdBFAKeoZ0mTFjhq6ubmVlJeogIic5OZlOpx84cAB1kDedOXMGx3GpXUX4AQ0NDQMHDhw7dqyoLTB89eqVrq7u9OnTYTnC2/z9/ZWVlYuKilAHAdSBniFFDh06RKPREhMTUQcRUSEhITIyMiI1N/Hs2TMVFZXly5ejDiKicnJy5OTkgoODUQf5/3g8nqenp6mpaWNjI+osoqizs9PR0dHOzq69vR11FkAR6BnSQgSfkUWNqL1CdHd3u7i4wDPyh4lae/79999Fra2KGmjP0gZ6hlRoaWmxtLQcPXq0qJ1hFjXV1dV6eno+Pj6ogwgEAsHKlSsVFRUl474epJo1a5a2trYoLNS4deuWaM6+iZozZ85gGBYdHY06CKACLuyDJCUAACAASURBVBAIMCDpFi9efOnSpUePHunp6aHOIuquX78+fvz448ePz58/H2GMa9euTZgwISYm5rvvvkMYQyw0Nzc7OjpaWFhcvnwZbQxra2sXF5d//vkHYQxxsXz58ujo6Pz8fHhSknjQMyRfRkaGq6vrqVOnfHx8UGcRDytXroyNjS0oKNDQ0EASoKury87Ozt7e/vTp00gCiJ3U1NRRo0adPXt26tSpqDIEBgZGRkYWFBRoamqiyiBGOjo6Bg0a5OLiEh0djToLIBf0DAnH4/GGDh2qpaWVmJiIOovYaG5utrKy+uabbw4dOoQkQEhIyK5du/Lz8w0MDJAEEEfz58+/efPm06dPFRUVqR/9yZMnQ4YM+fvvvxctWkT96GIqISFhwoQJ169fHzduHOosgETQMyTcnj17goKCcnJyLCwsUGcRJ1FRUfPnz09PT3d2dqZ46OLi4kGDBm3ZsmXNmjUUDy3WampqLC0tly5dun37doqHFggEY8eObW9vv3fvHo1Go3h0sfbNN9+w2eycnBwZGRnUWQBZoGdIslevXllaWgYEBGzatAl1FvHj7u7e1NR0//59Op1O5biTJk0qKyt7+PAhk8mkclwJcPDgwR9//PHRo0dWVlZUjnv8+HE/P78HDx44ODhQOa4EeP78ubW19caNG9etW4c6CyAL9AxJtmDBgpSUlCdPnsjJyaHOIn6ePn1qb28fFha2YMECyga9evXqpEmTbt++PXLkSMoGlRg8Hs/Z2VlLSys+Pp6yQdva2gYMGPDdd9/t3buXskElybZt27Zt21ZcXKyjo4M6CyAF9AyJ9fz5czMzs2PHjs2dOxd1FnG1ZMmSmzdvstlsBoNBzYgjRoxQV1e/ePEiNcNJnsTExK+++iojI8PJyYmaEXft2vXbb7+VlpZqaWlRM6KE6ezsNDU1nTt3bmhoKOosgBTQMyTWsmXLEhMTCwoKKHuNlDwlJSUWFhaRkZEzZ86kYLj/x959xkV1JWwAv1OoUgVsoBRRQQQLFoodELCCIERsIbbEaIiaaBKTlazJRo01mmhsqKAoKCqKg4KVKgjSi0pTrBSRIlJm5v0w+xpXsXLvnJk7z//D/jaI5zxyYebhlnMuXrzo5OSUkJDg4OAghenYysHBoXPnzidOnJDCXE1NTT179pw+ffrvv/8uhenY6vfff//5559LS0vxqA4roWew08OHD83MzLZs2bJgwQLSWeTbzJkzb9y4kZ2dLYX7+5ycnLhcbkxMDNMTsdupU6c8PT0zMzOtra2Znmvnzp1ff/11cXFxt27dmJ6LxRoaGkxMTL788svAwEDSWYB+6BnstHz58tDQ0OLiYlVVVdJZ5Ft+fn6/fv2OHz/u4eHB6ETXrl2zs7O7dOnS6NGjGZ2I9cRi8YABA6ysrA4fPszoRK2trb1793Z3d//zzz8ZnUgR/Pvf/966dWtpaammpibpLEAz9AwWqq6u7tGjx5o1a5YuXUo6Cxt4eXndvXs3JSWF0VmmTJlSWVmZkJDA6CwK4ujRozNmzCgoKDA3N2duluDg4Llz5968edPExIS5WRTEkydPTExMfvzxx2+//ZZ0FqAZHvVmodDQUA6HM3/+fNJBWGLp0qWpqamZmZnMTXH//v2oqCj0Qrp4e3t369YtKCiI0Vn27Nnj6emJkkELXV1df3//PXv2kA4C9EPPYKGDBw96eXkRWRWRlYYPH96rV6+QkBDmpjh06JCWltakSZOYm0Kh8Hg8Pz+/Q4cOiUQihqYoKyuLi4ubPXs2Q+MroFmzZt28efPatWukgwDN0DPY5ubNmykpKXiWlV5+fn7BwcGtra0MjR8SEuLr64slEWk0e/bssrKyq1evMjT+gQMHDAwMxo0bx9D4CsjW1rZfv37BwcGkgwDN0DPY5sCBA4aGhriXkF6zZs16/PjxhQsXmBj8xo0bWVlZqIb06tu376BBg5h70zp8+PCMGTOwZiu9ZsyYERoa2tTURDoI0Ak9g1XEYvHhw4dnz54t5aWyWa9nz5729vYMvWkFBwebm5vb29szMbgimzVr1rFjx549e0b7yImJiYWFhaiGtJs1a9bTp0+luZwrSAF6BqskJCSUlpbOmDGDdBAWmjVr1okTJxobG+kdViwWSx6O4HA49I4Mfn5+z549O3v2LO0jHzlyxMrKCruZ0M7Q0HDUqFGhoaGkgwCd0DNY5ezZs6amplZWVqSDsNDkyZMbGxtpv96fkZFx//79KVOm0DssUBTVqVOnoUOHMvHLsUAgmDx5Mu3DAkVRkyZNiomJYe5eKJA+9AxWEQgEEyZMIJ2Cnbp162ZtbU37m5ZAIOjSpcuAAQPoHRYk3N3dBQIBvasE3bp16/bt2+7u7jSOCS+4u7s/efIET52wCXoGe1RWVmZmZrq6upIOwlpubm60LwoeGxvr6uqKiyYMcXNze/DgQW5uLo1jxsbGamlp4X4ahvTp08fU1BSr77MJegZ7SJaSdHR0JB2EtUaMGJGfn19VVUXXgK2trampqdgCnjkDBw7U0tKid5XV+Ph4BwcHbE/InBEjRmBhXDZBz2CPxMREKysrXV1d0kFYy9HRkcPhJCUl0TXgjRs36uvrsTsrc3g83tChQ+l900pMTMTJDEY5OjomJSXhFg3WQM9gj5SUlGHDhpFOwWa6urq9evWicaOT1NRUHR0dCwsLugaE19nb29N4yCoqKkpLS+3s7OgaEF5nb2/f0NCQl5dHOgjQAz2DPbKzs3E7IdP69++flZVF12iZmZn9+/fHzRmM6t+//+3bt+laRSMjI4OiKPygMcrS0lJFRSU7O5t0EKAHegZL3L17t6qqysbGhnQQlrO2tqbx5S8zMxOHjGnW1tZCoZCuX46zsrK6dOnSqVMnWkaDNvH5/D59+qBnsAZ6Bkvk5+dTFCX7K2dcv36dw+EEBgaSDvKR+vbtW1JSQtdqXQUFBX379qVlKEbJ9VHr2bOnioqK5Aek/fLz82X/p4yS80NGUZSVlRWum7AGegZLlJSUaGlp6enpkQ7yj/j4eA6H88svv7Tzc2SKmZmZWCwuKytr/1DV1dVPnz41MzNr/1A0Yt9R4/F4PXr0KCkpoWW00tJSHDIpMDU1peuQAXF4NIslSktLTU1NSad4t8GDB9O7aJKUSb7IJSUl7b95s7S0lKIoExOTdodiHAuOGl1vWiUlJWPGjKFlKEbhkIHswPkMligvL+/evTvpFOynra2to6Nz9+7d9g8lGaRHjx7tHwreztjYmJZDRlFUeXk5DpkUGBsbNzQ0VFdXkw4CdBADK7i6un722Wc0DlhdXf3FF1907txZVVXV1tb29OnTQUFBFEWFh4e/+ByRSLR37157e3sNDQ1VVVUbG5vt27eLRCKxWLxmzZo2v9lSU1Mpilq9evVbPuftI4vFYsni35s3b7548aK9vb26urqRkdFvv/0m+dM//vijd+/eKioqffr0CQsLo/FrImFubv7rr7+2f5w9e/Zoamq2f5yX4ai16Ycffujfv3/7x3n69ClFUdHR0e0f6gUcsjbduHGDoqibN2/SOywQgZ7BEoMHD16xYgVdozU2Nr7y5B6Hw/H19X355U8kErW5Mez8+fPF7Xv5e/vI4v9/+fP19X1lTcZNmzatWLHi5Y9wudwbN27Q9WWRsLOzW7ZsWfvHWbt2rampafvHeQFH7U02btxoZGTU/nGKioooikpNTW3/UBI4ZG9y584diqISExNpHBNIQc9gCXNz8//85z90jbZ+/XqKovr06XPhwoW6urqSkpIlS5ZIXlBevPwdPHiQoihra+uzZ89WVVXV19dfuXKlf//+L14d4uLiKIpas2bNyyO//PL3ps9558gvNjP7+uuvS0tL6+vrjx07pqSkpK2trampuWfPnsePH1dVVS1fvpyiqNmzZ9P1ZZEYP368v79/+8f5/vvvBw0a1P5xXsBRe5OgoKAOHTq0f5y0tDSKom7fvt3+oSRwyN6kvr6eoqioqCgaxwRS0DNYwsjIaNOmTXSNNnToUA6Hk5OT8/IHXVxcXn75GzNmDI/Hu3///sufI9mwauXKleJ2vPy9c2TJy5+bm9vLn+Dl5UVR1MaNG198pLW1VVtbW3JDHI08PT2nT5/e/nGWLl1qb2/f/nFewFF7k8OHD/N4vPaPk5iYSFFUeXl5+4eSwCF7k5aWFoqiIiIiaBwTSMHzJizR3NyspKRE12hFRUWGhoavrBPg6ur68iaKubm5QqFQcvOp5JtJ8n8oipKc8/xo7znyqFGjXv5bxsbGFEWNHDnyxUd4PJ6hoeGjR4/aE+Z1ysrKTU1N7R+nublZWVm5/eO8gKP2JioqKkKhUCgU8ni89owjOe74QaOYP2R8Pp/H49HygwbEoWewRGtrK40vfxRFvb4Ytvh/H5MTiUQURQmFwtf/bnNzc3umfs+RVVVVX/4jSeDXPygZjUbKysoNDQ3tH6elpYX2PT9x1Nok6XPNzc1qamrtGUeysxd+0Nr8IO0/aEpKSu38B4KMwHOtLMHj8Wjc3rBnz57l5eWvrMf38u9YFEVZWFioq6vX1NS8fpbs2LFjFEVxuVzq/1+a36TNz3nnyGS1tLTQch6Cz+e3+RL/0XDU3kRyEr79R03SC/GDJh10/aABcegZLKGiokJj9/fy8hKLxd7e3pcvX25oaCgrK1u6dOn58+df/py5c+c+e/bM2dn5zJkzFRUVzc3NZWVlUVFRXl5eFy5coCiqY8eOFEXFxcVVVVW9aaI2P+edI5PV3NysoqLS/nHoPWQUjtqbNTU18Xi8dl40oV46L0JHKIrCIXszyXUuWn7QgLzXmyzIo549e754rr39nj179sr+XhwOZ9q0aRRFnTx5UvI5IpHo008/bfObSiAQiMXi1tZWQ0PDV77ZXrk9rc3PeefILx7rfzmz5Kb37Ozslz9oZWVlaGhI15dFYsKECZ9++mn7x/nuu+9sbW3bP84LOGpvsn//fnV19faPI3nepKioqP1DSeCQvYnk0uSZM2doHBNIwfkMltDR0ampqaFrNDU1tUuXLi1cuLBTp06S5YMiIyMlO37p6upKPofD4QQFBR09etTZ2VlXV1dZWdnMzMzDw+PEiRPOzs4URfF4vGPHjg0fPrxDhw5vmqjNz3nnyGRVV1e/+CK0h46OzpMnT9o/zgs4am9C4yGjKIrGo4ZD9iaSlUAlp2FA7pEuOkCPcePGzZ07l7nxhULhwIEDORxOZWUlc7PIhV69ev3yyy/tH2f37t1aWlrtH+ctcNQkVq1aZWNj0/5xJFWe3vVAX4FDJiFZD7SwsJB0EKABzmewhL6+fmVlJY0DLl++PCQkpKys7NmzZxkZGT4+Pjdu3Bg9erRMbQlLRFVVFS1fBH19/draWnqf3MNRa1NlZSUtXwEtLS0lJSX8oEmB5D4SnM9gBzzXyhJGRkaxsbE0DlhYWLhp06aXP6KhofHKRxRQXV1ddXW1kZFR+4eSXC8vLy/v2bNn+0eTwFFr0507d2jZZZDD4RgaGtK1JZsEDlmb7ty5o6ampuBlizVwPoMljI2N6d1GefPmzZ9++qm5ubmKioqBgYG3t3dSUtIrezEoIMlm7pLd4dtJsiO8ZEC64Ki1qaSkRPLVbj8TExMcMimQHLLXFxcBeYTzGSxhamr65MmTmpoaya1q7derVy/JvpHwspKSEg6HQ8ubloGBgYaGBr3tEEftdSKRqKysjJZqSFGUiYkJDpkUlJSU0HXIgDicz2AJS0tLiqIkexMAc3Jzc3v06PGWG/s/iIWFBQ4Z00pKShobGyU/IO1naWmJQyYFubm5kudugAXQM1jC2NhYR0cnKyuLdBCWy87Otra2pmu0/v3745AxLTs7m8vlvrKHyEezsbG5d+8evbeCwiuEQmFBQQGNP2hAFnoGS3A4nH79+uFNi2n09gwbGxscMqZlZWWZmppqaGjQMppk2/Ts7GxaRoM23bx5s7GxsV+/fqSDAD3QM9hj6NChycnJpFOwWW1tbX5+/tChQ+kacOjQoZWVlbdv36ZrQHhdUlISjYesa9eu3bt3xw8ao5KSktTU1NAzWAM9gz0cHByys7OfPn1KOghrJSYmikQiBwcHuga0tbVVU1NLSEiga0B4hUgkSk5OdnR0pHFMBwcHHDJGJSQkDBs2DJuosQZ6Bns4OjoKhcJr166RDsJa8fHx5ubmnTp1omtAJSWlwYMHx8fH0zUgvCInJ6empobGakhRlIODQ1JSEr177cLL4uPj6T1kQBZ6Bnt06dKlb9++586dIx2EtaKjo2nf92Hs2LHR0dH0jgkvREdH6+vrS26qoIuTk1N1dfX169dpHBNeKCkpuXnzJvENVoBG6Bms4u7uLtliEWhXUVFx48YNd3d3eod1d3cvLy/Ho5IMEQgEbm5uXC6dL3RWVlbGxsb4QWOIQCDQ0NDA+Qw2Qc9gFXd39/z8/OLiYtJBWOjMmTNKSkpjxoyhd9ghQ4bo6+ufOXOG3mGBoqgnT54kJibSXg0pinJzc8MhY8iZM2ecnZ1VVFRIBwHaoGewyqhRowwMDMLDw0kHYaGQkJCJEyfS9XjkC1wu18PD49ixY/QOCxRFHT16lMfjTZgwgfaRPT0909LSioqKaB9ZwT1+/Dg2NtbX15d0EKATegar8Pl8Dw+PsLAw0kHY5t69e1euXJk1axYTg/v4+Fy/fh1Pt9IuODjY09NTW1ub9pGdnJw6deqEdki7w4cPq6mpTZ48mXQQoBN6Btv4+vqmp6fn5+eTDsIqwcHBOjo6TJyBpyhqzJgxnTp1Cg0NZWJwhVVUVJSUlMRQNeTz+Z6enocOHWJicEUWHBzs7e2trq5OOgjQCT2DbcaOHduzZ889e/aQDsIqhw4d+uSTTxh6oJ/P58+ePXv37t14VJJGwcHBnTp1Yu6xBX9//+zsbCzYRaO8vLz09PTZs2eTDgI0Q89gGw6H4+/vf+DAgaamJtJZWCItLS0nJ2fmzJnMTTFv3rzy8vLz588zN4VCEYvFISEhM2bM4POZ2pJ62LBh/fv33717N0PjK6CDBw8aGxuPGDGCdBCgGXoGC3322Wf19fUHDhwgHYQltm7damVlZWdnx9wUffr0GTt27KZNm5ibQqFERUUVFxf7+/szOsvnn39++PDhBw8eMDqLgmhoaNi7d++nn35K70PIIAtwRFmoa9euc+bMWbduXWtrK+kscq+4uDg0NPS7775jeqLvvvsuNjY2MTGR6YkUwW+//TZp0iSmN8jw9/fv2LEj2iEtduzY0djY+OWXX5IOAvTjiMVi0hmAfsXFxX369AkKCmL0bL8iWLBgwYULFwoLC5k7A/+Co6Ojvr7+qVOnmJ6I3WJjY11cXBISEqSw1tOGDRsCAwNLS0v19fWZnovFmpqazMzMZsyYsX79etJZgH7oGaw1e/bs69ev5+Tk4DzkRysvLzc3N9++ffu8efOkMN3p06enTJmSkZFhY2MjhenYasyYMUpKStK52aWhocHU1PSLL774+eefpTAdW/3555/ffPNNUVFRt27dSGcB+qFnsFZBQYGVlVV4ePjUqVNJZ5FXAQEBERERRUVF0tk6UiwWDx48uHfv3njG9aMlJyfb29tfvnx51KhR0plxzZo1GzduLCsrY2KhDkXQ0tLSu3fviRMnbtu2jXQWYAR6Bpv5+Pjk5eXduHFDSUmJdBb5U1JSYmVltW7duiVLlkht0rCwMD8/v5SUlEGDBkltUtYQi8WjR48Wi8VXr16V2qQ1NTUmJiaLFy/+5ZdfpDYpm2zbtu2bb765detWjx49SGcBRqBnsFlZWVnfvn0DAwO//fZb0lnkz+TJk4uKijIyMqTZ0sRi8dixYxsaGpKTk3HB60MFBwd/+umnSUlJQ4cOlea8W7duXbFiRWZmpoWFhTTnZYFHjx5ZWFgsWrTo119/JZ0FmIKewXL//ve/161bl5eXZ2xsTDqLPDl16pSHh8eFCxfGjh0r5alzc3MHDhz4559/zp8/X8pTy7Xa2loLCwtPT88///xTylMLhcIhQ4bo6enFxMRIeWp5N2vWrKtXr+bl5XXo0IF0FmAKegbLNTc329jYWFtbY3O199fY2GhlZeXo6BgcHEwkwPLly/fv319QUGBgYEAkgDxavHhxeHh4QUGBrq6u9GdPTU21s7MLDQ318fGR/uxyKi4ubtSoUSdOnJgyZQrpLMAg9Az2i4mJGTdu3JkzZ5jYuJKVVq1atX379vz8fFJ3v9fV1VlaWrq5uWH9+PeUnp4+dOjQffv2EVy1et68eVFRUQUFBbgh9H20trba2tp269ZNIBCQzgLMQs9QCD4+PikpKenp6R07diSdRdalpKSMGDFiw4YN0rz983Xh4eG+vr5RUVEMbd7GJo2NjXZ2djo6OpcvX+ZwOKRiVFZWWlhYeHh4oB2+j1WrVm3evDknJ8fMzIx0FmAWeoZCePLkycCBA/v163f69GmCL8Syr6amZtCgQaampjExMcRvw5wzZ86ZM2fS09Nxb83bLVy4MCwsLD093dTUlGySqKioSZMm7d+/H5uBvd3FixfHjRu3c+dO6axMA2ShZyiK5OTkkSNHrlu3bunSpaSzyC4vL6/ExMQbN2506dKFdBaqoaFhyJAh2traV69exZPJbxIWFvbJJ58cO3ZMRtaJWbZs2a5du1JTUy0tLUlnkVGPHj0aMGDAqFGjjhw5QjoLSIUYFMZ//vMfJSWlhIQE0kFk1JYtW7hc7oULF0gH+Ud2dra6uvoPP/xAOoiMunXrlpaWVkBAAOkg/2hubra3t+/Xr19DQwPpLLJIKBQ6OTmZm5s/ffqUdBaQEvQMBSIUCt3c3ExMTCorK0lnkTnXrl1TVlb+5ZdfSAd51e7du7lc7tmzZ0kHkTkNDQ0DBgwYMmRIU1MT6Sz/o6SkRFdXd+7cuaSDyKJVq1apqqpmZGSQDgLSg56hWB4/fmxsbGxvb49ftl5269atTp06jR8/XigUks7ShtmzZ2tqal6/fp10EBnS0tIyceJEfX39oqIi0lnacPLkSS6XK4O1law9e/ZwOJw9e/aQDgJShZ6hcCTvqc7OzrL2WyARVVVVOTk5vXr1GjJkSF1dHek4bWtubnZzc9PX1y8oKCCdRSaIRKLPPvtMXV1dli8C7ty5k8Ph/P3334WFhaSzyITIyEg+n7969WrSQUDa0DMUUUpKioaGhp+fn2z++i5N1dXV6urqmpqap06dIp3lbRoaGhwcHLp3737nzh3SWchbsWKFkpKSjF9Levz4sZOTE0VRP/30E+ks5CUlJamrqy9YsIB0ECAAPUNBRUdHKykpffPNN6SDkNTY2Dh69Gg9PT3JPdEWFhY7duyQ2bMaFRUVffr0sbGxqampIZ2FpE2bNnE4nIMHD5IO8kYJCQl+fn6SR4SMjIxUVVWvXLlCOhRJWVlZurq6np6era2tpLMAAegZiiskJITL5S5btkwkEpHOQkBtba2Tk5OOjk5mZuaYMWO4XC6Hw+Fyuerq6l9++WVubi7pgG0oLS01NDS0tbV99OgR6SxkrF+/nsPhbNiwgXSQNtTX1+/atcvKyoqiKGVlZYqiuFxuRkaGl5eXhobG+fPnSQckIzU11cDAYNSoUY2NjaSzABnoGQrt+PHjKioqM2bMaG5uJp1Fqh4+fDho0KDOnTunp6eLxeKMjIyXly+TvEn079//wIEDsvaVKS4u7tWrl6mp6c2bN0lnkSqRSLRixQoOh7N+/XrSWV518+bNlStXamlpcbncF8u7KSkp+fv7i8XilpaWzz77TFlZ+fDhw6STStuFCxe0tLScnJxqa2tJZwFi0DMUnQK+EBQXF/fu3fuVt+rZs2e/shaW5AyHnp7eypUrS0tLCQZ+haQkdenSRVKSFMGLt+pDhw6RzvIPoVAYExPj5ubG4XBeX0hNWVn5xc00IpHo22+/ldkzMQw5duyYqqqqAv4aA69AzwBxSkqKgYHBsGHDKioqSGdhXFpaWpcuXWxtbR8+fPjyx+/evSs5jfE6Pp/P5XI9PDxiY2Nl5BrT06dPx44dq62tfenSJdJZGFdXV+fm5qahoXHu3DnSWf7r/v37P//8c+fOnTkcDo/Ha/N75vXbP9euXcvhcH744QcZ+S5i1ObNmxX5siy8DD0DxGKxuKCgwMTEpHv37vHx8aSzMGj37t1qamrOzs5tnrz5/vvv+Xz+WxbPNTExefz4sfRjt+n58+fTpk3j8/nr169n8Ut5VlaWhYVFp06dUlJSSGf5x6pVq97yfUJRVMeOHdv8Htu3bx+fz58wYQKL18qrq6ubMWOGbF7hAiLQM+C/ampqvLy8JA+4s+951xevfV999dWbzuLW1ta+aT9bHo+nra0ta8tXiESiLVu2KCsrOzs7v3J6hh0OHDigrq4+dOjQkpIS0ln+h0gkmjNnTptnMiiK4nK5O3fufNPfTUlJMTU1NTIyiouLk2Zm6cjLy+vXr5++vn5UVBTpLCAr0DPgH2x938rNzbWystLX13/nigvbt29/fZtWDoejrKwss0tCsfJ96316IVnNzc3jxo17/QQYl8vt2bNnS0vLW/5uTU2Nt7c3+zq9pBeOHDmyvLycdBaQIegZ8KqkpCRjY2MjI6MTJ06QztJezc3N69evV1NTe8/XvpaWFnNz81eqBofDOXLkiBTSfrSqqqrJkyfz+fxVq1Y9e/aMdJz2unjxYu/evQ0MDKKjo0lneZuGhoZevXq9fgfo6dOn3/l3RSLRhg0blJSUXFxcbt26JYW0jLp37563tzeXy/3hhx/e3rFAAaFnQBuqqqpmzZrF4XAmTJggm/tHvI/Lly9bWVmpqamtWbPm/RcIioiIeOVtQ1NT087OTsZvkhWJRNu2bdPS0jI1NY2MjCQd5yPdv3/fz8+PoqhJkybdu3ePdJx32Lp1K5fL1dPTe1E1+Hy+o6Pj+4+Qgc36yQAAIABJREFUnJxsbW2tqqq6evVqOV1eoqWlZdOmTZqamj179oyJiSEdB2QRega80dWrV/v166empiZ3L4KVlZULFizgcDhOTk4fcVOFvb295J2Dy+WuWbPm9u3b5ubmPXv2lP3fOx88eCApiBMnTiwuLiYd5wMIhcK///5bW1vbyMgoLCyMdJx3EIlEq1ev5nA4q1evLioq6tixo+ReDQ6Hk5qa+kFDtbS0bNmyRUtLy8zMTO7uaYiLi7OxsVFSUvrqq6/q6+tJxwEZhZ4BbyO57qChoWFubn7w4EHZPyNaU1Pzyy+/6OjoGBsbf/R1n+TkZA6Hw+Fw5s+fL/nIgwcPJEtWpKWl0ReWKRcuXLC0tFRXV//+++9l5wGZNxEKhRERETY2NioqKqtWrZL9nYRbWlrmzp3L5/Nf7DuampqqpqbG4XB8fX0/bszy8nIfHx/JiZwPbSpE5Obm+vn5cTgcNzc32e/fQBZ6Brzb3bt358yZw+fzzczMdu7c+fz5c9KJ2lBRUfHjjz9qa2vr6Oj861//aufb1bRp0yZOnPjy1ZYXqzgIBIJ2h2VcU1PT77//3qlTJ3V19a+//lo278trbW09dOiQlZUVl8v18vKSi31N6+rq3N3dNTQ0XrmnWCAQdOjQoZ3PxcTExAwdOpSiKFdX16tXr7YrKGPS09O9vLy4XK6VldXx48dJxwE5gJ4B76u4uPjzzz9XUVExNDTcvHmz7Kwfevfu3eXLl2toaBgYGPz666+0bDNWXl7++g2VTU1NM2bMUFZWDgkJaf8UUtDQ0LBlyxYjIyMVFZWFCxfKzu+djY2Ne/bsMTc35/P5M2fOlM3dZF738OFDW1vbzp07X79+/fU/pevLe+7cuZEjR1IUNXLkSIFAIDsPpFy9enX8+PEcDsfW1jYiIkJ2goGMQ8+AD/Po0aPVq1draWmpqqpOmzYtMjKS1MWUZ8+ehYWFTZw4kc/nd+rUafXq1U+fPmV60pcvzDM9F12ampoOHDjQu3dviqJsbW23bNlC8J7W69evf/XVV/r6+kpKSrNmzZKLcxgSRUVFvXr1MjMzk87OMvHx8RMnTuRwOEZGRl999VVGRoYUJm3T3bt3165d26dPH4qiHB0dIyMjWbwuHDABPQM+RnV19Y4dOxwcHCiK6tq16/Lly6W210Zzc/O5c+dmzZrVoUMHZWVlDw+PiIgIKV/KkTxo8NVXX8nRr3Stra1nz56dPn26mpqaqqqqt7f3qVOnpHZ7b15e3o8//mhiYkJR1MCBAzdt2vTgwQPpTE2LlJSUTp06DRkyRMo75ebm5n733XdGRkYURQ0ZMuSPP/6Q2sI2VVVVu3fvHjlyJIfD6dSpU0BAQJtncQDeCT0D2uXWrVv/+te/zMzMKIoyNDScN29eWFjY/fv3aZ8oPz9/165dU6dO1dLSoijKzs5u+/btBBdvPn78uKqq6tSpU+XrSRyxWPz06dN9+/aNHj2ay+Wqq6tPmDBh+/bt2dnZtHemioqKkydPLlq06MW3x7fffpudnU3vLFJw/vx5TU1NFxcXUtcKhUJhbGzsnDlzNDU1uVyura3tjz/+eOnSJdrvmX3+/Hl8fPyaNWscHBx4PJ6qqqqvr++ZM2dk/wZwkGUcsVjc5tK5AO9PLBZfv349OjpaIBCkpKQIhUIzM7Nhw4bZ2NhYW1tbWlr26NHj7VuHvKKxsbG4uDg3Nzc7OzsrKyspKamioqJDhw6jR492d3d3d3eXvHWRdfnyZQ8Pj4EDB548eVJbW5t0nA9WXl4uEAgEAsGFCxdqa2t1dHTs7e379+9vbW1tZWVlbm7eoUOH1/9Wc3NzmxvOCYXCe/fuFRQUZGVlZWdnp6SkFBQUcLncAQMGSA6ZnZ3dmxbqlmUHDhyYP3++n5/f7t27X1+SS8qePXt24cIFgUAQHR1dUlKipKQ0cODAQYMG9e/fv1+/fr169ercufMHDVhVVXXr1q3s7Ozs7Oz09PTr1683NTUZGhq6ubm5ubmNGzdOUusB2gM9A2hWV1eXnJycmJiYmpqak5NTVlZGURSfzzcyMurevbu+vr6enp6enh5FUbq6uhRFtba21tXVtba2VlVVVVVVVVZWlpaWPnjwQPK3zM3NbWxs7OzsHBwcBg0aRPyF/hW5ubnu7u5aWloCgaB79+6k43wkoVCYlZWVkJCQnJyclZVVUFDQ0tJCUZSBgYGJiUmnTp309PQkd1R06NDhypUro0aNamxsFIlENTU1FRUVVVVV9+7dKysrk/ytrl27WltbDxkyxMHBwcHBQUdHh/S/7+OtW7fu+++/X7FixW+//cbhcEjH+R93796Nj49PSkq6ceNGdnb206dPKYpSV1c3NTXt2rWrgYGBnp6e5NqipC8+e/asqampsbGxsrKyqqrq/v37paWldXV1FEVpaGhYWVkNHDjQ3t7e0dGxZ8+ehP9twC7oGcCsmpqawsLCkpKSkpKSe/fuVVdXV1ZWVldXUxT15MkTiqL4fL6mpiafz9f7f8bGxiYmJqampn369FFVVSX9L3iH+/fvu7u7V1ZWCgQCGxsb0nFo0NLScvPmzeLi4pKSkrKyMsnbUlVVVUtLS0NDw61bt/T19bt168blcrW1tSXvZ127djU1NZUcMkmJlHdCoXDJkiW7du3atm3bF198QTrOu5WVlRUVFUkO2YMHDySHrKGhobm5uaGhgaIodXV1FRUVNTU1yU9Zly5djI2NTU1Ne/bsaWpqKmstCtgEPQOgvZ48eTJlypScnJxTp06NGDGCdBwGXbp0aezYsZMmTYqMjCSdhUFNTU2zZs2KjIwMDg6eNm0a6TgA8u3VrSkB4EPp6urGxMQ4Ozu7uLiEh4eTjsOg0NBQDocTHR0tORfFSk+ePHFxcYmNjY2JiUHJAGg/9AwAGqioqISGhn722WfTp0/fsWMH6TiMaGlpOXr0qFgsFolEr+82xw73798fPXp0UVHR5cuX2X1qCkBq0DMA6MHj8f76669ff/31yy+//O6779h3RVIgENTW1lIUJRaLg4ODScehX25urp2dnVAoTE5OZsetNgCyAD0DgE4rV64MCgratGmTv7+/5PkL1jh06JDkeR+RSHT16tV79+6RTkSny5cvSx61SEhIkN9HhwBkEHoGAM3mzJkTFRUVERExYcIEyXODLNDQ0CBZY17ynzwej013opw4ccLd3X3s2LECgUAel0IBkGXoGQD0c3FxuXDhQmZmppOT0+PHj0nHocGpU6eam5tf/KdQKDxw4ADBPDT6448/vL29FyxYcOzYMdl/jhpA7qBnADBiyJAhSUlJNTU19vb2t27dIh2nvUJCQrjcf14uxGJxRkaGvP+7xGJxYGDg119//dNPP0n2rCGdCICF8HMFwBQzM7O4uDhdXd0RI0akpaWRjvPxqqurY2JiWltbX/6gkpLSkSNHSEVqv+bm5lmzZv3222/BwcGBgYGk4wCwFnoGAIM6d+58+fLlQYMGjR49WiAQkI7zkcLDw19/fKalpWX//v0k4tCgvr5+ypQpp06dOnXq1IwZM0jHAWAz9AwAZmloaERGRvr6+k6ePHnv3r2k43yM4ODgNh/TLS4uzsjIkH6ednr48OGoUaMyMjKuXLni5uZGOg4Ay33AFpoA8HH4fP7u3buNjIzmz59/9+5d+TpLf//+/cTExDZ7hrKycmho6IABA6Sf6qMVFRW5u7tLHs3t1asX6TgA7IfzGQDSwOFwAgMDt27dumbNmq+++kokEpFO9L5CQ0PftOZYc3PzwYMH5WhFstTUVHt7ex0dnaSkJJQMAOnA+QwA6VmyZImRkZGfn195efmhQ4fU1NRIJ3o3yVLcL8rE7du3O3XqpKWlJflPHo9XVFRkbm5OLuD7iomJ8fLysrOzO378uKamJuk4AIoC+7UCSNvly5c9PT0HDBhw4sQJHR0d0nE+jJaW1ubNm+fOnUs6yIc5cODA/Pnz/fz8du/eLVnVFACkA9dNAKRt9OjR8fHxRUVFw4cPv3v3Luk47Ldu3Tp/f/9ly5YFBQWhZABIGXoGAAFWVlbJyck8Hs/Ozi4rK4t0HNYSCoWLFi1atWrVX3/9tXbtWg6HQzoRgMJBzwAgo1u3bpcvX+7Zs+fo0aPj4uJIx2GhpqamTz75ZN++fUeOHPn8889JxwFQUOgZAMTo6urGxMS4uLi4uLiEhYWRjsMqT548cXZ2vnDhQmxsrLe3N+k4AIoLPQOAJBUVlcOHD8+dO9fPz++vv/4iHYclysrKHBwc7t69m5iYOHz4cNJxABQanmsFIIzH4/3555+9e/devHhxYWHhli1bcBtBe+Tk5Li7u+vo6MTHxxsZGZGOA6Do0DMAZEJAQICuru68efNqamr27NmDxyI+zqVLlzw9PQcNGnTixAltbW3ScQAA100AZMbs2bPPnj174sSJ8ePH19XVkY4jfyIiIsaPH+/k5HT27FmUDAAZgZ4BIEMkty5mZWU5OTk9fvyYdBx58scff0ybNm3BggXh4eGqqqqk4wDAf6FnAMiWIUOGJCUl1dTU2Nvb37p1i3QcOSAWiwMDA7/++uuffvpp69atXC5e1gBkCH4gAWSOmZlZXFycrq7uiBEj0tLSSMeRac3NzTNnzvztt99CQkLkayNcAAWBngEgizp37nzlypVBgwaNGjVKIBCQjiOj6uvrp0yZEhkZeerUKT8/P9JxAKAN6BkAMqpDhw6RkZHTp0+fPHnynj17SMeROQ8fPhw1alRGRsaVK1fc3NxIxwGAtuG5VgDZxefzd+3aZWhouGDBgvLyclwXeKGoqMjNzU0sFsfFxcnFrvQACgs9A0CmcTicwMBAfX39gICAqqoq3OdIUVRKSsrEiRNNTU3PnDljYGBAOg4AvI2iv2AByIXFixcfO3Zs79693t7ejY2NpOOQdPr06TFjxtjZ2V26dAklA0D2oWcAyAdPT88LFy5cvXrVycmpqqqKdBwy9u/fP3XqVB8fn4iICHV1ddJxAODd0DMA5Ia9vf2VK1fKy8tHjhx59+5d0nGkbd26df7+/suXLw8KCuLzcc0XQD6gZwDIEysrq+TkZCUlJTs7u8zMTNJxpEQoFH7xxRerVq3asWPH2rVrSccBgA+AngEgZ7p163bp0iVzc/MxY8ZcvXqVdBzGNTU1ffLJJ/v37z9y5Mjnn39OOg4AfBj0DAD5o6ure/78eRcXl3HjxoWFhZGOw6Dq6mpnZ+eLFy/GxMR4e3uTjgMAHww9A0AuqaioHD58eN68eX5+fn/++SfpOIwoLS11dHQsLy9PSEgYPnw46TgA8DFwLxWAvOLxeNu3b+/Vq9eSJUtu3ry5ZcsWDodDOhRtcnJy3N3ddXR04uLijIyMSMcBgI+EngEg3wICAnR1defNm1dTU7Nnzx4lJSXSiWhw6dIlT0/PQYMGnThxQltbm3QcAPh4uG4CIPdmz5599uzZkydPjh8/vra2lnSc9jp+/Pj48eOdnZ3Pnj2LkgEg79AzANjA2dn5woULWVlZTk5Ojx8/Jh3n423dutXHx2fBggVhYWGqqqqk4wBAe6FnALDE4MGDk5OTa2tr7ezsbt68STrOBxOLxd99993SpUv/85//YBsXANbATzIAe5iamiYmJnbp0sXBwSEpKYl0nA/Q3Nw8c+bMzZs3h4SErFy5knQcAKANegYAq+jp6cXExAwbNszFxeXs2bOk47yX+vr6yZMnR0ZGRkZG+vn5kY4DAHRCzwBgmw4dOpw6dcrPz2/KlCm7d+8mHecdHj58OHLkyMzMzKtXr7q6upKOAwA0w3OtACzE5/P//vvvbt26LVy48N69e4GBgaQTta2oqMjNzU0sFsfFxZmbm5OOAwD044jFYtIZAKBdtmzZ0tzc3OYfJSYmRkZGzp07t1evXrTMFRkZaWNjY2Ji0v6hxGLxli1bVFRUPv300zdt8u7u7m5tbd3+uQCAFPQMALmnqampoqKioaHR5p82NzcrKytLOdJ7amlp4fP5b1rG9M6dO7t37547d66UUwEAjXDdBIAN1q1bx773Y01NTdIRAKC9cB8oAAAAMAU9AwAAAJiCngEAAABMQc8AAAAApqBnAAAAAFPQMwAAAIAp6BkAAADAFPQMAAAAYAp6BgAAADAFPQMAAACYgp4BAAAATEHPAAAAAKagZwAAAABT0DMAAACAKegZAAAAwBT0DAAAAGAKegYAAAAwBT0DAAAAmIKeAQAAAExBzwAAAACmoGcAAAAAU9AzAAAAgCnoGQAAAMAU9AwAAABgCnoGAAAAMAU9AwAAAJiCngEAAABMQc8AAAAApqBnAAAAAFPQMwAAAIAp6BkAAADAFPQMAAAAYAp6BgAAADAFPQMAAACYgp4BAAAATEHPAAAAAKagZwAAAABT0DMAAACAKegZAAAAwBT0DAAAAGAKegYAAAAwBT0DAAAAmIKeAQAAAExBzwAAAACmoGcAwAe4ffs26QgAIE/4pAMAAA2io6OrqqqkMFFwcPDEiRN1dXWlMFdLS4sUZgEARqFnAMg9Y2Pj1NTU1NRUpicSiUTl5eX37t3T0tJiei6Korp06aKpqSmFiQCAORyxWEw6AwDIh3379s2dO9fS0jIvL490FgCQD7g/AwDeV0hICIfDyc/Pz83NJZ0FAOQDegYAvJfHjx9fuXJFLBYrKysfOXKEdBwAkA/oGQDwXkJDQ7lcLkVRzc3N+/fvxyVXAHgf6BkA8F4OHjwoFAol/7+8vDwlJYVsHgCQC+gZAPBuxcXFN27ceHEOQ1lZOTQ0lGwkAJAL6BkA8G6hoaF8/j+PwTc3N4eEhLw4vQEA8CboGQDwbsHBwa+smlVVVXXp0iVSeQBAXqBnAMA7ZGVlFRYWvvJBJSWlw4cPE8kDAHIEPQMA3iE0NFRJSemVD7a0tBw9evT58+dEIgGAvEDPAIC3EYvFBw8ebHOrkcbGRoFAIP1IACBH0DMA4G0SExPv37/f5h/xeLxDhw5JOQ8AyBfsowYAbyNZ+vPFdRPJo60cDoeiKKFQeObMmbq6Oux2BgBvgp4BAG8zatQoa2vrF/8ZEBDg4+Pj6Oj44iO1tbXoGQDwJtivFQA+gJaW1ubNm+fOnUs6CADIB9yfAQAAAExBzwAAAACmoGcAAAAAU9AzAAAAgCnoGQAAAMAU9AwAAABgCnoGAAAAMAU9AwAAAJiCngEAAABMQc8AAAAApqBnAAAAAFPQMwAAAIAp6BkAAADAFPQMAAAAYAp6BgAAADAFPQMAAACYgp4BAAAATEHPAAAAAKagZwAAAABT0DMAAACAKegZAAAAwBT0DAAAAGAKegYAAAAwBT0DAAAAmIKeAQAAAExBzwAAAACmoGcAAAAAU9AzAAAAgCnoGQAAAMAU9AwAAABgCnoGAAAAMIUjFotJZwAAwmpraysqKqpeUl1d3dTURFFUTU2NWCxubm5uaGigKCo6Orpv3749evTg8/mampoURXXo0EFZWZmiKF1dXb3XKCkpkf2nAQBZ6BkAiqK+vr60tLSkpKSkpKT0/z148KCqqqqlpeXFp6moqEgqwov2QFGUkpKShoYGRVHq6uqNjY1isbi1tbWuro6iqGfPnr1oJBUVFbW1tS9Pqq2t3blz5+7du5uampr8P1NT065du3I4HCn+6wGADPQMAHZ68uRJdnZ2VlaW5H9v375dWVkp+SMDA4MX7/qGhoaSVqGvr29gYKCnpyfpEx+tpaXl5fMilZWVDx8+LCsrk9SaO3fuSDqNioqKiYlJv379rK2tra2t+/fvb2pqyuXiSi4A26BnALDEvXv3EhMT09PTs7Ozs7Oz79y5Q1GUrq6ujY2NtbV17969TU1NJfWiQ4cOpEIKhcJ79+5JOsft27fz8vIyMzOLi4tFIpGGhoaVlZWNjY2Njc2wYcMGDhzI5/NJ5QQAuqBnAMgroVCYk5MTHx+fmJiYkJBQVlbG5/MtLS2tra0l3cLa2rp79+6kY75bQ0NDbm5uZmampCFlZmY+efKkQ4cOQ4cOdXR0dHBwcHBw0NbWJh0TAD4GegaAPBGLxenp6dHR0VevXk1KSqqrq9PW1nZwcLC3tx8+fPjQoUMJnqugi1gsLigoSExMjI+PT0pKKiws5HK5VlZWw4cPd3FxcXJy0tLSIp0RAN4XegaAHKiqqjp//nx0dPS5c+cePXrUrVs3JycnBwcHR0dHKysrdt/W8Pjx46SkpPj4+Li4uOvXr3O5XEdHRzc3Nzc3t/79+5NOBwDvgJ4BILsyMzNPnjwZHR2dmprK5XIdHBzc3d0V+f21srIyJiZGIBCcO3fu8ePH3bp1c3NzGz9+/Pjx49XU1EinA4A2oGcAyJycnJywsLCwsLDCwkIjIyNJt3B2dsb1ghdEIpHk+pFAILh27ZqamtqkSZN8fHzc3NxUVVVJpwOAf6BnAMiKkpKSyMjIgwcPpqenGxoaenl5TZs2zdHREetMvF1VVVVUVFR4eHh0dLSysvLYsWNnz549efJkFRUV0tEAAD0DgLQnT54EBwfv27cvMzOza9eu3t7ePj4+Dg4O7L7rggn3798/duxYWFhYYmKitra2r6/vvHnzBg8eTDoXgEJDzwAgQywWX716dffu3cePH1dSUvL19Z05c+aIESNQL9rv7t274eHhe/fuzcvLGzhw4Pz58/38/PBkLAAR6BkA0vbkyZPw8PBt27bl5OTY2touWLBg+vTpkr1CgF5paWm7du06fPhwa2vrpEmTFixY4OTkhOtQANKEngEgPTdu3Ni4cWN4eLi6uvqMGTPmz5+vsE+OSNPTp08PHz68e/fuGzduWFtbL1261M/PD3dvAEgHegYA48RisUAg2Lhx48WLF21sbJYuXerj46Ourk46l8JJS0vbtm1baGhox44dlyxZ8vnnn3fs2JF0KACWQ88AYFBzc/ORI0d+//33nJwcR0fHlStXTpw4EeftyXr06NGOHTu2bdvW0NDg4+Pzww8/WFhYkA4FwFroGQCMqK+v3759+9atW6urq/38/JYtW2ZtbU06FPyjvr5+7969W7ZsuXv3rqen508//WRjY0M6FAALoWcA0KyxsXHHjh1r1659/vz5l19+uWTJkm7dupEOBW0TCoXHjx9fu3ZtZmamt7d3YGCgpaUl6VAArIIn6ABo09zcvGvXLnNz859++mn69Om3bt367bffUDJkGY/H8/HxSU9PP3fu3K1bt/r16+fj43Pz5k3SuQDYAz0DgAYtLS0HDx60tLRcsmTJxIkTb9++vXXr1s6dO5POBe/L2dk5LS3tyJEj2dnZlpaWPj4+t2/fJh0KgA3QMwDaKzIy0srKav78+a6ursXFxX///XfXrl1Jh4IPxuFwpk2blpOTExQUlJ6ebmVl9e233z59+pR0LgD5hp4B8PFycnLGjRvn4eExaNCgwsLCv/76y9DQkHQoaBcejzd79uz8/PzNmzcHBQX17t179+7dQqGQdC4AeYWeAfAxqqurAwICBg4cWFVVdeXKlSNHjpiYmJAOBbRRUlJatGjR7du3/f39lyxZYm1tfe7cOdKhAOQSegbAh2ltbd21a5eFhcXhw4c3bNiQkpIyYsQI0qGAETo6OmvXrs3KyurZs6ebm9ukSZOKi4tJhwKQM+gZAB8gIyPDzs5u8eLF06dPLyoqCggI4PF4pEMBs3r37n369OmYmJjS0lIrK6vAwMDm5mbSoQDkBnoGwHtpaGhYtmzZ4MGDtbS08vLytm7dqqWlRToUSI+zs3N6evq//vWvdevWDRs2LC0tjXQiAPmAngHwbleuXBk0aFBQUNDGjRtjY2PNzc1JJwIClJSUvv/++5ycHD09PTs7u4CAgPr6etKhAGQdegbA29TU1CxcuHDMmDG9e/fOzs4OCAjgcvFTo9B69uwZExOzd+/ekJAQGxubmJgY0okAZBpeMQHe6PTp0xYWFmfOnImIiDh9+rSRkRHpRCATOBzO7Nmzs7OzBwwY4OrqunDhwoaGBtKhAGQUegZAG549e/bFF19MnjzZ3d09Ly/Pw8ODdCKQOd26dYuIiAgLCzt+/Litre3169dJJwKQRegZAK/Kycmxs7MLDQ0NCQkJCgrS1tYmnQhkl7e3d25urpmZmb29fWBgIFb0AngFegbAP8Ri8datWwcPHqyvr5+TkzNjxgzSiUAOdO7cOSoqasOGDWvXrh0xYgTW2AB4GXoGwH/du3fP2dl5xYoVP//8c2xsLO7GgPfH4XACAgKSk5NramoGDx4cFhZGOhGArEDPAKAoirp06dKgQYPu3buXmJi4cuVKPFQCH2HAgAFpaWmffPKJr69vQEBAS0sL6UQA5OHFFIDatWuXq6urnZ3dtWvXbG1tSccBOaampvbXX3+dPHly//79Y8aMuX//PulEAIShZ4BCq6+v9/X1XbRo0Zo1a06ePIlbPoEWU6ZMSUlJqa6uHjBgwMWLF0nHASAJPQMU161bt+zt7S9evCgQCFauXMnhcEgnAvbo06fPtWvXRo4c6erqum7dOtJxAIhBzwAFFRkZOXjwYDU1tfT0dBcXF9JxgIU0NTXDw8NXr179ww8/zJw5s7GxkXQiAALQM0ARbd682dPTc9q0aXFxcd27dycdB1iLw+H8+OOPUVFRZ8+edXJyqqioIJ0IQNrQM0CxCIXCr776avny5T/99NOePXtUVFRIJwL2c3NzS0lJqaystLOzKygoIB0HQKo4YrGYdAYAKWloaPDz8zt37lxQUND06dNJxwHFUlVV5eHhkZube+LEiVGjRpGOAyAlOJ8BiuLhw4ejR49OSEiIiYlByQDp09PTi4mJcXV1dXV1DQkJIR0HQEp4gYGBpDMAMC43N3fs2LFCofDy5csDBgwgHQcUFJ/Pnzp1ak1NzcqVK5WUlEaMGEE6EQDj+KQDADDu+vXrbm5uffv2PXHihJ6eHuk4oNC4XO7GjRvNzMwiZKf9AAAgAElEQVQCAgIqKys3btyIB6qB3dAzgOXi4+MnTJjg6Oh4/PhxNTU10nEAKIqivvzySwMDg5kzZ9bX1+/cuRPr3AOLoWcAm12+fHnSpEljxowJCwtTVVUlHQfgHz4+Ph06dPD29q6rqzt48KCSkhLpRACMQIkG1oqKinJ3d580aVJERARKBsigCRMmCASCqKioqVOnPn/+nHQcAEagZwA7HT161NPTc9asWSEhIXw+ztuBjBo9evTZs2fj4uLGjx9fX19POg4A/dAzgIVCQkJmzJixePHiv//+G1e+QcYNHz48NjY2Kytr8uTJWJsc2AfrdAHbRERE+Pr6Ll26dP369aSzALyvrKysMWPGDBs27OTJk8rKyqTjANAGPQNYJSYmZtKkSXPnzt2+fTseFwT5kpGRMWbMmNGjR4eHh+NiH7AGegawR0JCgqurq5eXV1BQEC6XgDxKTEx0dXX18PA4cOAAvoeBHdAzgCWuXbvm4uLi4uJy9OhR/C4I8is2NnbSpEl+fn579uzBOTlgAfRlYIOMjAx3d/fRo0cfOXIEJQPkmrOzc2ho6MGDB1esWEE6CwANsL8JyL3S0tIxY8YMGDDgxIkT2OcdWMDCwsLc3HzFihUaGhoODg6k4wC0C37zA/lWW1s7efJkPT29Y8eOYTEuYA0/P7+HDx9+88033bp1w/bCINfQM0COtbS0eHl5VVVVJScna2trk44DQKdly5aVlpZ+9tlnxsbGOKsB8gv3gYK8EovF/v7+ERERV69exVbvwEpCodDLyyshISExMbFXr16k4wB8DNwHCvLq3//+d0hISEhICEoGsBWPxzt8+LCZmZm7u3tFRQXpOAAfA+czQC4FBwfPmTNnx44dCxcuJJ0FgFkPHjyws7MzMTE5f/487nQGuYPzGSB/UlJS5s+f/80336BkgCLo2rXrmTNnMjIylixZQjoLwAfD+QyQM1VVVYMHDzY3N4+OjubxeKTjAEhJZGSkh4fHrl275s2bRzoLwAdAzwB5IhQKx48fX1hYeP36dX19fdJxAKTqhx9+2LRpU1xc3JAhQ0hnAXhf6BkgT7799tvt27fHx8fb2tqSzgIgbSKRaMKECbm5uWlpaQYGBqTjALwX9AyQGydPnpw6derevXv9/f1JZwEgo7q6evDgwaampufPn8d1Q5ALuA8U5ENhYeGcOXMWLVqEkgGKrGPHjhEREUlJST/99BPpLADvBeczQA40NjYOGTJES0vr8uXLysrKpOMAELZv37558+ZFRUW5u7uTzgLwDugZIAcWL14cEhKSmZlpbGxMOguATJg5c2ZMTExmZmaXLl1IZwF4G/QMkHXnzp1zd3c/dOgQdpMCeOHp06cDBgywsLA4e/Ysh8MhHQfgjdAzQKZVVFTY2NiMGzfuwIEDpLMAyJaEhIRRo0b98ccfixYtIp0F4I3QM0B2icXiKVOm5OTkZGRkaGlpkY4DIHNWr169fv36lJQUa2tr0lkA2oaeAbLrzz///Prrr69cuYJNsQHa1NraOnLkyLq6utTUVFVVVdJxANqA51pBRhUUFHz77berVq1CyQB4Ez6fHxISUlZWhsdcQWbhfAbIIpFINGrUqOfPnyclJfH5fNJxAGTa3r17Fy5cmJSUhPXIQQahZ4AsklwxSUlJGThwIOksALJOLBaPGzfu0aNHaWlpSkpKpOMA/A9cNwGZc//+/R9//HHFihUoGQDvg8Ph7Nq1q7i4+PfffyedBeBVOJ8BMsfDwyM/Pz8zMxP3tQG8v7Vr1wYGBt64ccPS0pJ0FoB/oGeAbDly5Iifn19sbOzYsWNJZwGQJ62trcOGDdPQ0Lh8+TJW7gLZgZ4BMqS6urpv374eHh47d+4knQVA/mRmZg4ZMmT79u0LFiwgnQXgv9AzQIYsWLAgKioqLy9PW1ubdBYAufTtt9/u2bPn5s2bBgYGpLMAUBR6BsiOjIyMwYMHHzx40M/Pj3QWAHn17NkzCwuL8ePH46QgyAj0DJAVo0ePbmpqSkxMxKVlgPY4ePCgv79/SkqKra0t6SwA6BkgG8LDw319fZOTk4cOHUo6C4B8E4vF9vb2ampqly5dIp0FAD0DZMDz588tLS1HjhyJTVkBaJGcnOzg4HDs2LGpU6eSzgKKDj0DyPv111/Xrl1bWFjYrVs30lkAWGLWrFkJCQl5eXlYhwbIwnqgQNijR4/Wr1///fffo2QA0Gjt2rUVFRWbN28mHQQUHc5nAGELFy48d+5cfn6+mpoa6SwArLJmzZoNGzYUFxfr6emRzgKKC+czgKSysrL9+/f/61//QskAoN2yZctUVVU3bNhAOggoNJzPAJL8/f3j4+Pz8/Ox+TsAEzZs2BAYGFhUVNS5c2fSWUBB4XwGEHPr1q2QkJDVq1ejZAAwZPHixTo6OuvXrycdBBQXzmcAMX5+fmlpabm5uegZAMz5448/Vq5cefv2bUNDQ9JZQBGhZwAZubm5NjY2R44cmTZtGuksAGzW1NTUq1evKVOmbNu2jXQWUEToGUCGt7d3YWFhZmYml4uLdwDM2rlzZ0BAQEFBgampKeksoHDQM4CAvLy8fv36HT9+3NPTk3QWAPZrbm7u06fPhAkTtm/fTjoLKBz8KgkEbNy4sXfv3lOmTCEdBEAhKCsrL126NCgoqLKyknQWUDjoGSBtjx8/Pnz48PLly3HFBEBq5s6dq6amhs3iQfrwQg/S9scff2hpac2cOZN0EAAF0qFDhwULFmzbtu358+eks4BiQc8AqXr27Nnff//95ZdfYgFQACkLCAiora0NCQkhHQQUC3oGSFVQUFBDQ8OiRYtIBwFQOJ07d54+ffqGDRtEIhHpLKBA8LwJSI9IJOrTp4+Li8tff/1FOguAIiooKOjbt+/p06cnTJhAOgsoCvQMkJ7IyEhPT8/8/PzevXuTzgKgoMaPH9/S0hITE0M6CCgK9AyQnokTJ7a0tJw7d450EADFdebMmcmTJ9+8edPc3Jx0FlAIuD8DpKS8vDw6Onr+/PmkgwAoNHd39+7du+/bt490EFAU6BkgJXv37tXV1Z00aRLpIAAKjcfjzZkzJygoqKWlhXQWUAjoGSANIpEoKCjI399fRUWFdBYARTdv3ryKioqoqCjSQUAh4P4MkAaBQDB+/Pi8vDxLS0vSWQCAcnV1VVJSOnPmDOkgwH7oGSANU6dOffLkyaVLl0gHAQCKoqhjx475+vqWlJT06NGDdBZgOVw3AcY9fPjwzJkz8+bNIx0EAP5r8uTJ+vr6+/fvJx0E2A89AxgXHh6upqbm5eVFOggA/JeysvKMGTMOHTpEOgiwH3oGMO7IkSNTpkxRVVUlHQQA/uHr63vz5s2MjAzSQYDl0DOAWeXl5UlJST4+PqSDAMD/GDp0qImJydGjR0kHAZZDzwBmhYWFaWtru7i4kA4CAP+Dw+H4+PgcPXoUTwMAo9AzgFlhYWGenp5YNgNABvn4+JSUlKSlpZEOAmyGngEMunPnTkpKCi6aAMgmW1tbc3NzXDoBRqFnAIOOHDmio6MzduxY0kEAoG3Tpk3DpRNgFHoGMCgiImLq1KnKysqkgwBA23x8fO7evZuamko6CLAWegYwpbKyMjU1FRunAciyAQMG9OjRQyAQkA4CrIWeAUyJjo7m8/m4aAIg41xdXaOjo0mnANZCzwCmREdHDx8+XFNTk3QQAHgbNze3lJSUiooK0kGAndAzgBEikSgmJsbNzY10EAB4B2dnZx6PFxsbSzoIsBN6BjDi+vXrjx8/dnd3Jx0EAN5BS0vLwcEBl06AIegZwAiBQGBkZGRlZUU6CAC8m5ubm0AgEIlEpIMAC6FnACOio6Pd3d05HA7pIADwbu7u7hUVFdhTDZiAngH0q62tTU1NHTduHOkgAPBebGxsunTpEhMTQzoIsBB6BtAvKSlJKBQOHz6cdBAAeC8cDmf48OEJCQmkgwALoWcA/RITE83Nzbt06UI6CAC8L0dHx8TERCxADrRDzwD6JSQkODo6kk4BAB/A0dGxqqqqsLCQdBBgG/QMoJlQKExJSUHPAJAvAwcO1NDQwKUToB16BtAsMzOzrq7OwcGBdBAA+AB8Pn/IkCHoGUA79AygWUJCgo6OjqWlJekgAPBhHB0d4+PjSacAtkHPAJolJCQ4ODhwufjWApAzjo6Ot27devjwIekgwCp4MwCaXb9+fdiwYaRTAMAHGzZsGIfDSUtLIx0EWAU9A+hUV1dXXFw8YMAA0kEA4IPp6up27949OzubdBBgFfQMoFN2drZYLLa2tiYdBAA+ho2NDXoG0As9A+iUlZWlqalpYmJCOggAfAxra+usrCzSKYBV0DOATtnZ2TY2Ntg+DUBOWVtbFxQUNDU1kQ4C7IGeAXTKysrCRRMA+WVjY9Pa2lpQUEA6CLAHegbQRiwW5+TkoGcAyK8+ffqoqKjg0gnQCD0DaHPnzp2amhobGxvSQQDgI/H5fAsLC9wKCjRCzwDaSM619u3bl3QQAPh4VlZW+fn5pFMAe6BnAG1KSkq0tbU7duxIOggAfDxTU9PS0lLSKYA90DOANqWlpaampqRTAEC7mJiYlJSUkE4B7IGeAbQpKSlBzwCQd6ampg0NDRUVFaSDAEugZwBtSktLsUIXgLyT/LaAUxpAF/QMoA16BgALdO/encfj4RYN+L/27jysiWthA/gkrAGBakBcqiKgIEiQxYVEwQJqaG2tRYTWFsGlUihqH23t87ResPa20lat12pbF2pVVEBFxSUuiLKjiJRNUCsIrkCqhEUJkHx/5H6UixSiTjjJ5P394SNJyLxzFPLmzMwJXdAzgB6KiVYcNwHQdHp6ekOHDsV8BtAFPQPoUVlZKZfLMZ8BwAC45ARohJ4B9KiurqYoavjw4aSDAMDLsrKyun37NukUwBDoGUCP2tpaAwMDMzMz0kEA4GVZWFjU1dWRTgEMgZ4B9KirqzM3NyedAgBowOVyxWIx6RTAEOgZQA+xWMzlckmnAAAamJubYz4D6IKeAfQQi8WYzwBgBi6XK5FIpFIp6SDABOgZQI+6ujrMZwAwg+I9w19//UU6CDABegbQA/MZAIyheM+AUzSAFugZQA+cnwHAGIr3DDhFA2iBngH0+Ouvv7TqE+Hz8vJYLFZ0dDTpIP9DPVP1gV27drFYrIMHDyr5eDUZqOeN3WcGDBjAYrFw3ARogZ4B9GhubjYyMiKdQk1lZGSwWKyvv/6adBAApejq6urp6TU3N5MOAkygSzoAMERLS4uBgQHpFH3H3d1dLpeTTtGVeqYCTWRgYIDrTYAWmM8AekilUn19fdIpAIAe+vr6LS0tpFMAE6BnAA3kcnlra6sa9gyRSMRisX788ceLFy96eXmZmJi4u7tTFCWXy2NjY/l8vomJCYfDcXZ23rJlS+eZgEePHoWHhw8aNIjD4bi7ux8/frzLofQuB/jb29s3b97s5ubWv3//V155xd3dfcOGDYpp56+//nrKlCkURa1evZr1/xTf1XOMfwrfgy6pOp4hNTWVz+cbGxsPGzZs3bp1ins3b95sZ2dnaGhob2+fmJjY+XnS0tLmzZtna2trYGBgYWHx5ptvZmZmdn5Ar+PT6971MGK9evz48ccffzx48OCOrT/7mF7/ibvoYZezs7NZLNbHH3/c5VsSEhJYLNYPP/yg5BaVia0+DAwM0DOAHnKAl/bkyROKoo4dO0Y6SFenTp2iKCogIEBX97+HCF1cXGQy2bx58579WVi8eLHiu548eTJu3LjOd7FYrMDAQIqiEhMTFY+5fPkyRVFRUVGKLz/99NNnn3Dz5s1yuXzt2rXd/tz1GqPb8D3vb5dUimcIDAzseAaFDRs2fPbZZ51vYbPZV69eVXzX/fv3n02lq6t78eJF5cen173rYcR6RsvWuwxUr7s8fvx4ExOThoaGzkm8vLyMjY0fPXqkzBaVia1WrKysYmJiSKcAJkDPABrU19dTFCUSiUgH6UrxQktR1IIFC8rLy9va2uRy+e7duymKcnJyOnnypFgsbmxsvHjxorOzM0VRWVlZcrn8u+++oyjKzs4uJSWloaGhoqIiMjJS8Tz/1DNGjRplbGx86NChx48fNzU1FRQUrFy58rffflPcm56eTlHU2rVrO2frNUa34XvWbc+gKGr58uWVlZWNjY0HDx7U09MzMzMzMTHZsWNHTU2NWCxesWIFRVHBwcGK73rw4MG0adOSk5Orq6ulUunDhw8TEhKMjY39/PwUD1BmfHrdu55HrAcdWz937lxDQ8OtW7fCw8Ofd+tdBqrXXd6zZw9FUVu3bu2IUVJSQlHURx99pOQWlYmtVuzs7Lr8jwV4MegZQIOamhqKos6fP086SFeKF9pJkybJZLKOG1977TUdHZ179+51fqTiZWPVqlVyuXzChAksFqu4uLjzA6ZNm9ZDz3jttddGjRrV2trabYxue0avMboN37Nue4ZQKOz8GH9/f4qi1q9f33FLW1ubmZmZ4hxShby8vICAgCFDhnSeCHn11VcV9yozPr3uXc8j1oOJEyc+u3UfH5/n2nqXgep1l1taWgYNGjR27NiOx0dERFAUVVpaquQWlYmtVng83pdffkk6BTABzs8AGijOS1fb6018fX07TomgKKqkpKS9vX3YsGG6uro6OjpsNpvNZjs6OlIUVVVVRVHUn3/+OXToUMUtHWbMmNHDJjZu3CiTyWxtbZcsWbJ169arV6/2mqrXGN2GfwFeXl6dvxwxYgRFUZ6enh236OjoDB069OHDh4ovs7Ky+Hx+YmLivXv32traOh6mODpGKTc+ve7dC4yYws2bN5/dulAofK6td9HrLuvr64eFhRUXF6elpVEU1djYuGfPnunTp48ZM0bJLSoTW63gPFCgC3oG0EAul1MU9ZIvh6rTZaFSmUxGUVR7e3t7e3vHVIHiro4L+Z7dF3mP14s6OzuXlZXt3r175MiR6enpQqHQ0dGxqKioh29RJsaz4V+AoaFh5y8Vu/bsjYo8FEWtW7dOKpVGRUXdvHnzyZMnimx2dnbPPklnXcan1717gRFTnpJj20GZXQ4LC9PX19+6dStFUXv27JFIJMuWLXvhLao/Npvd8V8C4GVg/QyggeJKE035fWpvb5+fn3/v3j0zM7NuH2BjY3P58uXS0lIHB4eOG8+ePdvz0+rq6np6eirmCZqbm+3s7BYuXHjp0iWKothsNkVRnd8oKxODlFu3bllaWnZeK/PPP/+8ceNG//79FV8qMz7K7F0PI9YDW1vbS5culZSUdJ4bEIlEz7v1znrdZYqiLC0tAwMDDxw48ODBg59//nnUqFF+fn7Kb1GZ2GpF21bEAdXBfAbQQLN6xsKFC5ubm319fY8fP15bWyuVSm/fvn3ixAl/f/+UlBSKovz9/eVy+Zw5cy5cuNDU1HT79u1PPvnkzJkzPTwnn8//5ZdfSktLnzx5Ul9fLxKJxGLxrVu3FPcqVmRPT0/v/MFUvcYgZfjw4TU1NT/99FN9fX19ff3Jkydff/31zm9tlRmfXveu5xHrgWLr/v7+58+fb2xsrKioiIiI6DJizzu2ve6ywrJly1pbWxcsWFBUVBQZGdl5UkfJ/1Q9x1YrUqkUPQPo0SdngQDDKZY9SE5OJh2kK8WJkBs3bux8o0wmCwkJ6fbH4dSpU3K5vLm5mcfjdb6dxWIFBARQFHXkyBHFk3Q5kbDb38hLly5V3NvW1jZ06NAuP3e9xug2fM+6PQ+0yzMori4pKirqfKOjo+PQoUMVfz9y5EiXPC4uLmPHjuVyuYoHKDM+ve5dzyPWAyWva+15610Gqtdd7sDn8ymKMjU1lUgknW/vdYsad12rtbX1unXrSKcAJsB8BtBAs+YzWCzWb7/9Fh8f7+vr279/f319fWtr67fffjspKcnX15eiKA6Hk5qaumTJkoEDBxoaGrq5uR07dkxxjKDzRHpnubm5ERERDg4OHA7H3NxcIBDs2LFj48aNint1dHQOHjw4efJkY2Nj5WOQMmvWrLi4OB6Px+FwBg8evGTJkpSUlM61QJnx6XXveh6xHhgaGqampoaHh1taWhoaGrq4uCQlJXU5ofJ5x7bXXe4QFhZGUdSCBQtMTEyea4vKxFYrLS0tarjyHmgilhyfhgB00NXV3bt3b1BQEOkgKiGTydzd3QsKCmpra1/+xEzm0Z7x+eSTTzZt2nTjxg0bGxvSWVRr4MCB0dHRHYt8ALwwzGcAPRi2SvGKFSv27t17+/bt5ubmgoKCuXPnXr16derUqcx+EVWeFo5Pe3v76dOnf/75Z09PT8aXDArngQJ9cL0J0ENfX19Tjpsoo7y8fMOGDZ1v6devX5db+l5BQYGLi8s/3Ttr1qxnzzNQEdWNj/rsY2fR0dFr1qxR/H3VqlV9H6Dv4TxQoAvmM4AeHA7n6dOnpFPQZuPGjSEhIR2fqjVnzpzs7Owu5/FpM+0cnyFDhmzYsKHz5axMJZPJ0DOALjg/A+jh6OgYEBDQeQUCANBQYrHY3Nw8JSXF29ubdBbQeJjPAHpwudzOi0MAgOZS/Cwz+Gwb6EvoGUAPc3Nz9AwAZqirq6PQM4Am6BlADy6Xq/jdBACaDvMZQCP0DKAHjpsAMEZdXZ2RkRGHwyEdBJgAPQPogfkMAMZQnAdKOgUwBHoG0APnZwAwhlgsxkEToAt6BtCDy+U2NTU9efKEdBAAeFnoGUAj9Aygh+LzSO/cuUM6CAC8rKqqqldffZV0CmAI9Aygx8iRIymKqqysJB0EAF5WRUWFlZUV6RTAEOgZQI8BAwaYmZlVVFSQDgIAL0Uul1dVVSneOQC8PPQMoM2IESMwnwGg6e7fv//06VPMZwBd0DOANlZWVugZAJpOMSuJ+QygC3oG0GbkyJE4bgKg6SoqKvT09IYMGUI6CDAEegbQBvMZAAxQWVk5YsQIHR0d0kGAIdAzgDYjR458+PBhc3Mz6SAA8OJwsQnQCz0DaDN69Gi5XF5WVkY6CAC8uLKystGjR5NOAcyBngG0GT16NIfDKSoqIh0EAF6QXC4vLi7m8XikgwBzoGcAbXR0dMaMGYOeAaC5KisrJRIJegbQCD0D6MTj8QoLC0mnAIAXVFhYyGKxHB0dSQcB5kDPADo5OTkVFBSQTgEAL6ioqGjkyJGmpqakgwBzoGcAnXg8Xm1tbU1NDekgAPAiioqKnJycSKcARkHPADo5OztTFIVDJwAaqrCwECdnAL3QM4BOFhYWgwYNQs8A0ERPnz69efPm2LFjSQcBRkHPAJq5urpevnyZdAoAeG75+fltbW2urq6kgwCjoGcAzQQCQXp6OukUAPDcMjIyLC0tbW1tSQcBRkHPAJoJBIK7d+9WV1eTDgIAzyczM3Py5MmkUwDToGcAzSZMmKCvr5+ZmUk6CAA8B7lcnp2dLRAISAcBpkHPAJpxOJxx48ahZwBoluvXr9fW1mI+A2iHngH0EwgE6BkAmiUjI4PD4SguTQegEXoG0E8gEBQWFkokEtJBAEBZmZmZEydO1NfXJx0EmAY9A+jH5/Pb29tzc3NJBwEAZWVlZeHkDFAF9Ayg3+DBg+3t7c+dO0c6CAAopaqqqry8fOrUqaSDAAOhZ4BKCIXCU6dOkU4BAEo5deqUsbHxlClTSAcBBkLPAJUQCoVFRUVYRQNAI4hEIm9vbwMDA9JBgIHQM0AlvLy8jIyMzpw5QzoIAPSitbU1NTVVKBSSDgLMhJ4BKmFoaDh16lQcOgFQfxkZGfX19TNmzCAdBJgJPQNURSgUnj17trW1lXQQAOiJSCSys7OzsbEhHQSYCT0DVOWNN96QSCTZ2dmkgwBAT0QiEQ6agOqgZ4CqWFtb29ranjhxgnQQAPhH1dXVRUVF6BmgOugZoELvvPNOYmKiXC4nHQQAupeYmGhmZvbaa6+RDgKMhZ4BKjR37tyKioq8vDzSQQCge/Hx8bNnz8YVraA66BmgQm5ubqNGjUpISCAdBAC6UVVVdfny5blz55IOAkyGngGqFRAQEB8fj0MnAGrowIEDr7zyire3N+kgwGToGaBac+fOra6uxmeqAaihhISEOXPm4DNaQaXQM0C1nJ2dx4wZg0MnAOrm1q1b+fn5OGgCqoaeASo3Z86cxMREmUxGOggA/O3AgQPm5ub4jFZQNfQMULmgoKA7d+6kpqaSDgIAf9u7d29AQICuri7pIMBw6Bmgcg4ODh4eHjt27CAdBAD+KyMj49q1awsXLiQdBJgPPQP6wuLFiw8fPlxbW0s6CABQFEVt377d2dnZ1dWVdBBgPvQM6AtBQUFGRkZ79+4lHQQAqPr6+oMHD4aFhZEOAloBPQP6AofDCQoK2rZtGxbSACAuLi5OLpcHBQWRDgJaAT0D+khYWFhZWVlmZibpIADabseOHUFBQa+88grpIKAV0DOgjygOBm/fvp10EACtlpeXd/Xq1UWLFpEOAtoCPQP6zuLFixMTE8ViMekgANrr119/dXBw4PP5pIOAtkDPgL4THBxsZGT0888/kw4CoKVqamr27t27dOlS0kFAi6BnQN8xMjL68MMPN2/e/PTpU9JZALTR5s2bTUxMgoODSQcBLYKeAX1q2bJlEokkLi6OdBAArdPc3PzLL79ERERwOBzSWUCLoGdAn7K0tAwKCvr+++/xcScAfSw2NraxsRHLZkAfY2E9A+hjxcXFPB7v+PHjr7/+OuksANqivb3d3t5+2rRpW7duJZ0FtAt6BhAgFApbW1tTUlJIBwHQFgcPHgwMDCwpKbG3tyedBbQLegYQcPbs2enTp+fl5bm5uZHOAqAVPDw8LC0tjxw5QjoIaB30DCBjwoQJlpaWycnJpIMAMN+pU6def/31nJyciRMnks4CWgc9A8hQ/OLLzs6eNGkS6SwADDdx4sSBAwei1gMR6BlAjKenJ4fDOX36NOkgAEx29OjR2bNn5+bmjh8/nnQW0EboGUBMSldXIE4AABFcSURBVEqKr6/vhQsXvLy8SGcBYCa5XO7q6mptbX3o0CHSWUBLoWcASd7e3q2trenp6aSDADBTYmJiUFBQfn6+s7Mz6SygpdAzgKTMzMzJkyefO3fOx8eHdBYAppHJZOPGjXN0dNy/fz/pLKC90DOAMKFQWF9fn5WVxWKxSGcBYJS9e/eGhIQUFxdjzQwgCD0DCLty5cqECRPi4uKCgoJIZwFgjubmZsUCoDt37iSdBbQaegaQt2DBgrNnz5aVlRkbG5POAsAQUVFRGzduLC8vHzx4MOksoNXwOWpA3rfffiuRSNavX086CABD3LlzZ/369atXr0bJAOIwnwFqYd26dV999VVZWdnw4cNJZwHQeO++++6lS5dKS0sNDAxIZwFth54BakEqlY4dO3bChAl79+4lnQVAs2VnZwsEgqSkpFmzZpHOAoCeAWrj8OHDc+bMSUtLmzx5MuksAJpKJpNNmjTJxMQEn4cMagI9A9SIt7d3Q0NDTk6Ojo4O6SwAGmnHjh0fffRRfn6+k5MT6SwAFIXzQEGtbN68ubCw8D//+Q/pIAAa6cGDB5999llkZCRKBqgPzGeAeomOjv7++++Lioqsra1JZwHQMAEBAZcvXy4uLu7Xrx/pLAD/hZ4B6kUqlbq6ulpaWp47dw4rhAIo78SJEzNnzhSJRDNmzCCdBeBv6BmgdnJzcwUCQWxsbHBwMOksAJpBIpE4Ojp6e3v//vvvpLMA/A/0DFBHkZGR+/fvLy0tHThwIOksABogPDw8MTGxtLTUwsKCdBaA/4GeAeqoqanJycnJw8MjLi6OdBYAdZeTkyMQCPbs2fPee++RzgLQFXoGqKmTJ0/OnDkzISFhzpw5pLMAqK/GxkYXF5fRo0efOHGCdBaAbqBngPoKCwuLj4//448/sBg5wD8JDQ09fvx4YWEhPsoE1BN6Bqiv5uZmNze3gQMHnj9/Hit3ATxLsYrukSNH3nrrLdJZALqHdbpAfRkZGcXFxeXk5OCjXAGedffu3cWLF4eFhaFkgDrDfAaou5iYmNWrV2dkZEyYMIF0FgB1IZPJpk2bdv/+/by8PCMjI9JxAP4RegaoO8Xv06qqqqtXr2KVQwCFb7/9NioqKjMzc/z48aSzAPQEx01A3bHZ7N9///2vv/5avnw56SwAaiEnJycqKuqbb75ByQD1h/kM0AzHjh17++23f/3118WLF5POAkBSTU2Nm5sbj8dLTk5ms/FeEdQdegZojC+//PKHH35IS0vDiRqgtdra2qZNm1ZZWZmXl8flcknHAegdegZoDJlMNnPmzOLi4itXrmBxZdBOK1as2Lp1a2ZmpqurK+ksAEpBzwBN8ujRI3d39xEjRpw5c0ZXV5d0HIA+lZSU5O/vHxsbGxISQjoLgLJwbA80Sf/+/Q8fPpybm/vFF1+QzgLQp8rLy0NCQiIiIlAyQLNgPgM0z65duxYsWHDgwIG5c+eSzgLQFx49euTh4cHlclNTU/X19UnHAXgOmHkGzRMSEpKfnz9//vxXX32Vz+eTjgOgWlKp9J133mlqajp//jxKBmgczGeARpLJZP7+/unp6dnZ2aNGjSIdB0BV5HJ5SEhIUlJSWlrauHHjSMcBeG44PwM0EpvN3rdvn62trZ+fX21tLek4AKqyZs2auLi4uLg4lAzQUJjPAA324MGDSZMmDRs27OzZs4aGhqTjANBs//798+bN++mnn8LDw0lnAXhBmM8ADTZo0KCTJ0+WlJTMnz9fJpORjgNAp4sXL4aGhn7++ecoGaDRMJ8BGi8lJcXPz2/58uXfffcd6SwA9CgsLPTy8hIKhfv27WOxWKTjALw4nejoaNIZAF6KtbW1tbX1Z599pqOj4+npSToOwMsqLy/38fFxdnZOSEjQ09MjHQfgpeC6VmCCefPmSaXShQsXGhgYfPrpp6TjALy46urqGTNmWFlZHTlyBGcdAQOgZwBDhIaGNjQ0LF++3MTEJCwsjHQcgBfx8OHDadOmmZmZnTx50sTEhHQcABqgZwBzLF269NGjRxERESYmJvPmzSMdB+D51NXVeXt7y2Sy06dPDxgwgHQcAHqgZwCjREVFPXnyZP78+Xp6eliVHDRIfX29UChsbGxMS0sbNGgQ6TgAtEHPAKb59ttvJRLJBx98wGaz58yZQzoOQO8ePXrk5+f34MGDtLS0ESNGkI4DQCf0DGAaFou1ZcsWAwODoKCg7du3h4aGkk4E0JOHDx9Onz798ePHqamp1tbWpOMA0Aw9AxiIxWJt3LjR1NR04cKFDQ0NS5cuJZ0IoHtVVVW+vr5tbW0XLlwYOXIk6TgA9EPPAMZas2aNkZHR8uXLpVLpypUrSccB6KqiosLX19fQ0PDChQtDhgwhHQdAJdAzgMlWrVplYmISGRlZV1e3bt060nEA/nbt2rVp06YNGjRIJBKZm5uTjgOgKugZwHDh4eF6enphYWFSqfSHH35gs/GZPkBeTk7Om2++6eDgkJycbGpqSjoOgAqhZwDzLV682NTUdP78+VVVVXv27OFwOKQTgVY7fPjw+++/7+PjEx8fb2RkRDoOgGrhvR1ohcDAwNTU1LS0tKlTpz58+JB0HNBemzZtCggImDdvXlJSEkoGaAP0DNAWHh4e2dnZjx8/9vDwuHbtGuk4oHXa29sjIyM/+eST1atXb9++XVcX08mgFfC58KBdxGLx7Nmzi4uLDx8+PHXqVNJxQFs0NTW9++67Z86c2bVrV1BQEOk4AH0H8xmgXbhc7unTp318fIRC4e+//046DmiF6urqKVOm5ObmXrhwASUDtA16BmgdDocTHx+/bNmy0NDQiIgIqVRKOhEwWUpKipubm1Qqzc7OnjRpEuk4AH0NPQO0EZvNjomJOXLkSFxcnEAguH37NulEwEByuXzTpk1+fn58Pj8zMxNrioN2Qs8A7fXWW2/l5uY2NzePHz8+JSWFdBxglIaGhsDAwJUrV65duzYpKcnMzIx0IgAy0DNAq9nZ2eXk5Hh5eQmFwpiYGJwWDbS4fv26h4dHamqqSCRatWoVi8UinQiAGPQM0HYmJiYJCQlr16794osvgoKCHj9+TDoRaLa4uDh3d3dTU9OCggIfHx/ScQAIQ88AoFgs1ueff3769On09HRnZ+e0tDTSiUAj1dfXv//++x988EFoaOiFCxeGDh1KOhEAeegZAP/l4+NTWFjo4uIyderUZcuW4ToUeC65ublubm5nz549duzYpk2b9PX1SScCUAvoGQB/Mzc3P3LkyK5du3bu3CkQCK5fv046EWiAtra2mJiYKVOm2NjYFBQUzJw5k3QiADWCngHQVXBwcF5enkwmc3Nz27lzJ+k4oNZu3brl6em5Zs2aH3/8USQSDR48mHQiAPWCngHQDXt7+9zc3BUrVixZssTPz6+yspJ0IlA7Mpls27Ztzs7OEokkJycnPDwc15UAPAs9A6B7urq60dHRaWlpVVVVjo6OMTEx7e3tpEOBuigqKuLz+R9//HFERMSVK1d4PB7pRABqCj0DoCd8Pr+goOBf//pXVFTU+PHj8/PzSScCwp4+fRodHe3u7q6jo1NQULBu3ToDAwPSoQDUF3oGQC/09PRWrVp15coVAwODiRMnfv7550+fPiUdCsjIyMhwcXH5/vvvv/rqq7S0NAcHB9KJANQdegaAUhwdHTMzM9evX79lyxYej5ecnEw6EfSpe/fuBQcHe3p62tralpWVrVq1SkdHh3QoAA2AngGgLDabvXTp0pKSEhcXl7feemvGjBmlpaWkQ4HKPX369N///vfo0aPT09MTExOTk5OHDRtGOhSAxkDPAHg+w4cPj4+Pz8nJkUgkzs7OS5Ysqa2tJR0KVCU5OdnR0fGbb75ZuXLltWvX/P39SScC0DDoGQAvYuLEiZmZmTt37jx27JidnV1MTAzWD2WYa9euCYXCWbNmubm5Xbt2LTo62tDQkHQoAM2DngHwgthsdnBw8M2bN5cuXRoVFWVvb79t2zZc+8oAFRUVS5YscXJyEovFGRkZCQkJw4cPJx0KQFOhZwC8FGNj4+jo6JKSksmTJ4eHhzs7Ox86dAifL6+hKioqQkNDFadi7Nu379KlS3w+n3QoAM2GngFAAxsbm927dxcXF7u6ugYGBvJ4vMTERLQNDVJdXb1s2bIxY8ZcuHBhy5YthYWFc+fOxfqeAC8PPQOANvb29rt3787Pz7e1tQ0MDJw0adKJEyfQNtTc7du3IyMjR40adezYsS1btty4cePDDz/U1dUlnQuAIdAzAGjG4/GSkpIuX75sYWHx5ptvjh07dufOnS0tLaRzQVf5+fnvvfeera3t0aNHN27cWF5evnDhQjQMAHqx8GYLQHVu3Ljx008/bdu2zdTU9KOPPoqMjORyuaRDAZWRkRETE3PixAkejxceHj5//nysHQ6gIugZACp37969zZs3//rrr1KpNDQ0dPny5TY2NqRDaaOWlpZ9+/atX7++tLR0+vTpK1eu9PX1JR0KgOHQMwD6SGNjo+JF7ubNmx4eHsHBwR988AGHwyGdSyuUlZXt2rUrNja2vr4+MDDw008/dXJyIh0KQCugZwD0qba2tpMnT27fvv3UqVMDBgwIDg5etGiRvb096VzM1NTUlJCQsH379uzsbBsbm4ULF4aEhAwePJh0LgAtgp4BQMbdu3djY2NjY2MrKyunTJmyaNGid955p1+/fqRzMcSlS5diY2P379/f0tIye/bsRYsWeXt74zpVgL6HngFAkkwmO3/+/LZt244ePcpms319fQMCAlA4XlhJSUliYuL+/fuvX79uZ2cXGhq6YMECCwsL0rkAtBd6BoBaePToUXJycmJi4unTp3V1dX18fAICAvz9/Y2NjUlH0wCKehEfH19WVjZs2LDZs2cHBAQIBAJMYAAQh54BoF5qamoOHToUHx+fnp5ubGw8c+ZMPz+/GTNmDBw4kHQ09dLW1paZmSkSiY4ePXrt2rVhw4YFBATMnTt3woQJqBcA6gM9A0BN3b9//+DBg0ePHk1PT29ra3N1dRUKhX5+fhMnTtTR0SGdjpjq6mqRSCQSic6dOyeRSGxtbd94442AgAA+n496AaCG0DMA1F1jY+P58+cVL64VFRUDBgzw9fX18fERCAQODg7a8OIqFouzsrLS0tJEIlFxcbGRkdHUqVP9/PyEQqGtrS3pdADQE/QMAE1SXl5+6tQpkUiUmZnZ2NjYv39/Pp8vEAgEAsH48eOZtBrH9evXs7KyMjIysrKyysrKKIpycHCYPn26UCj09PQ0NDQkHRAAlIKeAaCR2traCgsLFS/DGRkZd+/e1dPTc3Nzc3Nz4/F4Tk5OY8eONTExIR1TWe3t7X/++WdhYWFRUdEff/yRnZ1dU1PD4XDGjx+vaFF8Pr9///6kYwLAc0PPAGCC27dvZ2ZmZmVlXb16tbi4WCKRsFgsKysrRedwcnKys7OzsrIyMzMjnZSiKKq1tbW6uvrWrVvFxcVFRUWFhYWlpaXNzc06Ojo2NjY8Hs/Dw8PDw8Pd3V1PT490WAB4KegZAEwjl8srKyuLiooUL+GFhYU3btxob2+nKGrAgAFWVlYjR47s+HPYsGFcLpfL5dJ+JEIul4vFYrFYXFtbW1FRUVFRUVlZqfjzzp07bW1tFEVZWFh0NCEej+fo6MikQz8AQKFnAGiDlpaWW7dudX6lV/wpFos7HmNsbMzlcs3/X79+/czMzNhstp6enmLRsH79+nWeXaivr5fJZK2trY2NjRRFNTU1NTU1KYpFXV2d4i8dv14MDAxGjBjRpeJYW1tjBS0AxkPPANBeEonk3r174v9VW1srFosbGxsbGhra2to6moTiy47vNTU11dHR6WghJiYmHA6H+78sLCwU3WXIkCHacF0MADwLPQMAAABUhU06AAAAADAWegYAAACoCnoGAAAAqMr/AZOiMfHomo7UAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<IPython.core.display.Image object>"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Visualize Dask Computation Graph\n",
-    "\n",
-    "visualize(result)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "Qszhkwfrx2ar"
-   },
-   "outputs": [],
-   "source": [
-    "# Write the meshes as vtk files\n",
-    "\n",
-    "m1 = itk.mesh_from_dict(output_result[0])\n",
-    "m2 = itk.mesh_from_dict(output_result[1])\n",
-    "\n",
-    "itk.meshwrite(m1, 'm1.vtk')\n",
-    "itk.meshwrite(m2, 'm2.vtk')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "_c_VmhNIyCPT"
-   },
-   "outputs": [],
-   "source": [
-    "# Read the meshes for viewing\n",
-    "\n",
-    "v1 = vtk.vtkPolyDataReader()\n",
-    "v1.SetFileName('m1.vtk')\n",
-    "v1.Update()\n",
-    "m1 = v1.GetOutput()\n",
-    "\n",
-    "v2 = vtk.vtkPolyDataReader()\n",
-    "v2.SetFileName('m2.vtk')\n",
-    "v2.Update()\n",
-    "m2 = v2.GetOutput()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 717,
-     "referenced_widgets": [
-      "00a6b63103ea40cb97280c5226da49ec",
-      "856173aca43d43d5a2affc843effc3bc"
-     ]
-    },
-    "id": "ICt28TFryR9s",
-    "outputId": "1c75c2c3-120e-4b3c-ebb5-cde0351e0972"
-   },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "00a6b63103ea40cb97280c5226da49ec",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Viewer(geometries=[{'vtkClass': 'vtkPolyData', 'points': {'vtkClass': 'vtkPoints', 'name': '_points', 'numberO…"
-      ]
-     },
-     "metadata": {
-      "application/vnd.jupyter.widget-view+json": {
-       "colab": {
-        "custom_widget_manager": {
-         "url": "https://ssl.gstatic.com/colaboratory-static/widgets/colab-cdn-widget-manager/a8874ba6619b6106/manager.min.js"
-        }
-       }
-      }
-     },
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "#Visualize the meshes\n",
-    "\n",
-    "from google.colab import output\n",
-    "output.enable_custom_widget_manager()\n",
-    "\n",
-    "itkwidgets.view(geometries=[m1])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 717,
-     "referenced_widgets": [
-      "a94aac452f134317b546f25e3e8ea65c",
-      "4193a5dee9b243b899733baac0bc46be"
-     ]
-    },
-    "id": "-rDaCgo5yfKX",
-    "outputId": "943632bf-a1ca-4616-95a3-f54c0dcdbca0"
-   },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a94aac452f134317b546f25e3e8ea65c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Viewer(geometries=[{'vtkClass': 'vtkPolyData', 'points': {'vtkClass': 'vtkPoints', 'name': '_points', 'numberO…"
-      ]
-     },
-     "metadata": {
-      "application/vnd.jupyter.widget-view+json": {
-       "colab": {
-        "custom_widget_manager": {
-         "url": "https://ssl.gstatic.com/colaboratory-static/widgets/colab-cdn-widget-manager/a8874ba6619b6106/manager.min.js"
-        }
-       }
-      }
-     },
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "from google.colab import output\n",
-    "output.enable_custom_widget_manager()\n",
-    "\n",
-    "itkwidgets.view(geometries=[m2])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "60Q7zAjaYemS"
-   },
-   "outputs": [],
-   "source": [
-    "# Close the cluster and free the resources\n",
-    "\n",
-    "cluster.close()"
-   ]
-  }
- ],
- "metadata": {
-  "accelerator": "GPU",
-  "colab": {
-   "collapsed_sections": [],
-   "name": "DaskComputationCoiled.ipynb",
-   "provenance": []
-  },
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.12"
-  },
-  "widgets": {
-   "application/vnd.jupyter.widget-state+json": {
-    "00a6b63103ea40cb97280c5226da49ec": {
-     "model_module": "itkwidgets",
-     "model_module_version": "^0.32.1",
-     "model_name": "ViewerModel",
-     "state": {
-      "_custom_cmap": null,
-      "_dom_classes": [],
-      "_downsampling": false,
-      "_largest_roi": {
-       "dtype": "float64",
-       "shape": [
-        2,
-        3
-       ]
-      },
-      "_model_module": "itkwidgets",
-      "_model_module_version": "^0.32.1",
-      "_model_name": "ViewerModel",
-      "_rendering_image": false,
-      "_reset_crop_requested": false,
-      "_scale_factors": {
-       "dtype": "uint8",
-       "shape": [
-        3
-       ]
-      },
-      "_view_count": null,
-      "_view_module": "itkwidgets",
-      "_view_module_version": "^0.32.1",
-      "_view_name": "ViewerView",
-      "annotations": true,
-      "axes": false,
-      "background": [
-       1,
-       1,
-       1
-      ],
-      "blend_mode": "composite",
-      "camera": {
-       "dtype": "float32",
-       "shape": [
-        3,
-        3
-       ]
-      },
-      "channels": null,
-      "clicked_slice_point": null,
-      "cmap": null,
-      "geometries": [
-       {
-        "cellData": {
-         "activeScalars": 0,
-         "arrays": [
-          {
-           "data": {
-            "dataType": "Float64Array",
-            "name": "CellScalarData",
-            "numberOfComponents": 1,
-            "size": 105425,
-            "vtkClass": "vtkDataArray"
-           }
+    "widgets": {
+      "application/vnd.jupyter.widget-state+json": {
+        "a3a4c8e9ac194fdda8266fa1b8609667": {
+          "model_module": "@jupyter-widgets/output",
+          "model_name": "OutputModel",
+          "model_module_version": "1.0.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/output",
+            "_model_module_version": "1.0.0",
+            "_model_name": "OutputModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/output",
+            "_view_module_version": "1.0.0",
+            "_view_name": "OutputView",
+            "layout": "IPY_MODEL_777e25916eac4cac98f819685cb66c97",
+            "msg_id": "",
+            "outputs": [
+              {
+                "output_type": "display_data",
+                "data": {
+                  "text/plain": "╭───────────────────────────────────────── \u001b[1;51;32mCoiled Cluster\u001b[0m ─────────────────────────────────────────╮\n│                   \u001b]8;id=329916;https://cloud.coiled.io/pranjal-sahu/clusters/23051/details\u001b\\https://cloud.coiled.io/pranjal-sahu/clusters/23051/details\u001b]8;;\u001b\\                    │\n╰──────────────────────────────────────────────────────────────────────────────────────────────────╯\n╭─────────────────── Overview ───────────────────╮╭──────────────── Configuration ─────────────────╮\n│                                                ││                                                │\n│ \u001b[1;32mCluster Name:\u001b[0m oai-processing11                 ││ \u001b[1;32mRegion:\u001b[0m us-east-1                              │\n│                                                ││                                                │\n│ \u001b[1;32mCluster Status:\u001b[0m scaling..                      ││ \u001b[1;32mScheduler Instance Type:\u001b[0m t3.medium             │\n│                                                ││                                                │\n│ \u001b[1;32mScheduler Status:\u001b[0m started                      ││ \u001b[1;32mWorker Instance Type(s):\u001b[0m c5a.4xlarge (2)       │\n│                                                ││                                                │\n│ \u001b[1;32mDashboard Address:\u001b[0m \u001b]8;id=959551;http://54.160.165.180:8787\u001b\\http://54.160.165.180:8787\u001b]8;;\u001b\\  ││ \u001b[1;32mWorkers Requested:\u001b[0m 2                           │\n│                                                ││                                                │\n│                                                ││                                                │\n╰────────────────────────────────────────────────╯╰────────────────────────────────────────────────╯\n╭─────────────────────────────────── (2022/05/08 17:45:29 UTC) ────────────────────────────────────╮\n│                                                                                                  │\n│                                        All workers ready.                                        │\n│                                                                                                  │\n│                                                                                                  │\n╰──────────────────────────────────────────────────────────────────────────────────────────────────╯\n\n\n",
+                  "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">╭───────────────────────────────────────── <span style=\"color: #008000; text-decoration-color: #008000; font-weight: bold\">Coiled Cluster</span> ─────────────────────────────────────────╮\n│                   <a href=\"https://cloud.coiled.io/pranjal-sahu/clusters/23051/details\" target=\"_blank\">https://cloud.coiled.io/pranjal-sahu/clusters/23051/details</a>                    │\n╰──────────────────────────────────────────────────────────────────────────────────────────────────╯\n╭─────────────────── Overview ───────────────────╮╭──────────────── Configuration ─────────────────╮\n│                                                ││                                                │\n│ <span style=\"color: #008000; text-decoration-color: #008000; font-weight: bold\">Cluster Name:</span> oai-processing11                 ││ <span style=\"color: #008000; text-decoration-color: #008000; font-weight: bold\">Region:</span> us-east-1                              │\n│                                                ││                                                │\n│ <span style=\"color: #008000; text-decoration-color: #008000; font-weight: bold\">Cluster Status:</span> scaling..                      ││ <span style=\"color: #008000; text-decoration-color: #008000; font-weight: bold\">Scheduler Instance Type:</span> t3.medium             │\n│                                                ││                                                │\n│ <span style=\"color: #008000; text-decoration-color: #008000; font-weight: bold\">Scheduler Status:</span> started                      ││ <span style=\"color: #008000; text-decoration-color: #008000; font-weight: bold\">Worker Instance Type(s):</span> c5a.4xlarge (2)       │\n│                                                ││                                                │\n│ <span style=\"color: #008000; text-decoration-color: #008000; font-weight: bold\">Dashboard Address:</span> <a href=\"http://54.160.165.180:8787\" target=\"_blank\">http://54.160.165.180:8787</a>  ││ <span style=\"color: #008000; text-decoration-color: #008000; font-weight: bold\">Workers Requested:</span> 2                           │\n│                                                ││                                                │\n│                                                ││                                                │\n╰────────────────────────────────────────────────╯╰────────────────────────────────────────────────╯\n╭─────────────────────────────────── (2022/05/08 17:45:29 UTC) ────────────────────────────────────╮\n│                                                                                                  │\n│                                        All workers ready.                                        │\n│                                                                                                  │\n│                                                                                                  │\n╰──────────────────────────────────────────────────────────────────────────────────────────────────╯\n\n\n</pre>\n"
+                },
+                "metadata": {}
+              }
+            ]
           }
-         ],
-         "vtkClass": "vtkDataSetAttributes"
         },
-        "metadata": {
-         "name": "Geometry 0"
-        },
-        "pointData": {
-         "activeScalars": 0,
-         "arrays": [
-          {
-           "data": {
-            "dataType": "Float64Array",
-            "name": "PointScalarData",
-            "numberOfComponents": 1,
-            "size": 53818,
-            "vtkClass": "vtkDataArray"
-           }
+        "777e25916eac4cac98f819685cb66c97": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
           }
-         ],
-         "vtkClass": "vtkDataSetAttributes"
         },
-        "points": {
-         "dataType": "Float32Array",
-         "name": "_points",
-         "numberOfComponents": 3,
-         "size": 161451,
-         "vtkClass": "vtkPoints"
+        "c7aa7935d75b439d838123e4587eafc4": {
+          "model_module": "itkwidgets",
+          "model_name": "ViewerModel",
+          "model_module_version": "^0.32.1",
+          "state": {
+            "_custom_cmap": null,
+            "_dom_classes": [],
+            "_downsampling": false,
+            "_largest_roi": {
+              "shape": [
+                2,
+                3
+              ],
+              "dtype": "float64"
+            },
+            "_model_module": "itkwidgets",
+            "_model_module_version": "^0.32.1",
+            "_model_name": "ViewerModel",
+            "_rendering_image": false,
+            "_reset_crop_requested": false,
+            "_scale_factors": {
+              "shape": [
+                3
+              ],
+              "dtype": "uint8"
+            },
+            "_view_count": null,
+            "_view_module": "itkwidgets",
+            "_view_module_version": "^0.32.1",
+            "_view_name": "ViewerView",
+            "annotations": true,
+            "axes": false,
+            "background": [
+              1,
+              1,
+              1
+            ],
+            "blend_mode": "composite",
+            "camera": {
+              "shape": [
+                3,
+                3
+              ],
+              "dtype": "float32"
+            },
+            "channels": null,
+            "clicked_slice_point": null,
+            "cmap": null,
+            "geometries": [
+              {
+                "vtkClass": "vtkPolyData",
+                "points": {
+                  "vtkClass": "vtkPoints",
+                  "name": "_points",
+                  "numberOfComponents": 3,
+                  "dataType": "Float32Array",
+                  "size": 161451
+                },
+                "polys": {
+                  "vtkClass": "vtkCellArray",
+                  "name": "_polys",
+                  "numberOfComponents": 1,
+                  "size": 421688,
+                  "dataType": "Uint32Array"
+                },
+                "pointData": {
+                  "vtkClass": "vtkDataSetAttributes",
+                  "activeScalars": 0,
+                  "arrays": [
+                    {
+                      "data": {
+                        "vtkClass": "vtkDataArray",
+                        "name": "PointScalarData",
+                        "numberOfComponents": 1,
+                        "size": 53818,
+                        "dataType": "Float64Array"
+                      }
+                    }
+                  ]
+                },
+                "cellData": {
+                  "vtkClass": "vtkDataSetAttributes",
+                  "activeScalars": 0,
+                  "arrays": [
+                    {
+                      "data": {
+                        "vtkClass": "vtkDataArray",
+                        "name": "CellScalarData",
+                        "numberOfComponents": 1,
+                        "size": 105423,
+                        "dataType": "Float64Array"
+                      }
+                    }
+                  ]
+                },
+                "metadata": {
+                  "name": "Geometry 0"
+                }
+              },
+              {
+                "vtkClass": "vtkPolyData",
+                "points": {
+                  "vtkClass": "vtkPoints",
+                  "name": "_points",
+                  "numberOfComponents": 3,
+                  "dataType": "Float32Array",
+                  "size": 49761
+                },
+                "polys": {
+                  "vtkClass": "vtkCellArray",
+                  "name": "_polys",
+                  "numberOfComponents": 1,
+                  "size": 128896,
+                  "dataType": "Uint32Array"
+                },
+                "pointData": {
+                  "vtkClass": "vtkDataSetAttributes",
+                  "activeScalars": 0,
+                  "arrays": [
+                    {
+                      "data": {
+                        "vtkClass": "vtkDataArray",
+                        "name": "PointScalarData",
+                        "numberOfComponents": 1,
+                        "size": 16588,
+                        "dataType": "Float64Array"
+                      }
+                    }
+                  ]
+                },
+                "cellData": {
+                  "vtkClass": "vtkDataSetAttributes",
+                  "activeScalars": 0,
+                  "arrays": [
+                    {
+                      "data": {
+                        "vtkClass": "vtkDataArray",
+                        "name": "CellScalarData",
+                        "numberOfComponents": 1,
+                        "size": 32225,
+                        "dataType": "Float64Array"
+                      }
+                    }
+                  ]
+                },
+                "metadata": {
+                  "name": "Geometry 1"
+                }
+              }
+            ],
+            "geometry_colors": {
+              "shape": [
+                2,
+                3
+              ],
+              "dtype": "float32"
+            },
+            "geometry_opacities": {
+              "shape": [
+                2
+              ],
+              "dtype": "float32"
+            },
+            "gradient_opacity": 0.22,
+            "interpolation": true,
+            "label_image_blend": 0.5,
+            "label_image_names": null,
+            "label_image_weights": null,
+            "layout": "IPY_MODEL_db828dcbb20a483ca4564508b383d739",
+            "lut": "glasbey",
+            "mode": "v",
+            "opacity_gaussians": null,
+            "point_set_colors": {
+              "shape": [
+                0,
+                3
+              ],
+              "dtype": "float32"
+            },
+            "point_set_opacities": {
+              "shape": [
+                0
+              ],
+              "dtype": "float32"
+            },
+            "point_set_representations": [],
+            "point_set_sizes": {
+              "shape": [
+                0
+              ],
+              "dtype": "uint8"
+            },
+            "point_sets": [],
+            "rendered_image": null,
+            "rendered_label_image": null,
+            "roi": {
+              "shape": [
+                2,
+                3
+              ],
+              "dtype": "float64"
+            },
+            "rotate": false,
+            "sample_distance": 0.25,
+            "select_roi": false,
+            "shadow": true,
+            "slicing_planes": false,
+            "ui_collapsed": false,
+            "units": "",
+            "vmax": null,
+            "vmin": null,
+            "x_slice": null,
+            "y_slice": null,
+            "z_slice": null
+          }
         },
-        "polys": {
-         "dataType": "Uint32Array",
-         "name": "_polys",
-         "numberOfComponents": 1,
-         "size": 421696,
-         "vtkClass": "vtkCellArray"
-        },
-        "vtkClass": "vtkPolyData"
-       }
+        "db828dcbb20a483ca4564508b383d739": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        }
+      }
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/uncbiag/OAI_analysis_2/blob/pranjal3/notebooks/DaskComputationCoiled.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "FFTe-kxYbxW6"
+      },
+      "outputs": [],
+      "source": [
+        "# Install packages\n",
+        "\n",
+        "# Remember to Restart runtime after installation\n",
+        "\n",
+        "\n",
+        "!pip install itk==5.3rc4\n",
+        "!pip install vtk\n",
+        "!pip install itkwidgets\n",
+        "!pip install icon-registration==0.3.4\n",
+        "!pip install tornado==6.1\n",
+        "!pip install coiled\n",
+        "!pip install torch\n",
+        "!pip install jupyter\n",
+        "!pip install git+https://github.com/uncbiag/mermaid.git\n",
+        "!pip install git+https://github.com/uncbiag/easyreg.git\n",
+        "!pip install git+https://github.com/PranjalSahu/OAI_analysis_2.git#egg=oai_package"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# All Imports\n",
+        "\n",
+        "import coiled\n",
+        "import dask\n",
+        "from dask import compute, visualize, delayed\n",
+        "\n",
+        "import itk\n",
+        "import vtk\n",
+        "import itkwidgets\n",
+        "from oai_analysis_2 import dask_processing as dp\n",
+        "\n",
+        "import os\n",
+        "os.environ[\"CUDA_VISIBLE_DEVICES\"]=\"\""
       ],
-      "geometry_colors": {
-       "dtype": "float32",
-       "shape": [
-        1,
-        3
-       ]
+      "metadata": {
+        "id": "GWZItOLfcoA4"
       },
-      "geometry_opacities": {
-       "dtype": "float32",
-       "shape": [
-        1
-       ]
-      },
-      "gradient_opacity": 0.22,
-      "interpolation": true,
-      "label_image_blend": 0.5,
-      "label_image_names": null,
-      "label_image_weights": null,
-      "layout": "IPY_MODEL_856173aca43d43d5a2affc843effc3bc",
-      "lut": "glasbey",
-      "mode": "v",
-      "opacity_gaussians": null,
-      "point_set_colors": {
-       "dtype": "float32",
-       "shape": [
-        0,
-        3
-       ]
-      },
-      "point_set_opacities": {
-       "dtype": "float32",
-       "shape": [
-        0
-       ]
-      },
-      "point_set_representations": [],
-      "point_set_sizes": {
-       "dtype": "uint8",
-       "shape": [
-        0
-       ]
-      },
-      "point_sets": [],
-      "rendered_image": null,
-      "rendered_label_image": null,
-      "roi": {
-       "dtype": "float64",
-       "shape": [
-        2,
-        3
-       ]
-      },
-      "rotate": false,
-      "sample_distance": 0.25,
-      "select_roi": false,
-      "shadow": true,
-      "slicing_planes": false,
-      "ui_collapsed": false,
-      "units": "",
-      "vmax": null,
-      "vmin": null,
-      "x_slice": null,
-      "y_slice": null,
-      "z_slice": null
-     }
+      "execution_count": 1,
+      "outputs": []
     },
-    "04433edc426a4ba99ba1d3a937f42d15": {
-     "model_module": "@jupyter-widgets/base",
-     "model_module_version": "1.2.0",
-     "model_name": "LayoutModel",
-     "state": {
-      "_model_module": "@jupyter-widgets/base",
-      "_model_module_version": "1.2.0",
-      "_model_name": "LayoutModel",
-      "_view_count": null,
-      "_view_module": "@jupyter-widgets/base",
-      "_view_module_version": "1.2.0",
-      "_view_name": "LayoutView",
-      "align_content": null,
-      "align_items": null,
-      "align_self": null,
-      "border": null,
-      "bottom": null,
-      "display": null,
-      "flex": null,
-      "flex_flow": null,
-      "grid_area": null,
-      "grid_auto_columns": null,
-      "grid_auto_flow": null,
-      "grid_auto_rows": null,
-      "grid_column": null,
-      "grid_gap": null,
-      "grid_row": null,
-      "grid_template_areas": null,
-      "grid_template_columns": null,
-      "grid_template_rows": null,
-      "height": null,
-      "justify_content": null,
-      "justify_items": null,
-      "left": null,
-      "margin": null,
-      "max_height": null,
-      "max_width": null,
-      "min_height": null,
-      "min_width": null,
-      "object_fit": null,
-      "object_position": null,
-      "order": null,
-      "overflow": null,
-      "overflow_x": null,
-      "overflow_y": null,
-      "padding": null,
-      "right": null,
-      "top": null,
-      "visibility": null,
-      "width": null
-     }
-    },
-    "06f88296a85a4161b62436df3bdbe371": {
-     "model_module": "@jupyter-widgets/controls",
-     "model_module_version": "1.5.0",
-     "model_name": "ButtonStyleModel",
-     "state": {
-      "_model_module": "@jupyter-widgets/controls",
-      "_model_module_version": "1.5.0",
-      "_model_name": "ButtonStyleModel",
-      "_view_count": null,
-      "_view_module": "@jupyter-widgets/base",
-      "_view_module_version": "1.2.0",
-      "_view_name": "StyleView",
-      "button_color": null,
-      "font_weight": ""
-     }
-    },
-    "0fdf3ebec30d4459a90be4314731236d": {
-     "model_module": "@jupyter-widgets/output",
-     "model_module_version": "1.0.0",
-     "model_name": "OutputModel",
-     "state": {
-      "_dom_classes": [],
-      "_model_module": "@jupyter-widgets/output",
-      "_model_module_version": "1.0.0",
-      "_model_name": "OutputModel",
-      "_view_count": null,
-      "_view_module": "@jupyter-widgets/output",
-      "_view_module_version": "1.0.0",
-      "_view_name": "OutputView",
-      "layout": "IPY_MODEL_c511b4eef0e74cd98b84c8c4e9b2cda5",
-      "msg_id": "",
+    {
+      "cell_type": "code",
+      "source": [
+        "# To create a software environment using docker with open gl installed\n",
+        "import coiled\n",
+        "coiled.create_software_environment(\n",
+        "    name=\"oai13\",\n",
+        "    container=\"pranjalsahu/pranjal-sahu-oai7:latest\",\n",
+        ")"
+      ],
+      "metadata": {
+        "id": "jrqYtBziroJ7",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 200
+        },
+        "outputId": "a767050b-561c-497b-9c60-de721fcde481"
+      },
+      "execution_count": 2,
       "outputs": [
-       {
-        "data": {
-         "text/html": "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008000; text-decoration-color: #008000\">⠧</span> <span style=\"color: #008000; text-decoration-color: #008000; font-weight: bold\">Creating Cluster. This might take a few minutes...</span>\n</pre>\n",
-         "text/plain": "\u001b[32m⠧\u001b[0m \u001b[1;32mCreating Cluster. This might take a few minutes...\u001b[0m\n"
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "\u001b[31mInvalid Coiled token encountered. You can create new tokens and manage your existing ones at \u001b[0m\n",
+              "\u001b[4;31mhttps://cloud.coiled.io/profile.\u001b[0m\n",
+              "\n"
+            ],
+            "text/html": [
+              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #800000; text-decoration-color: #800000\">Invalid Coiled token encountered. You can create new tokens and manage your existing ones at </span>\n",
+              "<span style=\"color: #800000; text-decoration-color: #800000; text-decoration: underline\">https://cloud.coiled.io/profile.</span>\n",
+              "\n",
+              "</pre>\n"
+            ]
+          },
+          "metadata": {}
         },
-        "metadata": {},
-        "output_type": "display_data"
-       }
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "Please login to \u001b[4;94mhttps://cloud.coiled.io/profile\u001b[0m to get your token\n"
+            ],
+            "text/html": [
+              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Please login to <span style=\"color: #0000ff; text-decoration-color: #0000ff; text-decoration: underline\">https://cloud.coiled.io/profile</span> to get your token\n",
+              "</pre>\n"
+            ]
+          },
+          "metadata": {}
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Token: ··········\n"
+          ]
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "\u001b[32mAuthentication successful\u001b[0m\n"
+            ],
+            "text/html": [
+              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008000; text-decoration-color: #008000\">Authentication successful</span>\n",
+              "</pre>\n"
+            ]
+          },
+          "metadata": {}
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Save credentials for next time? [Y/n]: Y\n"
+          ]
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "Credentials have been saved at \u001b[34m/root/.config/dask/\u001b[0m\u001b[34mcoiled.yaml\u001b[0m\n"
+            ],
+            "text/html": [
+              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Credentials have been saved at <span style=\"color: #000080; text-decoration-color: #000080\">/root/.config/dask/coiled.yaml</span>\n",
+              "</pre>\n"
+            ]
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Creating new software environment\n",
+            "Creating container-only software environment\n",
+            "Successfully saved software environment build\n"
+          ]
+        }
       ]
-     }
     },
-    "1756413d3140403a8b76e05a0e866375": {
-     "model_module": "@jupyter-widgets/controls",
-     "model_module_version": "1.5.0",
-     "model_name": "IntTextModel",
-     "state": {
-      "_dom_classes": [],
-      "_model_module": "@jupyter-widgets/controls",
-      "_model_module_version": "1.5.0",
-      "_model_name": "IntTextModel",
-      "_view_count": null,
-      "_view_module": "@jupyter-widgets/controls",
-      "_view_module_version": "1.5.0",
-      "_view_name": "IntTextView",
-      "continuous_update": false,
-      "description": "Workers",
-      "description_tooltip": null,
-      "disabled": false,
-      "layout": "IPY_MODEL_c9d8794770314d9f9477af9179f02cee",
-      "step": 1,
-      "style": "IPY_MODEL_6d320e968b5a41dcb994108cc4d95e50",
-      "value": 0
-     }
-    },
-    "35f0646f5ded451d99e92a7c74e9486e": {
-     "model_module": "@jupyter-widgets/controls",
-     "model_module_version": "1.5.0",
-     "model_name": "VBoxModel",
-     "state": {
-      "_dom_classes": [],
-      "_model_module": "@jupyter-widgets/controls",
-      "_model_module_version": "1.5.0",
-      "_model_name": "VBoxModel",
-      "_view_count": null,
-      "_view_module": "@jupyter-widgets/controls",
-      "_view_module_version": "1.5.0",
-      "_view_name": "VBoxView",
-      "box_style": "",
-      "children": [
-       "IPY_MODEL_89cfc99bacb3424983f0127b1065c98b",
-       "IPY_MODEL_9e81c59ecf804e56af1c69f30fda8cf9"
+    {
+      "cell_type": "code",
+      "source": [
+        "# Create Dask Client. This will also spawn dask worker and scheduler\n",
+        "\n",
+        "name = 'oai-processing11'\n",
+        "cluster = coiled.Cluster(n_workers=2,\n",
+        "                        name=name,\n",
+        "                        worker_vm_types=['c5a.4xlarge'],\n",
+        "                        scheduler_vm_types=['t3.medium'],\n",
+        "                        software='pranjal-sahu/oai13')\n",
+        "client = dask.distributed.Client(cluster, \n",
+        "                                  serializers=['pickle', 'dask'],\n",
+        "                                  deserializers=['pickle', 'dask'])\n",
+        "print(client)"
       ],
-      "layout": "IPY_MODEL_641ae4f0ec3a4d78858476edec985aa0"
-     }
-    },
-    "3fbd04438ff14c56b54242a5270f7abb": {
-     "model_module": "@jupyter-widgets/controls",
-     "model_module_version": "1.5.0",
-     "model_name": "IntTextModel",
-     "state": {
-      "_dom_classes": [],
-      "_model_module": "@jupyter-widgets/controls",
-      "_model_module_version": "1.5.0",
-      "_model_name": "IntTextModel",
-      "_view_count": null,
-      "_view_module": "@jupyter-widgets/controls",
-      "_view_module_version": "1.5.0",
-      "_view_name": "IntTextView",
-      "continuous_update": false,
-      "description": "Minimum",
-      "description_tooltip": null,
-      "disabled": false,
-      "layout": "IPY_MODEL_c9d8794770314d9f9477af9179f02cee",
-      "step": 1,
-      "style": "IPY_MODEL_524f7dc765484bc1bde0936c51a13fcf",
-      "value": 0
-     }
-    },
-    "4193a5dee9b243b899733baac0bc46be": {
-     "model_module": "@jupyter-widgets/base",
-     "model_module_version": "1.2.0",
-     "model_name": "LayoutModel",
-     "state": {
-      "_model_module": "@jupyter-widgets/base",
-      "_model_module_version": "1.2.0",
-      "_model_name": "LayoutModel",
-      "_view_count": null,
-      "_view_module": "@jupyter-widgets/base",
-      "_view_module_version": "1.2.0",
-      "_view_name": "LayoutView",
-      "align_content": null,
-      "align_items": null,
-      "align_self": null,
-      "border": null,
-      "bottom": null,
-      "display": null,
-      "flex": null,
-      "flex_flow": null,
-      "grid_area": null,
-      "grid_auto_columns": null,
-      "grid_auto_flow": null,
-      "grid_auto_rows": null,
-      "grid_column": null,
-      "grid_gap": null,
-      "grid_row": null,
-      "grid_template_areas": null,
-      "grid_template_columns": null,
-      "grid_template_rows": null,
-      "height": null,
-      "justify_content": null,
-      "justify_items": null,
-      "left": null,
-      "margin": null,
-      "max_height": null,
-      "max_width": null,
-      "min_height": null,
-      "min_width": null,
-      "object_fit": null,
-      "object_position": null,
-      "order": null,
-      "overflow": null,
-      "overflow_x": null,
-      "overflow_y": null,
-      "padding": null,
-      "right": null,
-      "top": null,
-      "visibility": null,
-      "width": null
-     }
-    },
-    "41aceabecac9409ca3cd650811e5b81c": {
-     "model_module": "@jupyter-widgets/controls",
-     "model_module_version": "1.5.0",
-     "model_name": "DescriptionStyleModel",
-     "state": {
-      "_model_module": "@jupyter-widgets/controls",
-      "_model_module_version": "1.5.0",
-      "_model_name": "DescriptionStyleModel",
-      "_view_count": null,
-      "_view_module": "@jupyter-widgets/base",
-      "_view_module_version": "1.2.0",
-      "_view_name": "StyleView",
-      "description_width": ""
-     }
-    },
-    "4b8ceab0cbf144be98d10b01fb4c6401": {
-     "model_module": "@jupyter-widgets/base",
-     "model_module_version": "1.2.0",
-     "model_name": "LayoutModel",
-     "state": {
-      "_model_module": "@jupyter-widgets/base",
-      "_model_module_version": "1.2.0",
-      "_model_name": "LayoutModel",
-      "_view_count": null,
-      "_view_module": "@jupyter-widgets/base",
-      "_view_module_version": "1.2.0",
-      "_view_name": "LayoutView",
-      "align_content": null,
-      "align_items": null,
-      "align_self": null,
-      "border": null,
-      "bottom": null,
-      "display": null,
-      "flex": null,
-      "flex_flow": null,
-      "grid_area": null,
-      "grid_auto_columns": null,
-      "grid_auto_flow": null,
-      "grid_auto_rows": null,
-      "grid_column": null,
-      "grid_gap": null,
-      "grid_row": null,
-      "grid_template_areas": null,
-      "grid_template_columns": null,
-      "grid_template_rows": null,
-      "height": null,
-      "justify_content": null,
-      "justify_items": null,
-      "left": null,
-      "margin": null,
-      "max_height": null,
-      "max_width": null,
-      "min_height": null,
-      "min_width": null,
-      "object_fit": null,
-      "object_position": null,
-      "order": null,
-      "overflow": null,
-      "overflow_x": null,
-      "overflow_y": null,
-      "padding": null,
-      "right": null,
-      "top": null,
-      "visibility": null,
-      "width": null
-     }
-    },
-    "524f7dc765484bc1bde0936c51a13fcf": {
-     "model_module": "@jupyter-widgets/controls",
-     "model_module_version": "1.5.0",
-     "model_name": "DescriptionStyleModel",
-     "state": {
-      "_model_module": "@jupyter-widgets/controls",
-      "_model_module_version": "1.5.0",
-      "_model_name": "DescriptionStyleModel",
-      "_view_count": null,
-      "_view_module": "@jupyter-widgets/base",
-      "_view_module_version": "1.2.0",
-      "_view_name": "StyleView",
-      "description_width": ""
-     }
-    },
-    "54ee4db13cab4eebada9fe0ebc9dba3c": {
-     "model_module": "@jupyter-widgets/base",
-     "model_module_version": "1.2.0",
-     "model_name": "LayoutModel",
-     "state": {
-      "_model_module": "@jupyter-widgets/base",
-      "_model_module_version": "1.2.0",
-      "_model_name": "LayoutModel",
-      "_view_count": null,
-      "_view_module": "@jupyter-widgets/base",
-      "_view_module_version": "1.2.0",
-      "_view_name": "LayoutView",
-      "align_content": null,
-      "align_items": null,
-      "align_self": null,
-      "border": null,
-      "bottom": null,
-      "display": null,
-      "flex": null,
-      "flex_flow": null,
-      "grid_area": null,
-      "grid_auto_columns": null,
-      "grid_auto_flow": null,
-      "grid_auto_rows": null,
-      "grid_column": null,
-      "grid_gap": null,
-      "grid_row": null,
-      "grid_template_areas": null,
-      "grid_template_columns": null,
-      "grid_template_rows": null,
-      "height": null,
-      "justify_content": null,
-      "justify_items": null,
-      "left": null,
-      "margin": null,
-      "max_height": null,
-      "max_width": null,
-      "min_height": null,
-      "min_width": null,
-      "object_fit": null,
-      "object_position": null,
-      "order": null,
-      "overflow": null,
-      "overflow_x": null,
-      "overflow_y": null,
-      "padding": null,
-      "right": null,
-      "top": null,
-      "visibility": null,
-      "width": null
-     }
-    },
-    "57cb38340f6f4d3ab264f2d2632dea0c": {
-     "model_module": "@jupyter-widgets/base",
-     "model_module_version": "1.2.0",
-     "model_name": "LayoutModel",
-     "state": {
-      "_model_module": "@jupyter-widgets/base",
-      "_model_module_version": "1.2.0",
-      "_model_name": "LayoutModel",
-      "_view_count": null,
-      "_view_module": "@jupyter-widgets/base",
-      "_view_module_version": "1.2.0",
-      "_view_name": "LayoutView",
-      "align_content": null,
-      "align_items": null,
-      "align_self": null,
-      "border": null,
-      "bottom": null,
-      "display": null,
-      "flex": null,
-      "flex_flow": null,
-      "grid_area": null,
-      "grid_auto_columns": null,
-      "grid_auto_flow": null,
-      "grid_auto_rows": null,
-      "grid_column": null,
-      "grid_gap": null,
-      "grid_row": null,
-      "grid_template_areas": null,
-      "grid_template_columns": null,
-      "grid_template_rows": null,
-      "height": null,
-      "justify_content": null,
-      "justify_items": null,
-      "left": null,
-      "margin": null,
-      "max_height": null,
-      "max_width": null,
-      "min_height": null,
-      "min_width": null,
-      "object_fit": null,
-      "object_position": null,
-      "order": null,
-      "overflow": null,
-      "overflow_x": null,
-      "overflow_y": null,
-      "padding": null,
-      "right": null,
-      "top": null,
-      "visibility": null,
-      "width": null
-     }
-    },
-    "5a2b742a85db450980d791c0d30ec0bd": {
-     "model_module": "@jupyter-widgets/controls",
-     "model_module_version": "1.5.0",
-     "model_name": "HBoxModel",
-     "state": {
-      "_dom_classes": [],
-      "_model_module": "@jupyter-widgets/controls",
-      "_model_module_version": "1.5.0",
-      "_model_name": "HBoxModel",
-      "_view_count": null,
-      "_view_module": "@jupyter-widgets/controls",
-      "_view_module_version": "1.5.0",
-      "_view_name": "HBoxView",
-      "box_style": "",
-      "children": [
-       "IPY_MODEL_1756413d3140403a8b76e05a0e866375",
-       "IPY_MODEL_5af73d4418724958af448bb859c5104f"
-      ],
-      "layout": "IPY_MODEL_4b8ceab0cbf144be98d10b01fb4c6401"
-     }
-    },
-    "5af73d4418724958af448bb859c5104f": {
-     "model_module": "@jupyter-widgets/controls",
-     "model_module_version": "1.5.0",
-     "model_name": "ButtonModel",
-     "state": {
-      "_dom_classes": [],
-      "_model_module": "@jupyter-widgets/controls",
-      "_model_module_version": "1.5.0",
-      "_model_name": "ButtonModel",
-      "_view_count": null,
-      "_view_module": "@jupyter-widgets/controls",
-      "_view_module_version": "1.5.0",
-      "_view_name": "ButtonView",
-      "button_style": "",
-      "description": "Scale",
-      "disabled": false,
-      "icon": "",
-      "layout": "IPY_MODEL_c9d8794770314d9f9477af9179f02cee",
-      "style": "IPY_MODEL_06f88296a85a4161b62436df3bdbe371",
-      "tooltip": ""
-     }
-    },
-    "5c3a8f89501747de8a2d87347077af33": {
-     "model_module": "@jupyter-widgets/controls",
-     "model_module_version": "1.5.0",
-     "model_name": "DescriptionStyleModel",
-     "state": {
-      "_model_module": "@jupyter-widgets/controls",
-      "_model_module_version": "1.5.0",
-      "_model_name": "DescriptionStyleModel",
-      "_view_count": null,
-      "_view_module": "@jupyter-widgets/base",
-      "_view_module_version": "1.2.0",
-      "_view_name": "StyleView",
-      "description_width": ""
-     }
-    },
-    "641ae4f0ec3a4d78858476edec985aa0": {
-     "model_module": "@jupyter-widgets/base",
-     "model_module_version": "1.2.0",
-     "model_name": "LayoutModel",
-     "state": {
-      "_model_module": "@jupyter-widgets/base",
-      "_model_module_version": "1.2.0",
-      "_model_name": "LayoutModel",
-      "_view_count": null,
-      "_view_module": "@jupyter-widgets/base",
-      "_view_module_version": "1.2.0",
-      "_view_name": "LayoutView",
-      "align_content": null,
-      "align_items": null,
-      "align_self": null,
-      "border": null,
-      "bottom": null,
-      "display": null,
-      "flex": null,
-      "flex_flow": null,
-      "grid_area": null,
-      "grid_auto_columns": null,
-      "grid_auto_flow": null,
-      "grid_auto_rows": null,
-      "grid_column": null,
-      "grid_gap": null,
-      "grid_row": null,
-      "grid_template_areas": null,
-      "grid_template_columns": null,
-      "grid_template_rows": null,
-      "height": null,
-      "justify_content": null,
-      "justify_items": null,
-      "left": null,
-      "margin": null,
-      "max_height": null,
-      "max_width": null,
-      "min_height": null,
-      "min_width": null,
-      "object_fit": null,
-      "object_position": null,
-      "order": null,
-      "overflow": null,
-      "overflow_x": null,
-      "overflow_y": null,
-      "padding": null,
-      "right": null,
-      "top": null,
-      "visibility": null,
-      "width": null
-     }
-    },
-    "67040281464e48f29e7bb370c7994cc3": {
-     "model_module": "@jupyter-widgets/base",
-     "model_module_version": "1.2.0",
-     "model_name": "LayoutModel",
-     "state": {
-      "_model_module": "@jupyter-widgets/base",
-      "_model_module_version": "1.2.0",
-      "_model_name": "LayoutModel",
-      "_view_count": null,
-      "_view_module": "@jupyter-widgets/base",
-      "_view_module_version": "1.2.0",
-      "_view_name": "LayoutView",
-      "align_content": null,
-      "align_items": null,
-      "align_self": null,
-      "border": null,
-      "bottom": null,
-      "display": null,
-      "flex": null,
-      "flex_flow": null,
-      "grid_area": null,
-      "grid_auto_columns": null,
-      "grid_auto_flow": null,
-      "grid_auto_rows": null,
-      "grid_column": null,
-      "grid_gap": null,
-      "grid_row": null,
-      "grid_template_areas": null,
-      "grid_template_columns": null,
-      "grid_template_rows": null,
-      "height": null,
-      "justify_content": null,
-      "justify_items": null,
-      "left": null,
-      "margin": null,
-      "max_height": null,
-      "max_width": null,
-      "min_height": null,
-      "min_width": "500px",
-      "object_fit": null,
-      "object_position": null,
-      "order": null,
-      "overflow": null,
-      "overflow_x": null,
-      "overflow_y": null,
-      "padding": null,
-      "right": null,
-      "top": null,
-      "visibility": null,
-      "width": null
-     }
-    },
-    "6d320e968b5a41dcb994108cc4d95e50": {
-     "model_module": "@jupyter-widgets/controls",
-     "model_module_version": "1.5.0",
-     "model_name": "DescriptionStyleModel",
-     "state": {
-      "_model_module": "@jupyter-widgets/controls",
-      "_model_module_version": "1.5.0",
-      "_model_name": "DescriptionStyleModel",
-      "_view_count": null,
-      "_view_module": "@jupyter-widgets/base",
-      "_view_module_version": "1.2.0",
-      "_view_name": "StyleView",
-      "description_width": ""
-     }
-    },
-    "7c6a6eaedaf1455e9e4ce6e9bb2fc7b2": {
-     "model_module": "@jupyter-widgets/controls",
-     "model_module_version": "1.5.0",
-     "model_name": "HTMLModel",
-     "state": {
-      "_dom_classes": [],
-      "_model_module": "@jupyter-widgets/controls",
-      "_model_module_version": "1.5.0",
-      "_model_name": "HTMLModel",
-      "_view_count": null,
-      "_view_module": "@jupyter-widgets/controls",
-      "_view_module_version": "1.5.0",
-      "_view_name": "HTMLView",
-      "description": "",
-      "description_tooltip": null,
-      "layout": "IPY_MODEL_54ee4db13cab4eebada9fe0ebc9dba3c",
-      "placeholder": "​",
-      "style": "IPY_MODEL_e58a8323c0b64d82a5fa75377cf46e50",
-      "value": "<div class=\"jp-RenderedHTMLCommon jp-RenderedHTML jp-mod-trusted jp-OutputArea-output\">\n    <div style=\"width: 24px; height: 24px; background-color: #e1e1e1; border: 3px solid #9D9D9D; border-radius: 5px; position: absolute;\">\n    </div>\n    <div style=\"margin-left: 48px;\">\n        <h3 style=\"margin-bottom: 0px; margin-top: 0px;\">Cluster</h3>\n        <p style=\"color: #9D9D9D; margin-bottom: 0px;\">oai-processing</p>\n        <table style=\"width: 100%; text-align: left;\">\n            <tr>\n                <td style=\"text-align: left;\">\n                    <strong>Dashboard:</strong> <a href=\"http://3.80.217.99:8787\" target=\"_blank\">http://3.80.217.99:8787</a>\n                </td>\n                <td style=\"text-align: left;\">\n                    <strong>Workers:</strong> 2\n                </td>\n            </tr>\n            <tr>\n                <td style=\"text-align: left;\">\n                    <strong>Total threads:</strong> 16\n                </td>\n                <td style=\"text-align: left;\">\n                    <strong>Total memory:</strong> 61.48 GiB\n                </td>\n            </tr>\n            \n        </table>\n\n        <details>\n            <summary style=\"margin-bottom: 20px;\">\n                <h3 style=\"display: inline;\">Scheduler Info</h3>\n            </summary>\n\n            <div style=\"\">\n    <div>\n        <div style=\"width: 24px; height: 24px; background-color: #FFF7E5; border: 3px solid #FF6132; border-radius: 5px; position: absolute;\"> </div>\n        <div style=\"margin-left: 48px;\">\n            <h3 style=\"margin-bottom: 0px;\">Scheduler</h3>\n            <p style=\"color: #9D9D9D; margin-bottom: 0px;\">Scheduler-0760b654-375f-4759-af1f-7ce3779130c3</p>\n            <table style=\"width: 100%; text-align: left;\">\n                <tr>\n                    <td style=\"text-align: left;\">\n                        <strong>Comm:</strong> tls://10.0.0.85:8786\n                    </td>\n                    <td style=\"text-align: left;\">\n                        <strong>Workers:</strong> 2\n                    </td>\n                </tr>\n                <tr>\n                    <td style=\"text-align: left;\">\n                        <strong>Dashboard:</strong> <a href=\"http://10.0.0.85:8787/status\" target=\"_blank\">http://10.0.0.85:8787/status</a>\n                    </td>\n                    <td style=\"text-align: left;\">\n                        <strong>Total threads:</strong> 16\n                    </td>\n                </tr>\n                <tr>\n                    <td style=\"text-align: left;\">\n                        <strong>Started:</strong> 9 minutes ago\n                    </td>\n                    <td style=\"text-align: left;\">\n                        <strong>Total memory:</strong> 61.48 GiB\n                    </td>\n                </tr>\n            </table>\n        </div>\n    </div>\n\n    <details style=\"margin-left: 48px;\">\n        <summary style=\"margin-bottom: 20px;\">\n            <h3 style=\"display: inline;\">Workers</h3>\n        </summary>\n\n        \n        <div style=\"margin-bottom: 20px;\">\n            <div style=\"width: 24px; height: 24px; background-color: #DBF5FF; border: 3px solid #4CC9FF; border-radius: 5px; position: absolute;\"> </div>\n            <div style=\"margin-left: 48px;\">\n            <details>\n                <summary>\n                    <h4 style=\"margin-bottom: 0px; display: inline;\">Worker: coiled-dask-pranjal09-152383-worker-7fd143b21f</h4>\n                </summary>\n                <table style=\"width: 100%; text-align: left;\">\n                    <tr>\n                        <td style=\"text-align: left;\">\n                            <strong>Comm: </strong> tls://10.0.0.218:34367\n                        </td>\n                        <td style=\"text-align: left;\">\n                            <strong>Total threads: </strong> 8\n                        </td>\n                    </tr>\n                    <tr>\n                        <td style=\"text-align: left;\">\n                            <strong>Dashboard: </strong> <a href=\"http://10.0.0.218:44941/status\" target=\"_blank\">http://10.0.0.218:44941/status</a>\n                        </td>\n                        <td style=\"text-align: left;\">\n                            <strong>Memory: </strong> 30.74 GiB\n                        </td>\n                    </tr>\n                    <tr>\n                        <td style=\"text-align: left;\">\n                            <strong>Nanny: </strong> tls://10.0.0.218:32795\n                        </td>\n                        <td style=\"text-align: left;\"></td>\n                    </tr>\n                    <tr>\n                        <td colspan=\"2\" style=\"text-align: left;\">\n                            <strong>Local directory: </strong> /dask-worker-space/worker-2h63xzwp\n                        </td>\n                    </tr>\n\n                    \n\n                    \n\n                </table>\n            </details>\n            </div>\n        </div>\n        \n        <div style=\"margin-bottom: 20px;\">\n            <div style=\"width: 24px; height: 24px; background-color: #DBF5FF; border: 3px solid #4CC9FF; border-radius: 5px; position: absolute;\"> </div>\n            <div style=\"margin-left: 48px;\">\n            <details>\n                <summary>\n                    <h4 style=\"margin-bottom: 0px; display: inline;\">Worker: coiled-dask-pranjal09-152383-worker-f46a11c2fc</h4>\n                </summary>\n                <table style=\"width: 100%; text-align: left;\">\n                    <tr>\n                        <td style=\"text-align: left;\">\n                            <strong>Comm: </strong> tls://10.0.4.47:33463\n                        </td>\n                        <td style=\"text-align: left;\">\n                            <strong>Total threads: </strong> 8\n                        </td>\n                    </tr>\n                    <tr>\n                        <td style=\"text-align: left;\">\n                            <strong>Dashboard: </strong> <a href=\"http://10.0.4.47:37427/status\" target=\"_blank\">http://10.0.4.47:37427/status</a>\n                        </td>\n                        <td style=\"text-align: left;\">\n                            <strong>Memory: </strong> 30.74 GiB\n                        </td>\n                    </tr>\n                    <tr>\n                        <td style=\"text-align: left;\">\n                            <strong>Nanny: </strong> tls://10.0.4.47:35227\n                        </td>\n                        <td style=\"text-align: left;\"></td>\n                    </tr>\n                    <tr>\n                        <td colspan=\"2\" style=\"text-align: left;\">\n                            <strong>Local directory: </strong> /dask-worker-space/worker-n62u0x3u\n                        </td>\n                    </tr>\n\n                    \n\n                    \n\n                </table>\n            </details>\n            </div>\n        </div>\n        \n\n    </details>\n</div>\n\n        </details>\n    </div>\n</div>"
-     }
-    },
-    "8230507bb71d4e8fb7f1a79cf5e31036": {
-     "model_module": "@jupyter-widgets/controls",
-     "model_module_version": "1.5.0",
-     "model_name": "ButtonStyleModel",
-     "state": {
-      "_model_module": "@jupyter-widgets/controls",
-      "_model_module_version": "1.5.0",
-      "_model_name": "ButtonStyleModel",
-      "_view_count": null,
-      "_view_module": "@jupyter-widgets/base",
-      "_view_module_version": "1.2.0",
-      "_view_name": "StyleView",
-      "button_color": null,
-      "font_weight": ""
-     }
-    },
-    "82eade6e25264c058e9a3e00e8a291a0": {
-     "model_module": "@jupyter-widgets/base",
-     "model_module_version": "1.2.0",
-     "model_name": "LayoutModel",
-     "state": {
-      "_model_module": "@jupyter-widgets/base",
-      "_model_module_version": "1.2.0",
-      "_model_name": "LayoutModel",
-      "_view_count": null,
-      "_view_module": "@jupyter-widgets/base",
-      "_view_module_version": "1.2.0",
-      "_view_name": "LayoutView",
-      "align_content": null,
-      "align_items": null,
-      "align_self": null,
-      "border": null,
-      "bottom": null,
-      "display": null,
-      "flex": null,
-      "flex_flow": null,
-      "grid_area": null,
-      "grid_auto_columns": null,
-      "grid_auto_flow": null,
-      "grid_auto_rows": null,
-      "grid_column": null,
-      "grid_gap": null,
-      "grid_row": null,
-      "grid_template_areas": null,
-      "grid_template_columns": null,
-      "grid_template_rows": null,
-      "height": null,
-      "justify_content": null,
-      "justify_items": null,
-      "left": null,
-      "margin": null,
-      "max_height": null,
-      "max_width": null,
-      "min_height": null,
-      "min_width": null,
-      "object_fit": null,
-      "object_position": null,
-      "order": null,
-      "overflow": null,
-      "overflow_x": null,
-      "overflow_y": null,
-      "padding": null,
-      "right": null,
-      "top": null,
-      "visibility": null,
-      "width": null
-     }
-    },
-    "856173aca43d43d5a2affc843effc3bc": {
-     "model_module": "@jupyter-widgets/base",
-     "model_module_version": "1.2.0",
-     "model_name": "LayoutModel",
-     "state": {
-      "_model_module": "@jupyter-widgets/base",
-      "_model_module_version": "1.2.0",
-      "_model_name": "LayoutModel",
-      "_view_count": null,
-      "_view_module": "@jupyter-widgets/base",
-      "_view_module_version": "1.2.0",
-      "_view_name": "LayoutView",
-      "align_content": null,
-      "align_items": null,
-      "align_self": null,
-      "border": null,
-      "bottom": null,
-      "display": null,
-      "flex": null,
-      "flex_flow": null,
-      "grid_area": null,
-      "grid_auto_columns": null,
-      "grid_auto_flow": null,
-      "grid_auto_rows": null,
-      "grid_column": null,
-      "grid_gap": null,
-      "grid_row": null,
-      "grid_template_areas": null,
-      "grid_template_columns": null,
-      "grid_template_rows": null,
-      "height": null,
-      "justify_content": null,
-      "justify_items": null,
-      "left": null,
-      "margin": null,
-      "max_height": null,
-      "max_width": null,
-      "min_height": null,
-      "min_width": null,
-      "object_fit": null,
-      "object_position": null,
-      "order": null,
-      "overflow": null,
-      "overflow_x": null,
-      "overflow_y": null,
-      "padding": null,
-      "right": null,
-      "top": null,
-      "visibility": null,
-      "width": null
-     }
-    },
-    "89cfc99bacb3424983f0127b1065c98b": {
-     "model_module": "@jupyter-widgets/controls",
-     "model_module_version": "1.5.0",
-     "model_name": "HTMLModel",
-     "state": {
-      "_dom_classes": [],
-      "_model_module": "@jupyter-widgets/controls",
-      "_model_module_version": "1.5.0",
-      "_model_name": "HTMLModel",
-      "_view_count": null,
-      "_view_module": "@jupyter-widgets/controls",
-      "_view_module_version": "1.5.0",
-      "_view_name": "HTMLView",
-      "description": "",
-      "description_tooltip": null,
-      "layout": "IPY_MODEL_57cb38340f6f4d3ab264f2d2632dea0c",
-      "placeholder": "​",
-      "style": "IPY_MODEL_41aceabecac9409ca3cd650811e5b81c",
-      "value": "\n        <table>\n            <tr><td style=\"text-align: left;\">Scaling mode: Manual</td></tr>\n            <tr><td style=\"text-align: left;\">Workers: 2</td></tr>\n        </table>\n        "
-     }
-    },
-    "95f476e89c704ea2b99117c533506201": {
-     "model_module": "@jupyter-widgets/controls",
-     "model_module_version": "1.5.0",
-     "model_name": "HBoxModel",
-     "state": {
-      "_dom_classes": [],
-      "_model_module": "@jupyter-widgets/controls",
-      "_model_module_version": "1.5.0",
-      "_model_name": "HBoxModel",
-      "_view_count": null,
-      "_view_module": "@jupyter-widgets/controls",
-      "_view_module_version": "1.5.0",
-      "_view_name": "HBoxView",
-      "box_style": "",
-      "children": [
-       "IPY_MODEL_3fbd04438ff14c56b54242a5270f7abb",
-       "IPY_MODEL_e8b95ef0e41c47a4a1144699015e17fd",
-       "IPY_MODEL_bf2ddee8d91e41698fda46f6fea7de6b"
-      ],
-      "layout": "IPY_MODEL_82eade6e25264c058e9a3e00e8a291a0"
-     }
-    },
-    "9e81c59ecf804e56af1c69f30fda8cf9": {
-     "model_module": "@jupyter-widgets/controls",
-     "model_module_version": "1.5.0",
-     "model_name": "AccordionModel",
-     "state": {
-      "_dom_classes": [],
-      "_model_module": "@jupyter-widgets/controls",
-      "_model_module_version": "1.5.0",
-      "_model_name": "AccordionModel",
-      "_titles": {
-       "0": "Manual Scaling",
-       "1": "Adaptive Scaling"
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 402,
+          "referenced_widgets": [
+            "a3a4c8e9ac194fdda8266fa1b8609667",
+            "777e25916eac4cac98f819685cb66c97"
+          ]
+        },
+        "id": "p2f2EHKNcsFb",
+        "outputId": "cc6172d3-bb16-48cd-d953-93cb310b816b"
       },
-      "_view_count": null,
-      "_view_module": "@jupyter-widgets/controls",
-      "_view_module_version": "1.5.0",
-      "_view_name": "AccordionView",
-      "box_style": "",
-      "children": [
-       "IPY_MODEL_5a2b742a85db450980d791c0d30ec0bd",
-       "IPY_MODEL_95f476e89c704ea2b99117c533506201"
-      ],
-      "layout": "IPY_MODEL_67040281464e48f29e7bb370c7994cc3",
-      "selected_index": null
-     }
+      "execution_count": 3,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "Output()"
+            ],
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "a3a4c8e9ac194fdda8266fa1b8609667"
+            }
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              ""
+            ],
+            "text/html": [
+              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+            ]
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "<Client: 'tls://172.18.0.2:8786' processes=0 threads=0, memory=0 B>\n"
+          ]
+        }
+      ]
     },
-    "a94aac452f134317b546f25e3e8ea65c": {
-     "model_module": "itkwidgets",
-     "model_module_version": "^0.32.1",
-     "model_name": "ViewerModel",
-     "state": {
-      "_custom_cmap": null,
-      "_dom_classes": [],
-      "_downsampling": false,
-      "_largest_roi": {
-       "dtype": "float64",
-       "shape": [
-        2,
-        3
-       ]
-      },
-      "_model_module": "itkwidgets",
-      "_model_module_version": "^0.32.1",
-      "_model_name": "ViewerModel",
-      "_rendering_image": false,
-      "_reset_crop_requested": false,
-      "_scale_factors": {
-       "dtype": "uint8",
-       "shape": [
-        3
-       ]
-      },
-      "_view_count": null,
-      "_view_module": "itkwidgets",
-      "_view_module_version": "^0.32.1",
-      "_view_name": "ViewerView",
-      "annotations": true,
-      "axes": false,
-      "background": [
-       1,
-       1,
-       1
+    {
+      "cell_type": "code",
+      "source": [
+        "# Main execution block\n",
+        "\n",
+        "phi_AB, image_A, image_B = dp.register_images_delayed()\n",
+        "deformed_fc = dp.deform_probmap_delayed(phi_AB, image_A, image_B, 'FC')\n",
+        "deformed_tc = dp.deform_probmap_delayed(phi_AB, image_A, image_B, 'TC')\n",
+        "\n",
+        "thickness_fc = dp.get_thickness(deformed_fc, 'FC')\n",
+        "thickness_tc = dp.get_thickness(deformed_tc, 'TC')\n",
+        "\n",
+        "result = [thickness_fc, thickness_tc]"
       ],
-      "blend_mode": "composite",
-      "camera": {
-       "dtype": "float32",
-       "shape": [
-        3,
-        3
-       ]
+      "metadata": {
+        "id": "eucu3TABeG4r"
       },
-      "channels": null,
-      "clicked_slice_point": null,
-      "cmap": null,
-      "geometries": [
-       {
-        "cellData": {
-         "activeScalars": 0,
-         "arrays": [
-          {
-           "data": {
-            "dataType": "Float64Array",
-            "name": "CellScalarData",
-            "numberOfComponents": 1,
-            "size": 32225,
-            "vtkClass": "vtkDataArray"
-           }
+      "execution_count": 4,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Visualize Dask Computation Graph\n",
+        "\n",
+        "visualize(result)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 1000
+        },
+        "id": "bdxMpRkNeJKE",
+        "outputId": "d5119b1f-d58a-497b-da3a-5c8dfd593a13"
+      },
+      "execution_count": 5,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Image object>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAq4AAAXBCAYAAABc+h0HAAAABmJLR0QA/wD/AP+gvaeTAAAgAElEQVR4nOzdd1QU5//28WtBQBFFBdQoJmAXAYOVZsGCYENNxI6JsSZ2TC9qijHGEksSxRIVBcSGBcGGiBQBkQCKglEQuxQLIJ15/sgjvy9RE/q9s1yvczg5kEXeAuf2s7P3zCgkSZJARERERKTc4tVEFxARERERlQUHVyIiIiKSBQ6uRERERCQLdUQHkPK4ceMGoqKiRGcoNS0tLTg5OYnOICIVkJeXh8OHD4vOUHp2dnYwMDAQnUFKQsGTs+iF3377DR999JHoDKWmp6eHtLQ00RlEpAJSU1PRtGlT0RlKLyAgAHZ2dqIzSDnw5CwqTU9PD5Ik8e0Vb7/++qvoHw8RqaCAgADh65syvj169Ej0j4aUEAdXIiIiIpIFDq5EREREJAscXImIiIhIFji4EhEREZEscHAlIiIiIlng4EpEREREssDBlYiIiIhkgYMrEREREckCB1ciIiIikgUOrkREREQkCxxciYiIiEgWOLgSERERkSxwcCUiIiIiWeDgSkRERESywMGViIiIiGSBgysRERERyQIHVyIiIiKSBQ6uRERERCQLHFyJiIiISBY4uBIRERGRLHBwJSIiIiJZ4OBKRERERLLAwZWIiIiIZIGDKxERERHJAgdXIiIiIpIFDq5EREREJAscXImIiIhIFji4EhEREZEscHAlIiIiIlng4EpEREREssDBlYiIiIhkgYMrEREREckCB1ciIiIikgUOrkREREQkCxxciYiIiEgWOLgSERERkSxwcCUiIiIiWeDgSkRERESywMGViIiIiGSBgysRERERyQIHVyIiIiKSBQ6uRERERCQLHFyJiIiISBY4uBIRERGRLHBwJaWWn58vOoGIqNbgmkvKro7oAFIu+fn58Pb2Fp0BAMjJyYGfnx9Gjx4tOgUAcOnSJdEJRKSCAgMDkZqaKjoDALB7925MmjRJdAYAIDMzU3QCKSEOrlRKZmYmxo4dKzqjlL1794pOKKGnpyc6gYhUzLfffis6oZSjR4+KTiB6LW4VoBIffvghJElSmrdBgwYBAMLCwoS3vHhLS0sT/FMiIlVhYGAgfE3737etW7cCABYtWiS85X/f7OzsBP+kSJlwcCWllJqaioCAACgUCnh6eorOISJSebt37y75b3FxseAaolfj4EpK6cU+W0mS4O7ujsLCQsFFRESq68GDBwgKCgIAPHr0COfOnRNcRPRqHFxJKe3atQuSJAEAHj9+jLNnzwouIiJSXXv37oWa2t8jgYaGBjw8PAQXEb0aB1dSOikpKYiMjCx5qYqLKBFR9dq1a1fJmltQUIC9e/ciLy9PcBXRyzi4ktLx8PCAurp6yfsFBQXw9vZGTk6OwCoiItV048YNREdHl9rXmpWVhRMnTgisIno1Dq6kdHbt2oWioqJSH3txTVciIqpanp6eqFOn9NUx1dXVsWfPHkFFRK/HwZWUytWrV3H16tWS/a0vqKurl5zxSkREVWfXrl0oKCgo9bHCwkIcPnwYWVlZgqqIXo2DKymVPXv2QEND46WPFxYW4tixY3j69KmAKiIi1RQTE4Pr16+/8v8VFBTgyJEjNVxE9O84uJJS2b1790vP/F8oKirC4cOHa7iIiEh1eXp6vvJgAQAoFAq4u7vXcBHRv1NI/3xNlkiQCxcuwMrK6rX/X01NDf3798epU6dqsIqISDVJkgRDQ0Pcu3fvtY9RV1fHgwcPoK+vX4NlRK8VzyOupDQ8PT2hqan52v9fXFyMs2fP4uHDhzVYRUSkmkJCQv51aH3hwIEDNVBDVDYcXEkpFBUVwcPDA/n5+f/5uP3799dQFRGR6vLy8oJCofjXxxQVFWHXrl01VET03+r890OIql9iYiLMzc1LXQbr8ePHePToETp06FDyMYVCgTt37ohIJCJSKRkZGejTp0/J+0VFRUhISICRkRG0tbVLPq6pqYnMzEw0aNBARCZRKdzjSkrrt99+w5IlS5Camio6hYhI5aWmpqJp06YICAiAnZ2d6ByiV+EeVyIiIiKSBw6uRERERCQLHFyJiIiISBY4uBIRERGRLHBwJSIiIiJZ4OBKRERERLLAwZWIiIiIZIGDKxERERHJAgdXIiIiIpIFDq5EREREJAscXImIiIhIFji4EhEREZEscHAlIiIiIlng4EpEREREssDBlYiIiIhkgYMrEREREckCB1ciIiIikgUOrkREREQkCxxciYiIiEgWOLgSERERkSxwcCUiIiIiWeDgSkRERESywMGViIiIiGSBgysRERERyQIHVyIiIiKSBQ6uRERERCQLHFyJiIiISBY4uBIRERGRLHBwJSIiIiJZ4OBKRERERLLAwZWIiIiIZKGO6ACq3bKyspCeno7U1FQ8efIEOTk5yM3NBQCEhoYiNzcXe/bsgaamJgCgcePG0NLSgp6eXslbnTr8NSYiKou8vDykp6eXvOXl5eHZs2cAgEePHgEA/P39kZaWBgCoX79+yZqrr68PPT091KtXT1g/kUKSJEl0BKmuZ8+eIS4uDgkJCUhOTkZycjKSkpKQnJyM1NRU5OXlvfZzGzRoADU1NTx//hwFBQWvfVzjxo3RsmVLGBsbw8jICEZGRmjdujXMzMxgbGwMNTW+sEBEtUNBQQESEhJw5cqVkrX2xdvdu3eRlZX12s+tW7cutLS0UFhYiOzs7Nc+TltbG82bNy9Zb42MjGBsbIxOnTqhc+fOqFu3bnX81YgAIJ6DK1WZJ0+eICwsDBcuXEBMTAxiY2ORlJQE4O+F7sXi9mKha9asWckzeAMDAzRq1Aja2trQ0tJ67dd4+vQpcnJykJ6ejrS0NKSnp+PRo0e4c+dOqcH4/v37kCQJOjo6MDU1hbm5Obp16wYbGxt06tSJwywRyV5BQQGio6MRGhqK6OhoxMXF4cqVK8jPz0edOnVgaGhYarhs1apVyStV/3v0VEdH57Vf4/nz58jNzS1Zb1+83b17t9RQfOvWLeTn50NdXR3t27eHmZkZLCwsYG1tje7du0NbW7sGvzOkwji4UsWlp6fj1KlTCAwMREhICOLj41FcXIz27dvj7bffhrm5OczNzWFmZgYjI6MabcvOzsaVK1cQExODuLg4xMbGIioqCllZWWjcuDGsrKxga2sLe3t7WFhYcJAlIqVXUFCA4OBgnDlzBsHBwYiMjMTz58+hr6+Pbt26lVpzO3XqVLLFqiYUFRXhr7/+QmxsLGJjYxEXF4eoqCjcuXMHGhoa6Nq1K6ytrTFgwADY2dlxkKWK4uBKZSdJEi5evAg/Pz/4+fkhMjISampq6NmzJ2xsbGBjYwMrKysYGBiITn2lwsJCxMbGIiQkBKGhoQgKCsK9e/fQtGlTDB48GI6OjnBwcEDjxo1FpxIRAQDu3LmD48ePw8/PD2fOnEFmZibat28PW1tb2NjYwNraGh06dIBCoRCd+kopKSkIDg5GWFgYzp8/j9jYWGhpaaF3795wcHDAsGHD0L59e9GZJB8cXOm/XblyBfv27YOHhweuX7+OZs2awd7eHsOHD8egQYPQqFEj0YkVdvPmTRw9ehTHjh1DUFAQioqKYGlpCRcXF4wdOxa6urqiE4molklPT4evry/c3d0REBAALS0t2NjYYODAgRgxYgQ6deokOrHCUlNTERgYiNOnT+PIkSN48OABTExMMGbMGIwfPx4dOnQQnUjKjYMrvdrdu3exfft27Ny5Ezdu3EDr1q3h7OwMZ2dnWFhYiM6rFk+fPsWRI0fg7e2NkydPQk1NDUOGDMG0adMwePBgbicgomqTm5uLAwcOYNu2bTh37hzq16+PESNGwNnZGYMHD/7Xvf9yVVRUhPPnz8Pb2xsHDhzAo0eP0K1bN7z//vuYOHGirA+KULXh4Er/p6ioCMePH8eWLVtw/PhxNGnSBJMnT8a4cePQo0cP0Xk16smTJ/Dx8cHOnTtx7tw5tGrVClOnTsUHH3wAQ0ND0XlEpCKuXLmCLVu2wN3dHZmZmRg+fDgmTZoER0fHWnV2flFREc6ePQsPDw94e3tDkiSMGTMG06dPh42Njeg8Uh4cXOnva6l6eHhg9erVSExMRLdu3TBjxgxMnjyZ1+sDcP36dWzbtg07duxAamoqhgwZgi+++AJWVlai04hIpoKDg/HTTz/B19cXLVu2xMSJE/HRRx+hVatWotOEe/bsGby8vODm5oaoqCh06dIFixYtwvjx46GhoSE6j8Ti4Fqb3bt3D+vXr8fmzZtRUFCA9957DwsWLEDbtm1Fpyml/Px87N+/H6tXr8alS5fQp08fLF68GMOGDVPaEyOISHnk5+dj9+7dWLNmDeLj4zFw4EC4urrC3t6ea8hrREZGYs2aNdi/fz/eeOMNzJs3DzNnzkSDBg1Ep5EYHFxro7S0NKxatQrr169Hw4YNMWvWLMydOxd6enqi02QjODgY69evx8GDB9GpUyd88803ePfdd/mPDxG9pLi4GAcOHMDnn3+O27dvw8nJCR9//HGt24JVGffv38fmzZuxbt06qKmpYe7cuVi0aBEaNmwoOo1qFgfX2iQjIwMrV67Exo0b0bBhQ3z++eeYMWOGSm76rykxMTFYsmQJjhw5gp49e+K7777DoEGDRGcRkRIoLi6Gh4cHli1bhlu3bmHq1Kn48ssvuR2gEh4/fozVq1dj3bp10NbWxmeffYbZs2fXqv3AtVw8T5OuBQoLC+Hm5oaOHTti27Zt+Prrr/HXX39h7ty5HForqUuXLvDx8cGff/6JN998E/b29hg4cCAuX74sOo2IBAoPD4eNjQ2mTJkCCwsLxMfHY9OmTRxaK6lx48b4/vvvkZycjNmzZ2PJkiVo164ddu3aBR6Hqx04uKo4Pz8/mJmZYd68efjggw9w8+ZNfPrpp7xrSRUzNzeHt7c3zp49i/T0dHTt2hXz58/H48ePRacRUQ1KSkrCmDFjYGlpCV1dXVy+fBne3t48d6CK6enpYenSpbh27Rr69++P9957D/369UN0dLToNKpmHFxV1N27d+Hk5IQhQ4bAxMQE8fHx+PHHH7mhvZr169cPFy9exMaNG+Hl5YX27dvD3d1ddBYRVbOCggL88MMPMDExQVxcHI4dOwZ/f39Z3yxADlq0aIGdO3fiwoULyM/PR/fu3TF37lxkZmaKTqNqwsFVxUiShE2bNqFz586Ij4/HmTNncODAAbRu3Vp0Wq2hrq6OGTNmIDExEWPHjsV7770HBwcHJCcni04jomoQGRmJ7t2744cffsDSpUsRFxeHoUOHis6qVXr27InQ0FBs374dnp6eMDU1ha+vr+gsqgYcXFXIjRs30LdvX8ydOxezZs1CbGws+vfvLzqr1tLV1cXGjRsRFBSElJQUmJqaYv369dyHRaQicnNzsXjxYlhZWUFPTw+xsbH49NNPea1RQRQKBaZMmYL4+HjY2Nhg2LBhmDBhAjIyMkSnURXi4KoiduzYAQsLC2RmZiIiIgIrVqzgzQOUhI2NDaKjo+Hq6gpXV1c4Ojri/v37orOIqBIuX76Mnj17YsuWLdi0aRPOnDnDfaxKomnTpvDw8MCxY8dw/vx5mJubIyAgQHQWVREOrjL39OlTTJw4EVOnTsX777+PCxcuwMLCQnQW/YOWlhaWLVuG0NBQ3Lx5E+bm5jh8+LDoLCIqJ0mS4Obmhl69ekFbWxtRUVGYNm0ar+GshIYOHYrLly+jT58+GDhwIObPn4+8vDzRWVRJHFxlLCIiAmZmZjh37hxOnjyJdevW8fJWSq5Hjx64dOkShg8fjpEjR2L+/PkoKCgQnUVEZfDkyROMGDECH330ET799FOEhITwKKuS09XVhYeHB7Zu3Yrt27fD1tYWt27dEp1FlcDBVabc3NzQp08fdO7cGTExMRg4cKDoJCojHR2dkhMItm3bhv79+3PrAJGSi42NRY8ePRAdHY1z587hm2++gbq6uugsKqOpU6fi0qVLyMvLQ/fu3XHq1CnRSVRBHFxlJjc3Fx988AFmzZqFjz/+GL6+vrxVq0yNGzcOFy5cwMOHD9GtWzcEBweLTiKiV/Dw8ICVlRVatGiBqKgoWFtbi06iCmjXrh3CwsIwaNAgODo64scff+TJsjLEwVVGMjIyYG9vj3379mH//v347rvvoKbGH6GcmZqaIioqClZWVhgwYAB27dolOomI/j9JkrB06VJMnDgRkyZNwunTp9GsWTPRWVQJ9evXh4eHB3777TcsWbIEY8eORU5OjugsKgeFxKcbsnDjxg0MHToU+fn58PX15UWtVYwkSVi2bBm+/fZbfPPNN1iyZAlP9iASKD8/Hx988AG8vLywYcMGzJo1S3QSVbEzZ87gnXfegYmJCQ4fPgwDAwPRSfTf4jm4ykBISAicnJzQpk0bHDlyhM/4VdjmzZsxZ84cTJo0CW5ubrweJJEAGRkZGDVqFGJiYrBv3z4MGjRIdBJVk7i4OAwbNgza2trw9fXlzXqUXzxfZ1Zy/v7+sLe3R+/evXH27FkOrSpu5syZOHLkCA4cOIDRo0cjNzdXdBJRrfLw4UPY2dkhOTkZwcHBHFpVnJmZGcLCwqCtrQ1bW1tcuXJFdBL9Bw6uSuzYsWMYNWoURo4ciX379kFbW1t0EtUAR0dHnD17FmFhYXBwcOA9t4lqyP379zFgwABkZmYiMDAQpqamopOoBrRo0QLnzp1Dp06d0Lt3b0RERIhOon/BwVVJeXl5YfTo0ZgyZQrc3d1Rp04d0UlUg7p164Zz584hMTERAwYM4C0LiarZrVu30Lt3bxQXFyM4OBjGxsaik6gG6ejo4OjRo+jZsyfs7e0REhIiOoleg4OrEvLy8sKkSZMwf/58/P7777xyQC3VuXNnBAQE4N69exgyZAiPvBJVk5SUFPTp0weNGjVCUFAQWrRoITqJBNDW1sbhw4fRt29fODo6Ijw8XHQSvQJPzlIyR44cwbvvvovZs2dj3bp1onNICfz111/o06cPWrdujRMnTqB+/fqik4hUxqNHj9C3b19oaGggMDAQTZo0EZ1EghUUFGD06NE4f/48AgIC0LVrV9FJ9H94VQFlcvr0aQwfPhwTJkzA1q1beTkkKhEXFwc7Ozt07doVR48e5a19iapAWloa+vXrh/z8fAQFBaF58+aik0hJ5Ofnw8nJCVFRUQgMDISJiYnoJPobB1dlER4ejv79++Odd97Bjh07uD2AXhIZGYmBAwfC0dERnp6efGJDVAnZ2dno27cvHj9+jKCgILRs2VJ0EimZrKwsDB48GCkpKbhw4QJ/R5QDB1dlcPPmTVhZWaFHjx7w8fHhiVj0WmfPnoWDgwMWLlyIFStWiM4hkqWioiKMHDkS4eHhCAsLQ5s2bUQnkZJ68uQJbGxsoKGhgfPnz6NBgwaik2o7XsdVtKdPn8LJyQktW7aEl5cXh1b6V3Z2dti5cydWrlyJX3/9VXQOkSwtXLgQp0+fho+PD4dW+leNGjWCr68vHj58CGdnZxQWFopOqvU4uApUUFAAJycnPH36FMeOHYOOjo7oJJKBcePGYcmSJViwYAFOnDghOodIVn755Rf8+uuvcHd3h7W1tegckgEjIyMcOXIEQUFBmDNnjuicWo9bBQSaN28etm/fjtDQUJibm4vOIRmRJAkuLi7w9fXFxYsXeZtCojI4e/Ys7O3t8f333+PTTz8VnUMyc+jQIbzzzjvYvHkzpk+fLjqntuIeV1E8PDwwadIkeHp6YuzYsaJzSIZyc3Nha2uLgoKCklsWEtGr3b59G927d4e1tTUOHjzIkxupQr766iusWrUKQUFB6Nmzp+ic2oiDqwixsbGwsrLC7NmzsWrVKtE5JGO3bt1C9+7dYW9vjz179ojOIVJKBQUFsLOzQ1paGiIiItCwYUPRSSRTxcXFGDZsGC5fvoyoqCgYGBiITqptOLjWtKysLHTt2hUtWrTA6dOneTIWVZqfnx+GDRsGNzc3fPDBB6JziJTO/PnzsWPHDkRERKBDhw6ic0jm0tPT0b17d3Ts2BHHjx/n0fuaxasK1LQFCxYgLS0N7u7uHFqpSjg6OmLx4sWYP38+EhISROcQKZWTJ09iw4YN+O233zi0UpXQ09ODt7c3zpw5gw0bNojOqXV4xLUGHTp0CKNHj4a3tzfGjBkjOodUSEFBAWxtbVFUVITQ0FBoamqKTiISLjU1FV26dIGtrS28vb1F55CK+fbbb7F8+XKEh4ejS5cuonNqC24VqCl3795Fly5dMHr0aLi5uYnOIRWUkJCAbt26Yf78+fjhhx9E5xAJN2LECMTGxiImJga6urqic0jFFBUVoW/fvnj27BkiIiJQt25d0Um1AbcK1JQPP/wQjRs3xtq1a0WnkIrq0KEDVq1ahZUrVyIqKkp0DpFQ7u7u8PX1hbu7O4dWqhbq6urYvXs3kpOT8f3334vOqTV4xLUG7N27F+PHj8epU6cwYMAA0TmkwiRJwsCBA5GWloaLFy9CQ0NDdBJRjUtLS4OJiQnGjh3LPYhU7davXw9XV1dERETAwsJCdI6q41aB6paRkQETExOMGDGCWwSoRiQmJqJLly5YunQpL7JOtdKECRNw7tw5xMfH82grVbvi4mL06dMH+fn5CAsLg7q6uugkVcatAtVt8eLFUFNTw8qVK0WnUC3Rvn17fP3111i2bBlu3LghOoeoRvn5+cHT0xNubm4cWqlGqKmpYfPmzYiJicHGjRtF56g8HnGtRpGRkbC0tISnpyecnZ1F51AtUlBQgLfffhvt2rWDj4+P6ByiGpGfnw8zMzOYm5tj3759onOolvnyyy/x22+/ITExkTcmqD7cKlBdJElCnz59IEkSzp8/zwsUU407c+YMBg4cCH9/fwwePFh0DlG1W716Nb766itcvXoVRkZGonOolnn+/Dk6deoER0dHbNq0SXSOquLgWl08PDwwefJkhIeHo3v37qJzqJYaMWIEbty4gZiYGN7wglRaamoq2rdvjzlz5uC7774TnUO1lLu7O9577z1ERESgW7duonNUEQfX6pCbm4v27dvD3t4eW7duFZ1Dtdj169dhamqKdevWYdasWaJziKrNRx99BB8fHyQkJEBHR0d0DtVSkiTBysoK9evXx5kzZ0TnqCKenFUdNm/ejPT0dD7rJ+HatWuHWbNm4fvvv0dubq7oHKJqkZycjK1bt2LZsmUcWkkohUKBVatWISAgAAEBAaJzVBKPuFax7OxstGnTBpMnT8bPP/8sOocIDx48QJs2bfDDDz9gwYIFonOIqtzUqVMRFBSEq1ev8trFpBTs7e2RnZ2NkJAQ0Smqhkdcq9rGjRuRlZWFjz/+WHQKEQCgefPmmD17NpYvX46srCzROURV6vr163B3d8eSJUs4tJLSWL58OcLCwuDv7y86ReXwiGsVysrKgrGxMWbMmMF7xZNSSU1NRevWrfHNN9/wSRWpFBcXF0RGRuLy5cu88DspleHDh+PRo0cIDw8XnaJKeMS1Kv3xxx94/vw5Fi1aJDqFqBQDAwPMmjUL69atQ35+vugcoipx+/ZteHl54fPPP+fQSkrnq6++QkREBAIDA0WnqBQeca0iRUVF6NChAxwcHHjnDFJKd+/eRevWreHm5oYpU6aIziGqtMWLF8PLyws3b96Epqam6Byil/Tp0we6uro4evSo6BRVwSOuVeXQoUNISkriyS+ktFq2bAlnZ2esWrUKfL5KcpeZmYmtW7di3rx5HFpJabm6usLX1xfx8fGiU1QGB9cqsnbtWjg5OaFt27aiU4hey9XVFZcvX8bp06dFpxBVyrZt21BUVITp06eLTiF6reHDh6N9+/b45ZdfRKeoDA6uVSA2NhahoaGYN2+e6BSif/X222+jb9++vB0hyZokSdi0aRNcXFzQuHFj0TlEr6Wmpoa5c+fCw8MDz549E52jEji4VgE3Nze0b98effv2FZ1C9J+mTZuGI0eO4P79+6JTiCokKCgICQkJmDZtmugUov80adIkSJIET09P0SkqgYNrJeXk5MDDwwPTp0+HQqEQnUP0n9599100bNgQ7u7uolOIKmTLli3o2bMnLCwsRKcQ/SddXV288847vAV8FeHgWkne3t7Izs6Gi4uL6BSiMqlbty4mTpyIrVu38iQtkp2MjAwcOHCAe1tJVqZPn46LFy8iOjpadIrscXCtpN27d2PYsGFo2rSp6BSiMps6dSquX7+OCxcuiE4hKpf9+/dDTU0N48aNE51CVGa2trZo164ddu/eLTpF9ji4VkJqaioCAwO5gJLsvP322+jUqRO8vb1FpxCVi5eXF4YNGwYdHR3RKURlplAoMHbsWHh7e6O4uFh0jqxxcK2Effv2QVNTE0OGDBGdQlRuY8aMwd69e7mIkmw8fPgQQUFBcHZ2Fp1CVG5jx47FnTt3EBYWJjpF1ji4VoK3tzdGjBiB+vXri04hKrfx48fj/v37CAkJEZ1CVCb79+9H3bp14eDgIDqFqNxMTU1hYmLCV7oqiYNrBaWmpiI4OBjvvvuu6BSiCunYsSM6d+6MgwcPik4hKpNDhw5h2LBhPFhAsjVmzBgcPHiQJ8ZWAgfXCjp58iTU1NQwaNAg0SlEFTZ06FD4+/uLziD6T9nZ2QgODsawYcNEpxBV2NChQ3Hnzh1cvnxZdIpscXCtIH9/f9ja2qJhw4aiU4gqzMHBAdeuXcPNmzdFpxD9q9OnT6OgoAD29vaiU4gqrFu3bmjatCkPGFQCB9cKKC4uxsmTJ+Ho6Cg6hahSXjz5OnHihOgUon/l7+9f8o8+kVypqanB3t6eg2slcHCtgEuXLuHRo0c8QYBkT0NDA3Z2dlxESemdOHGCay6pBAcHBwQHByMrK0t0iixxcK2Ac+fOQV9fH6ampqJTiCqtf//+OH/+PC+LRUorJSUFSUlJGDBggOgUokobMGAA8vPzeQOYCuLgWgEhISGwtbWFQqEQnUJUaba2tnj8+DGuXr0qOukbeQ8AACAASURBVIXolUJCQqChoYEePXqITiGqtObNm6N169YIDg4WnSJLHFwrICwsDDY2NqIziKpEly5d0KBBA17PlZRWaGgoLCwsoK2tLTqFqErY2Nhwza0gDq7ldOPGDTx48ICDK6kMdXV19OzZk4soKa2QkBCuuaRSbGxscOHCBRQWFopOkR0OruUUEREBTU1NdO3aVXQKUZWxtrZGeHi46Ayil+Tm5iIuLg6WlpaiU4iqjJWVFbKysrhFqwI4uJZTTEwMOnXqBC0tLdEpRFXG3Nwcf/31F54/fy46haiUy5cvo7CwEG+//bboFKIqY2JiAi0tLcTGxopOkR0OruUUGxsLMzMz0RlEVcrc3BxFRUWIj48XnUJUSmxsLOrVq4c2bdqITiGqMnXq1EGHDh0QFxcnOkV2OLiWEwdXUkVt2rSBtrY2n/2T0omLi4OpqSnU1dVFpxBVKXNzc665FcDBtRwyMjJw9+5dDq6kctTV1WFiYsJn/6R04uLiuOaSSjIzM+PgWgEcXMvh+vXrAICOHTsKLiGqeh06dMBff/0lOoOolMTERHTo0EF0BlGV69ChA+7du8dzC8qJg2s5JCUlQV1dHYaGhqJTiKqcsbExkpKSRGcQlSgoKMC9e/dgZGQkOoWoyhkZGUGSJNy6dUt0iqxwcC2H5ORkGBoaQkNDQ3QKUZUzMjJCcnKy6AyiEikpKSgqKoKxsbHoFKIq17p1awDgAYNy4uBaDrdu3eICSirL2NgY2dnZSE1NFZ1CBAAlT6R4xJVUUYMGDdCkSRMeMCgnDq7lcOvWLbz11luiM4iqxYvhgIsoKYuUlBRoa2vDwMBAdApRtTA2NuaaW04cXMvh0aNHaNasmegMWRk5ciTq1KlTpscOHDgQjRo1KvfXcHBwgI6OTrk/j0pr2rQpAPCIKykNrrnlxzVXXpo2bco1t5w4uJZDeno69PT0RGcQVQsdHR3UrVsXaWlpolOIAPy95urr64vOIKo2+vr6SE9PF50hKxxcy0HVF9E7d+5AoVBU+GWLyn7+6dOn8eTJkwp9LlUNPT09LqKkNFT9YAHXXNLT0+PBgnLi4FpG+fn5yMzMVOlFNDAwsFo+X6FQVOrPpZrDZ/+kTNLS0lT6YAHXXOLBgvLj4FpGT58+BYAK7QeqDhs2bED79u2hpaUFY2NjLF++HD4+PlAoFDhy5Eipx/75558YOXIk9PT0oKWlhdatW2Px4sUlfyfg7z1LkydPBvD3ZvG6deuWq+ffPl9DQwM3btzAqFGj0KhRI9StWxe9evXC+fPnS/0Zr9pvFRkZiSFDhqBx48Zo1KgRevfuDX9////siY+Ph56eHnr16oXMzEwAwJAhQ9C2bVtcv34dTk5OaNKkCXR1ddG7d29ERES89GeU5fsG/H1HtYULF6JNmzaoV68emjZtiiFDhrz0Z5b1cSI1atSIR2BIaTx79gy6urqiMwBwzf0vXHMrpnHjxlxzy0uiMrl9+7YEQAoLCxOdIv32228SAGnRokXS3bt3paSkJGnChAlSp06dJACSn59fyWMjIyOlevXqScOHD5euXbsmZWZmSkePHpWaNm0q9ezZUyooKCh5rKurqwRASkpKqlDXqz7fyclJql+/vtSzZ0/J19dXyszMlKKjo6W2bdtKzZo1k3Jzc0seO2DAAElXV7fk/fDwcElTU1NauHChdOvWLSk9PV1asGCBpKamJh07dqzkcYMHD5bq169f8n5KSopkaGgomZmZSRkZGaVadHV1pe7du0u+vr5SVlaWFBcXJ7Vp00Zq0aKFlJOTU6Hv26BBg6SWLVtKoaGhUk5OjnTz5k1p9OjRko6OjpSQkFDux4lkb28vTZs2TXQGkSRJkmRpaSm5urqKzuCayzW32mzZsqXUz4D+0xUOrmX0119/SQCkqKgo0SlS69atJSMjI6moqKjkY/n5+ZKRkdFLi2jv3r2lli1bllqsJEmStm3bJgGQ9uzZU/Kx6lpEAUje3t6lHrtq1SoJgBQcHFzysX8uon379pWMjY1L/T2LioqkN998UxoyZEjJx/53EU1PT5dMTEyk9u3bSw8ePCj1NV+0eHl5vbIlPDy85GNl/b7l5ORIampqLw17T58+lfT09KT169eX63GiDR8+XHJxcRGdQSRJkiR17dpV+vzzz0VncM3lmlttdu7cKdWrV090hpxc4VaBMsrPzwcAaGpqCu149uwZbt68id69e0NN7f9+fBoaGhg9evRLjw0JCYGdnR20tLRK/T8HBwcAQHh4ePVHAxg0aFCp95s3bw7g78vdvEpWVhaCgoJgbW1d6u+ppqaGW7duwdfX96XPef78OYYNG4bs7GycPn36tZfRGThwYKn333jjDQDAvXv3AJTv+6apqYmmTZvCx8cHhw4dQkFBAQCgYcOGSEtLw9y5c8v1ONE0NTWRl5cnOoMIAJCXl8c1t4K45spjzdXS0uKaW04cXMvoxS+W6EX0wYMHAP7vmpv/q127dqXev3fvHoqLi7F7924oFIpSby1btgQA3L59u9qb1dXVX9pHpa6uDgAoKip65ec8ePAAkiSV+cLjkiTB2dkZYWFh+PDDD9GqVavXtvzzBLsXi3RhYSGA8n3f1NTUcPToUTRp0gSjR49Go0aNMHDgQKxatQoZGRmlvkZZHicaF1FSJvn5+cJvsc0199W45lYNTU1NFBcXl3wv6L9xcJWZnJwcAK8+a/R1Z5JOmzYNkiS98u3gwYPV2ltRLxbZsg5Rz58/x59//olu3bph6dKliIuLq3RDWb9v3bt3x7Vr13D+/HksWrQIz549w8cff4x27dohOjq63I8TSaFQQJIk0RlEJUSfIc8199W45laNF79DxcXFgkvkg4NrGb040vri5QZRXlwa5lWXz7h582ap9w0NDUte5pGbF+33798v0+M1NTVx8eJF+Pj4QFtbG2PGjEFWVlalvnZ5vm8KhQK2trb47rvvEBERgdDQUDx79gzLli2r0ONEycvLe+mlOiJRNDU1S7ZpicI199W45laNvLw8KBQK4a/mygkH1zJ68UslehFt2bIlmjdvjgsXLpT6eEFBAfbv31/qYzo6OujduzcCAwNLXu564fz58zAxMcHFixdLPvbi5ZuKHnGr7Of/Lw0NDVhbWyMgIAC5ubml/p+5uTl69uz50uObN28OQ0ND7Ny5E4mJiZg5c2aFvnZ5vm/nzp2DoaEhYmJiSj3OysoKb7zxRsk/dmV9nGgcXEmZKMPgyjWXa251ys/P55pbThxcy+jFL5Yy7P+bPXs2rl69is8//xypqam4desWxo0b98rrHf70009QV1fHsGHDcO3aNeTm5iIwMBAuLi7Q0tKCqalpyWNf7CUKDw9Hbm5uuffcVPbz/2nFihXIzc3FpEmT8PDhQzx58gRfffUV4uLiMGvWrNd+3tChQ+Hq6goPDw+4ublV6GuX9fvWo0cP1KlTB1OmTCn5e2dkZGDNmjW4ffs2Pvjgg3I9TjQuoqRMlGFwBbjmcs2tPjxYUAHVfuECFfHw4UMJgHTu3DnRKVJhYaH0+eefSy1atJC0tLSkjh07Sr/++qv0xx9/SAAkf3//Uo+PioqSnJycpCZNmkh16tSRDA0NJVdXVyk9Pb3U49LT06XevXtLGhoakp6ennTr1q1ydb3q852cnCR1dfWXHuvp6SkBkPbt21fysX9emkWSJCk4OFjq37+/1LBhQ6lBgwZSr169Sn2OJL18TUFJkqSCggLJyspKqlu3rvTnn39KkiSVq0WSyv59S0lJkaZOnSq1atVK0tTUlPT19SVbW1tp7969FXqcSP369ZM+/PBD0RlEkiT9fXmmOXPmiM7gmss1t9r8+uuvUtOmTUVnyMkVhSTxTIyyyMvLQ926dXH48GGMGDFCdM4rrV69GosXL0ZoaCisrKxE55AMWVhYYMiQIfjhhx9EpxBhxIgRaNSoEXbt2iU65ZW45lJl/fDDDyVbLahM4rlVoIy0tLRQv359pdgXs3PnTkycOPGlfUiRkZHQ1NRE586dBZWR3KWlpb106RoiUfT09JCWliY6g2suVZv09HSuueVUR3SAnOjr6yvFIqqrqwtPT09oaWlh+fLl0NbWxt69e7Fv3z7MmzcPDRs2FJ1IMsVFlJSJvr4+4uPjRWdwzaVqk56eXnLlCiobHnEtBz09PaU44jpy5EgcPHgQCQkJ6NixIwwMDPDLL79gxYoVWL16dZV8DX9//5cuBP26N0tLyyr5miRWdnY2cnJyuIiS0lCWI65cc6m68FWu8uMR13IwMDB47e3yatrIkSMxcuTIavvzHRwceCH6WubFgMBFlJSFvr4+UlNTRWcA4JpL1SM1NRUdO3YUnSErPOJaDq1atUJKSoroDKJqkZycDAB46623xIYQ/X9vvvkmMjMzleoWnURVKTk5mWtuOXFwLQcjI6OSf9yJVE1SUhLq1q2L5s2bi04hAvD3mguA6y6ppOzsbKSmpsLY2Fh0iqxwcC0HIyMjpKSkoKioSHQKUZVLTk6GkZGR8HvDE73w1ltvQU1NjYMrqaQXv9ccXMuHg2s5GBkZoaCgAHfv3hWdQlTlkpKSuICSUtHS0kLz5s2RlJQkOoWoyr34veZWgfLh4FoO7dq1AwBeKJhU0vXr19GmTRvRGUSltG3blmsuqaTExEQ0a9YMDRo0EJ0iKxxcy6Fp06Zo1qwZYmNjRacQVSlJknD58mWYm5uLTiEqxdzcHHFxcaIziKpcbGws19wK4OBaTlxESRUlJSUhMzMTZmZmolOISjEzM0NsbCyKi4tFpxBVqbi4OA6uFcDBtZzMzc15xJVUTmxsLBQKBW9dSUrH3Nwc2dnZ3OdKKqWoqAhXr17lwYIK4OBaTubm5oiPj0dBQYHoFKIqExcXB2NjY+61IqVjamoKNTU1HjAglXL9+nXk5ORwcK0ADq7l1LNnT+Tm5iImJkZ0ClGVCQsLQ69evURnEL1ER0cHJiYmuHDhgugUoioTGhqKevXqwdTUVHSK7HBwLacOHTpAX18fISEholOIqkRxcTEuXLgAGxsb0SlEr2RjY8M1l1RKSEgIevbsCU1NTdEpssPBtZwUCgUsLS25iJLKuHLlCh4/fszBlZSWtbU1Ll68iNzcXNEpRFUiJCQEtra2ojNkiYNrBfDZP6mS4OBgNGzYkHutSGnZ2NggLy8Ply5dEp1CVGlpaWlITEzkwYIK4uBaAb1798a9e/d4UWxSCefOnYO1tTXU1dVFpxC9Ups2bdCiRQucPXtWdApRpQUGBkJNTQ1WVlaiU2SJg2sFWFpaokmTJvD39xedQlQpRUVFOHXqFAYPHiw6hehfDR48mGsuqQR/f39YWlqiUaNGolNkiYNrBairq6N///5cREn2wsPDkZGRAQcHB9EpRP/KwcEBYWFhyMjIEJ1CVCknT57kwYJK4OBaQQ4ODggMDMTz589FpxBVmL+/P4yMjNCxY0fRKUT/atCgQVAoFAgICBCdQlRhsbGxuH37NhwdHUWnyBYH1wpycHBAbm4u91yRrB0/fpxHW0kWGjdujF69esHX11d0ClGFHT9+HAYGBujatavoFNni4FpBLVu2RK9evbB//37RKUQVcvPmTVy6dAmjR48WnUJUJqNGjYKPjw/y8/NFpxBViLe3N0aNGgU1NY5fFcXvXCU4OzvDx8cHeXl5olOIys3Lywt6enqws7MTnUJUJs7Oznj69ClOnTolOoWo3G7cuIHo6Gg4OzuLTpE1Dq6VMGbMGDx79gwnT54UnUJUbt7e3nj33XdRp04d0SlEZdKqVStYWVnB29tbdApRuXl6esLAwAB9+/YVnSJrHFwrwdDQEFZWVti7d6/oFKJySUhIQExMDJ/5k+w4Ozvj8OHDvIsWyc6+fft4sKAKcHCtpEmTJuHQoUN48uSJ6BSiMvvjjz/QqlUr9OnTR3QKUbmMHTsWz58/x8GDB0WnEJVZVFQUYmNjMXHiRNEpssfBtZLGjx8PhUIBDw8P0SlEZVJYWIhdu3Zh6tSpvFsWyU7z5s0xdOhQbNmyRXQKUZlt3boVHTt2hLW1tegU2ePgWkm6uroYM2YMNm/eLDqFqEyOHj2Khw8f4v333xedQlQh06dPR2BgIK5duyY6heg/5eTkwMvLC9OnT4dCoRCdI3scXKvAjBkzEBsbi8jISNEpRP9p69atGDRoEN566y3RKUQVMnjwYLz55pvYvn276BSi/7R3717k5OTAxcVFdIpK4OBaBaysrGBubo4NGzaITiH6V4mJifD398eMGTNEpxBVmLq6OqZNm4bt27cjOztbdA7Rv9qwYQNGjx4NfX190SkqgYNrFVm4cCG8vLxw+/Zt0SlEr7VmzRoYGRnByclJdApRpXz00UfIzc3Fjh07RKcQvdbp06dx6dIlLFiwQHSKylBIkiSJjlAFBQUFaN26NSZMmICffvpJdA7RS1JTU/HWW29h1apV+PDDD0XnEFXa7NmzceLECVy/fp0nGpJScnR0RF5eHgICAkSnqIp4HnGtIhoaGvjwww+xadMmPH36VHQO0Ut+/fVX1KtXD1OmTBGdQlQlFi1ahFu3buHw4cOiU4hecvnyZZw4cQKurq6iU1QKB9cqNGvWLEiShN9++010ClEpz549w4YNGzBnzhzUr19fdA5RlWjXrh2cnJywfPly8MVDUjbLly+HiYkJhgwZIjpFpXBwrUKNGzfG/PnzsXLlSt6QgJTK2rVrUVRUhPnz54tOIapSy5YtQ3R0NI+6klK5cuUK9u7diyVLlvASWFWMe1yr2NOnT2FsbIwFCxbgm2++EZ1DhCdPnqB169ZYuHAhvv76a9E5RFVuzJgxuHbtGmJiYqCmxuMxJN4777yDxMRE/k5WPe5xrWq6urpYuHAh1qxZg8ePH4vOIcKqVaugpqbGo62kspYtW4b4+Hjs27dPdAoRoqOjcejQIXz33XccWqsBj7hWg8zMTLRp0waTJ0/G6tWrRedQLXbnzh107NgR33zzDT755BPROUTVZvLkybhw4QIuX74MLS0t0TlUiw0aNAhPnz5FeHg4twlUPR5xrQ4NGjTAt99+iw0bNiAhIUF0DtVin332GZo1a4Z58+aJTiGqVj/++CPu37+PdevWiU6hWszHxwdnzpzB6tWrObRWEx5xrSZFRUXo2rUrWrVqhWPHjonOoVooLCwMNjY2OHDgAEaNGiU6h6jaLV26FGvWrEFCQgLeeOMN0TlUy+Tn58PU1BQ9evTAnj17ROeoqngOrtUoICAAAwYMgJ+fHxwcHETnUC1SXFwMKysr6Ojo4MyZM6JziGrE8+fP0bFjRwwaNAjbtm0TnUO1zMqVK7Fs2TJcu3YNrVq1Ep2jqrhVoDr1798f77zzDubMmYPnz5+LzqFaZPPmzYiOjsYvv/wiOoWoxmhra2PlypXYsWMHzp8/LzqHapHk5GR8++23+Oyzzzi0VjMeca1m9+/fR+fOnTF9+nTeCpZqxL1799C5c2fMnj0by5cvF51DVOOcnJxKLo9Vt25d0TlUCwwfPhzXr19HTEwMTw6sXjziWt3eeOMN/Pjjj1izZg2ioqJE51At8NFHH8HAwIDXbKVaa8OGDbh//z6fuFGNcHd3x/Hjx7F161YOrTWAR1xrgCRJsLOzw7Nnz3DhwgVoamqKTiIVtXfvXowfPx4BAQHo16+f6BwiYTZs2ABXV1dERkaiS5cuonNIRT169AidO3fG2LFjsXHjRtE5tQFPzqop169fh4WFBebMmYMVK1aIziEVdOfOHXTp0gXOzs74/fffRecQCVVcXIx+/fohIyMDkZGRqFevnugkUjGSJGH48OGIj4/Hn3/+iYYNG4pOqg24VaCmtGvXDmvXrsXPP/+MgIAA0TmkYoqLizFlyhQ0adIEP//8s+gcIuHU1NTg4eGBe/fu4dNPPxWdQyro119/hZ+fH/744w8OrTWIg2sNmj59Ot599124uLggIyNDdA6pkJ9//hnnz5/Hnj17oKOjIzqHSCkYGhrCzc0NGzdu5PW0qUrFx8fjk08+wddff42+ffuKzqlVuFWghqWnp8Pc3Bw9e/bEwYMHeWcNqrSwsDD069cP33//PT7++GPROURKZ/LkyTh58iSioqJgaGgoOodkLjs7G5aWlmjQoAGCgoJQp04d0Um1Cfe4ivBi0FiyZAm++OIL0TkkYw8fPkS3bt1gYWGBw4cPQ02NL6IQ/VNWVhYsLS1Rv359BAUF8cxvqpQpU6bg2LFjuHjxIoyNjUXn1Dbc4yqClZUVVq5cia+//hp+fn6ic0imCgsLMXbsWGhoaGDHjh0cWoleQ0dHBwcPHkRCQgLmz58vOodkbO3atdi9ezc8PDw4tArCf+kEmT9/PsaNG4fJkycjKSlJdA7J0OLFixEZGYnDhw9DT09PdA6RUmvfvj22b98ONzc33g6WKuTcuXP45JNP8P3332Pw4MGic2otbhUQKDs7G7a2tsjLy0NISAgaN24sOolk4vfff8dHH32EPXv2YPz48aJziGTjyy+/xKpVq+Dn54f+/fuLziGZSEhIgLW1Nezs7LBv3z6enyIO97iKdu/ePVhaWsLY2BgnT57k3iv6T35+fhgxYgSWLFmCr776SnQOkaxIkoTJkyfj6NGjCA4OhpmZmegkUnJpaWmwtraGrq4uAgMDUb9+fdFJtRkHV2Vw5coV2NjYwNHRER4eHnwmR68VHR2NPn36YMyYMdi+fbvoHCJZys/Ph4ODA5KSkhAWFobmzZuLTiIllZOTg4EDB+L+/fsICwtDs2bNRCfVdjw5Sxl07twZe/fuxf79+/HJJ5+IziEllZiYCEdHR1hZWWHz5s2ic4hkS1NTE/v27YOGhgYcHR3x+PFj0UmkhAoKCuDs7Ixr167Bz8+PQ6uS4OCqJAYPHgxPT0+sXbsWy5YtE51DSub27dsYPHgwjIyMcODAAWhoaIhOIpI1PT09nDlzBk+ePIGjoyMyMzNFJ5ESKSoqgouLC86ePYvDhw+jQ4cOopPo/+PgqkTeffddbN26FcuWLcNPP/0kOoeUxKNHj2Bvb48GDRrg+PHjaNCggegkIpXQqlUrnDp1CikpKXB0dER2drboJFICkiRh9uzZOHz4MI4dOwZbW1vRSfQ/OLgqmffeew9r1qzB559/jl9++UV0Dgl279492NnZQZIknD59Gk2aNBGdRKRS2rZtixMnTuDq1asYNWoUnj9/LjqJBCouLsbs2bOxc+dOHDhwAP369ROdRP/A+5QpoQULFqCoqAiLFi1CVlYWzxyvpZKTkzFw4EBoamrizJkzaNq0qegkIpVkZmaGU6dOYfDgwXBwcMCxY8fQsGFD0VlUwwoLC/H+++9j37592LdvHxwdHUUn0SvwqgJKzM3NDbNnz8bixYu5daCWSUhIwKBBg6Cvr48TJ07AwMBAdBKRyrt27RoGDhyIZs2a4cSJE9DX1xedRDUkPz8fEyZMgJ+fHw4dOgR7e3vRSfRqvKqAMpsxYwZ27NiBNWvWYObMmSgsLBSdRDUgIiICffr0gaGhIQICAji0EtWQjh07IjAwEOnp6bCzs0NKSoroJKoBT58+xdChQ3H69GmcPHmSQ6uS4+Cq5CZPnoz9+/dj9+7dGDFiBM98VXE+Pj6ws7ND9+7dcfLkSTRq1Eh0ElGt0rZtW5w/fx4KhQKWlpa4dOmS6CSqRikpKbC1tUV8fDzOnj0LGxsb0Un0Hzi4yoCTkxMCAwNx6dIl2NjY8CiAilq3bh3eeecdjB8/Hj4+PtDR0RGdRFQrtWrVCqGhobCwsECfPn1w9OhR0UlUDWJjY0sG1bCwMFhYWAguorLg4CoTPXr0QFhYGAoLC2FtbY2wsDDRSVRF8vLyMHPmTCxcuBA//vgjtm7dyuu0Egmmo6MDHx8fjB07FqNGjcLPP/8MnhKiOvbu3Qtra2t06tQJwcHBePPNN0UnURlxcJURY2NjhISEoEuXLujXrx9+//130UlUSbdv30afPn3g5eWFAwcO8M5pREpEQ0MD27Ztw4oVK/DFF1/A2dmZ27VkrrCwEK6urhg3bhymTp0KX19f6Orqis6icuBVBWSouLgY3333Hb799ltMnjwZv//+O+rVqyc6i8opICAA48aNg4GBAQ4ePMg7sxApsbNnz2LcuHHQ09PDwYMH0bFjR9FJVE4PHz7E2LFjERkZic2bN2PSpEmik6j8eFUBOVJTU8OSJUtw9OhRHDlyBN27d0dMTIzoLCqjgoICfPnll7C3t4ednR3Cw8M5tBIpOTs7O0RFRUFXVxfdu3fHli1bRCdRORw/fhxdunTBnTt3EBoayqFVxji4ytiQIUPw559/wsDAAD169MDSpUtRXFwsOov+RVJSEvr164e1a9di9erV8PLy4klYRDJhaGiI8+fPY/HixZg9ezZGjRqFtLQ00Vn0L3Jzc/HZZ59h+PDh6NOnDyIjI9GlSxfRWVQJHFxl7s0338SZM2ewdOlSLF++HIMHD8atW7dEZ9E/SJKETZs2wdzcHLm5ubh06RLmz58PhUIhOo2IyqFOnTpYunQpTp8+jaioKHTp0gXHjx8XnUWvcPHiRfTo0QObNm2Cu7s7vL290bhxY9FZVEkcXFWAuro6vvjiC4SEhODu3bswNTXFunXrUFRUJDqN8PddsPr27Yu5c+dizpw5CAsL4/44Ipnr168fYmJi0K9fPwwdOhQTJkzAo0ePRGcRgOzsbLi6usLS0hL6+vqIiYnBhAkTRGdRFeHgqkJ69OiB6OhoLFq0CJ988glsbGwQGxsrOqvWys/Px/fff4+3334b2dnZCA8Px48//ghNTU3RaURUBRo3bow9e/bg2LFjCAkJgYmJCXbt2sXLZgl04sQJmJmZYfv27di0aRMCAgLw1ltvic6iKsTBVcVoaWlh2bJluHTpEhQKBSwsLODi4sIjATXs9OnTsLCwwPLlUEZMGQAAIABJREFUy/Hpp5/iwoUL6Nq1q+gsIqoGQ4cOxdWrVzFt2jRMnToVvXr14rW2a9jt27fh4uICBwcHdO7cGXFxcZg2bRq3Y6kgDq4qqnPnzggNDcUff/yBU6dOoWPHjvjpp5+Qn58vOk2lJSYmYtiwYRg0aBBat26NK1euYOnSpbyhAJGK09bWxooVKxAREYF69erBxsYGLi4uePDggeg0lZadnY2lS5eiffv2iIiIwLFjx3D06FEYGhqKTqNqwsFVhSkUCri4uCAxMREzZszAkiVLYGZmBg8PD159oIolJydj2rRp6Ny5M+7du4egoCAcPXoUxsbGotOIqAZ17doVgYGB8PT0xLlz59CuXTt8+eWXyMjIEJ2mUnJycrB27Vq0adMG69evx08//YTLly9j6NChotOomnFwrQUaNGiAFStWID4+HpaWlnBxcYG5uTn279/PvViVdOfOHXz44Yfo0KEDzp49i61bt+LixYvo3bu36DQiEkShUGDs2LG4du0avv76a7i5uaF169ZYtmwZnj59KjpP1vLy8rBx40a0bdsWX331FVxcXHD9+nXMmzcPderUEZ1HNYB3zqqFrl27hmXLlsHb2xsmJiZwdXXFhAkTeNJQOVy7dg2rV6+Gu7s7mjVrhq+++grvvfcetwQQ0UsyMzOxbt06rF69GgqFAjNnzsS8efPwxhtviE6TjWfPnmHz5s1Yv3490tLSMHPmTHz22Wdo3ry56DSqWfEcXGuxy5cvY+XKlfDy8oK+vj7mzZuHmTNn8jp3/yIoKAirVq2Cr68v2rZti0WLFuH999/n0E9E/+nJkyfYuHEjNm7ciMePH2PixIlYtGgRTE1NRacprdu3b2PdunXYsmULJEnC9OnTsXDhQu5hrb04uBLw4MEDbNq0CRs2bEB2djZGjBiBGTNmYMCAATwjE3//Y+Pt7Y3ff/8df/75J7p164Z58+Zh4sSJUFdXF51HRDKTn58PLy8vrFz5/9i776gor4QN4M/QLCAoxRIbKIoNULFR7KKAEhMVNNEYuzExS6LuZt1836fZuDFmExMTk9gLFgSMgg1QRFFKNALSjIKKHQtF6WWG+f7Iyq5rA5yZO+/M8zuHkwMMcx84yc0zd+5736+QmZkJFxcXzJs3D1OnToWpqanoeMLV1NQgJiYGGzZsQFhYGKysrDB//nwEBARwYYVYXOnfiouLsWvXLmzatAlJSUno1q0bZs+ejcmTJ6N9+/ai42mUXC5HdHQ0AgMDsX//fhgbG2PKlCmYN28e+vXrJzoeEekApVKJY8eOYePGjThw4ACaNm2KqVOnYtq0aRg4cKDeLRxkZmZi9+7d2LZtG+7evYsRI0Zgzpw5ePPNN/muFj3G4krPlpycjE2bNiEoKAiPHj2Cm5sb/P39MWnSJLz22mui46mFQqHAyZMnERwcjH379qGgoACDBg2qLe9mZmaiIxKRjrp//z62b9+OLVu24OLFi+jYsSP8/f3h7++v0y+WL126hJCQEISEhCAjIwPt2rXDu+++i1mzZqFTp06i45H2YXGlF1MoFDhx4gQCAwMRHh6OkpIS9OnTB6NGjcKoUaMwdOhQSV+QlJeXhxMnTiA6OhoHDx5Ebm4uevToAT8/P0ydOhVdunQRHZGI9ExmZiZCQ0MRFBSErKwstGrVCqNHj4avry9Gjx4NCwsL0REbTC6X49dff8WhQ4cQHR2N5ORkWFpawsfHB35+fvDx8eEWLHoRFlequ4qKCkRFRSEiIgKRkZG4fv06rKysMGLECLi7u8Pd3R29e/fW6iNJ7t27h4SEBJw+fRqnTp1CSkoKjI2N4eHhAS8vL4wfP55llYi0xrlz53Do0CFERETg3LlzMDIygqurK4YMGQI3Nze4ubnB3NxcdMznKi8vx2+//Ya4uDjEx8cjNjYWpaWl6NmzJ7y9veHj44MhQ4awrFJdsbhSw124cAGRkZE4efIkEhISkJ+fD1NTUwwYMAB9+vSBo6MjHB0d0bNnTzRu3Fjj+W7evImMjAykpaUhPT0dZ8+eRXZ2NgwNDdGrVy8MHjwYnp6eGDlyJC+IICKtl5eXh6NHj+LYsWNISEhAVlYWDAwM0KtXL/Tv3792znVycoK1tbXG8xUVFSE9PR0ZGRlITU1FSkoKkpKSUF1djXbt2sHd3R0jRoyAt7e33l03QSrD4kqqoVQq8fvvvyMhIQGJiYlITU3FhQsXUF5eDkNDQ9jZ2cHOzg62tra1/2zTpg2srKxgbW0NKyurpzbf19TU4NChQ3j99defGu/Ro0d48OAB8vPzkZeXhxs3biAnJwfXrl1DTk4Orly5gsLCQgBA+/bt4ejoiH79+sHNzQ2urq5avUJBRFQX9+/fR0JCAuLi4nD+/HmkpqYiLy8PANCqVSt07tz5iXm3bdu2sLa2ho2NDaysrJ65bz8sLAxvvPHGU18vLy+vnW/z8vJw584d5OTkPDHv3rhxAwBgbm4OR0dH9O7dG66urvDw8EDHjh3V+8cgfcHiSuqjUChw+fJlpKWl4eLFi7WT27Vr13Dz5k3I5fInHt+sWTMYGRnBzMwMxsbGqKysxMOHD9GqVSsAf5x6IJfLUVJSgurq6id+tkWLFk+U4s6dO6NXr15wdHTk8SlEpDdyc3ORnp6OzMzM2mL5eN4tLS194rGNGzdGkyZN0KhRIzRt2hTAH+9UtWnTBkZGRqioqEB5eTkqKytRVlb2xM82atQItra2T8y7PXr0gKOjI2xtbTX165L+YXElMRQKBfLz85/6kMvlKC0tRVVVFfbu3YukpCT89a9/hYWFBczNzWFoaAgzMzNYWVnBxsamdrWWb/UTEb1YUVFR7TtVj1dPy8vLUVVVhdLSUmRnZ2Pz5s0YN24cPDw8nii2VlZWT30QCcDiStqpqqoKNjY2KCoqwqpVq/CXv/xFdCQiIp02Y8YMbN++Hc7Ozjh//rzoOETPcsFAdAKiZ4mKikJxcTEAIDAwUHAaIiLdVlFRgb179wIAUlNTkZ2dLTgR0bOxuJJW2rlzZ+2xWpmZmcjMzBSciIhIdx0+fLh2H6uJiQmCgoIEJyJ6NhZX0jqlpaU4cOBA7QVYxsbGCA4OFpyKiEh37dq1q/Ys1aqqKmzfvl1wIqJnY3ElrRMWFoaqqqraz6urq7Ft2zZwOzYRkeoVFRXh8OHDT5z0cvXqVaSkpAhMRfRsLK6kdXbu3AkDgyf/1bx58ybOnTsnKBERke7at2/fU8cTcrsAaSsWV9IqBQUFiI6OfmoSNTY25iRKRKQGO3bsgEwme+JrVVVV2LFjB2pqagSlIno2FlfSKiEhIc/cElBdXY0dO3ZAoVAISEVEpJsePHiA2NjYZ86td+/eRVxcnIBURM/H4kpaZceOHc/dy5qXl4fY2FgNJyIi0l3BwcFPrbY+ZmxsjN27d2s4EdGLsbiS1rhz5w4SExOf+9YUJ1EiItUKDAx87jtZ1dXVCAoKeuJiWSLRWFxJa/zncSzPUl1djZCQEFRWVmowFRGRbrp+/TrOnTv3whNbioqKcOzYMQ2mInoxFlfSGjt37nzpHtbi4mJERUVpKBERke4KCgp67jaBxwwNDflOF2kVFlfSCpcuXUJaWlqdzmrl6QJERK8uKCjopacGKBQKhIeH195Vi0g0mZKnupMWqKqqQmlp6RNf27x5M7788sun7pltaGgIc3NzTcYjItI5hYWFT3yel5eHrl27Ijw8HIMHD37ie+bm5i/cykWkIReMRCcgAv447NrExOSJrzVt2hQymQwtWrQQlIqISHf999z6+PzsZs2acd4lrcWtAkREREQkCSyuRERERCQJLK5EREREJAksrkREREQkCSyuRERERCQJLK5EREREJAksrkREREQkCSyuRERERCQJLK5EREREJAksrkREREQkCSyuRERERCQJLK5EREREJAksrkREREQkCSyuRERERCQJLK5EREREJAksrkREREQkCSyuRERERCQJLK5EREREJAksrkREREQkCSyuRERERCQJLK5EREREJAksrkREREQkCSyuRERERCQJLK5EREREJAksrkREREQkCSyuRERERCQJLK5EREREJAksrkREREQkCSyuRERERCQJLK5EREREJAksrkREREQkCTKlUqkUHYK0w44dO/Dpp5+KjlGrqqoKlZWVaNasmegotSwtLXH+/HnRMYhIBxQUFKB3796iY9RSKpUoLi6GqakpDA0NRcepFRwcDFdXV9ExSDtcMBKdgLRHcXEx8vPz8dlnn4mOopUSExMRGxsrOgYR6QiFQoGbN2/ivffeQ+fOnUXH0TqlpaVYvnw5KioqREchLcLiSk9o0qQJlixZIjqGVvrpp59YXIlI5fz9/TF8+HDRMbTOgwcPsHz5ctExSMtwjysRERERSQKLKxERERFJAosrEREREUkCiysRERERSQKLKxERERFJAosrEREREUkCiysRERERSQKLKxERERFJAosrEREREUkCiysRERERSQKLKxERERFJAosrEREREUkCiysRERERSQKLKxERERFJAosrEREREUkCiysRERERSQKLKxERERFJAosrEREREUkCiysRERERSQKLKxERERFJAosrEREREUkCiysRERERSQKLKxERERFJAosrEREREUkCiysRERERSQKLKxERERFJAosrEREREUkCiysRERERSQKLKxERERFJAosrEREREUkCiysRERERSQKLKxERERFJAosrEREREUkCiysRERERSQKLKxERERFJAosrEREREUkCiysRERERSQKLKxERERFJAosrEREREUkCiysRERERSQKLKxERERFJAosrEREREUkCiysRERERSQKLKxERERFJAosrabWrV6+KjkBEpDc455K2MxIdgLRLYWEhOnToIDoGAEAul+PRo0ewsrISHQUAUFJSAgMDvtYjItWaMmUKGjVqJDoGAOD+/fuwsbGBTCYTHQU1NTWiI5AWYnGlWm5ubli1apXoGLWio6Nx4sQJLFiwAMbGxqLjAACaNm0qOgIR6QgzMzP885//FB2j1v379/HPf/4Tw4cPh5OTk+g4tezt7UVHIC0iUyqVStEhiJ6la9euyM7ORlBQEKZMmSI6DhGRTlu2bBn+/ve/Y/z48QgLCxMdh+hZLvB9T9JK58+fR3Z2NmQyGXbu3Ck6DhGRztu+fTsA4MiRI3j06JHgNETPxuJKWmn37t0wMTGBUqlEVFQU8vPzRUciItJZv/32G65fvw7gj72l+/fvF5yI6NlYXEnrKJVK7Nq1C1VVVbWfcxIlIlKfoKCgJ64l2LFjh8A0RM/HPa6kdU6fPo0hQ4bUfm5gYAB3d3ecOnVKYCoiIt1UU1OD1q1b48GDB7VfMzAwwO3bt9G6dWuByYiewj2upH2CgoJgYmJS+3lNTQ3i4uJw+/ZtgamIiHTTyZMnnyitwB/FNTQ0VFAioudjcSWtIpfLsWfPntptAo8ZGhoiJCREUCoiIt21e/fup44cVCgUCAwMFJSI6PlYXEmrHD16FIWFhU99XaFQ1F7xSkREqlFVVYWQkBBUV1c/8XWlUolz587h8uXLgpIRPRuLK2mVZ73yB/6YRFNTU5GVlSUgFRGRboqIiEBJSckzv2dsbMx3ukjrsLiS1igrK8O+ffueeuX/mImJCfbs2aPhVEREumvXrl0wMnr2TTSrq6uxdetWDSciejEWV9IaBw8eREVFxXO/X1VVxe0CREQqUlpaioMHDz53sQAALl++jPT0dA2mInoxFlfSGrt27YKhoeELH3P16lWkpKRoKBERke7av3//UxfC/jdjY2MEBQVpKBHRy7G4klZ4+PAhoqKiUFNTA2NjYxgbG8PIyAhGRkZPfA6AkygRkQoEBQVBqVTWzrHPmnflcjl27twJHvlO2uLZG1uINKy4uBg//PDDE187efIkDh48iG+++eaJr7ds2VKT0YiIdNKkSZMwfvz42s+Li4uxZMkSLFq0CA4ODk88trS0FGZmZpqOSPQU3jmLtNZPP/2EZcuWPXUwNhERqd6DBw/QsmVLxMTEYPjw4aLjED0L75xFRERERNLA4kpEREREksDiSkRERESSwOJKRERERJLA4kpEREREksDiSkRERESSwOJKRERERJLA4kpEREREksDiSkRERESSwOJKRERERJLA4kpEREREksDiSkRERESSwOJKRERERJLA4kpEREREksDiSkRERESSwOJKRERERJLA4kpEREREksDiSkRERESSwOJKRERERJLA4kpEREREksDiSkRERESSwOJKRERERJLA4kpEREREksDiSkRERESSwOJKRERERJLA4kpEREREksDiSkRERESSwOJKRERERJLA4kpEREREksDiSkRERESSYCQ6ANF/KioqgkKhgEKhQF5eHhQKBW7evAkzMzMAgJmZGYyNjQWnJCLSDRUVFSgvLwcA3Lx5EwCQm5uLwsJCAICJiQlMTU2F5SP6bzKlUqkUHYJ0S1lZGa5du4Zr164hLy8P+fn5tR8PHjx44vPy8nJUVlairKysXmPIZDI0b94cMpkMVlZWz/2wtrZGmzZtYGdnhzZt2kAmk6nptyYiEkMul+PWrVu4fv06cnNzn5hjH3/k5eUhLy8Pjx49Qk1NDR49elTvcZo1awYjIyOYmZnVzq/W1tZPzbstW7aEra0tOnbsCBMTEzX8xqTHLrC4UoPcvHkTFy5cQE5OTm1Jffxx79692sc1btz4iQnNxsbmiYmuSZMmaNKkCRo3bgwAMDc3h6GhIQwMDGBhYQEAqKqqQmlpKQCgpKQE1dXVAIDCwkIolcpnTtKPJ+qCgoLaLI0aNYKtre0TH3Z2drC3t0fPnj1rMxARaZuioiJkZmbi8uXLT827N2/ehFwuBwAYGBjUlsr/LpQ2NjawsLCAoaEhzM3NAfwxRzdp0gTAv4upUqnEw4cPATw5/5aWlqKqqgolJSVPLET89wLF4znawMCgduHAzs7uiXnX0dER1tbWmv4zkvSxuNKLlZaWIjMzE6mpqUhPT0daWhrS0tJq30aysLB4akL6z382a9ZMaH6FQoE7d+7UTvT//c/bt29DLpfD0NAQXbp0gZOTE5ycnODo6AgnJyfY2toKzU9E+kWhUODy5cu1c21aWhrS09ORk5MD4I8X4B06dHhinv3PjzZt2gj+DYD8/PzaUv2fJTsnJwc5OTm1WxPatGkDR0dHODs718653bt35yotvQiLK/1bTU0NMjIyEB8fj4SEBJw5cwZXrlxBTU0NzMzM0LNnz9oJ5vGHpaWl6NivpLq6GleuXEF6ejpSU1ORkZGBtLQ0XLt2DUqlEhYWFujduzfc3d3h5uYGV1dXyf/ORKQ97ty5g/j4eMTHxyMxMRHp6ekoLy+HkZERunTpUlvoHs+5HTt2hIGBtK+rvnPnDjIyMmoXRDIyMpCZmYmqqioYGxujW7ducHV1rZ137e3tRUcm7cHiqs9KSkpw9uzZ2qKakJCAoqIimJubY9CgQXB1dYWzszOcnJzQqVMnvdofWlRUhIyMDKSnp+O3335DQkICLl68CADo3r073N3dayfVLl26CE5LRFKgUCiQmZmJuLg4JCQkID4+HteuXYORkRGcnZ3h5uaGvn37wtHRUe+2L8nlcly6dAnp6elISUlBQkICzp07h4qKCrRq1Qpubm7w8PCo/RtxVVZvsbjqm6tXr+LgwYM4dOgQTp06haqqKrRp0wYeHh5wd3eHi4sLBg4cyCv3n6GoqAhnz55FXFxc7QpJeXk5WrZsiaFDh2LcuHHw9fVFixYtREclIi3x4MEDnDx5EgcPHsThw4dRUFAAMzMzODs71867gwcPRvPmzUVH1TpyuRypqam1c25sbCzu37+PJk2awN3dHaNGjYKvry969OghOippDourrissLMSxY8cQGRmJyMhI5ObmonXr1vDy8sKYMWMwZMgQvPbaa6JjSlJVVRWSkpJw/PhxRERE4MyZM5DJZHB1dYW3tze8vLzQu3dvvVqpJtJ3crkc8fHxtXNuamoqGjVqhKFDh8Lb2xvDhw9Hr169JP92vyhZWVmIjY1FZGQkoqOjUVRUhC5dusDLywve3t4YNmxY7cVmpJNYXHXRnTt3sHfvXuzduxcJCQmQyWQYNGhQbZnq06cPy5QaFBQUPPEi4e7du2jdujXGjx8Pf39/DB06FIaGhqJjEpGKVVRUICIiAsHBwYiMjMSjR49gb28Pb29veHt7Y+jQoWjatKnomDqnuroaCQkJT7xIaNy4MUaMGAF/f3+MHz++9nQa0hksrrri3r17+OWXXxAcHIy4uDiYmZnh9ddfx+uvvw5PT0++DaVhSqUS58+fx5EjR7B3716cP38erVq1wqRJk+Dv7w8PDw+uuBBJWGVlJaKiohASEoIDBw6gtLQUQ4YMwYQJE+Dt7c0LigS4c+cOIiMjERYWhqNHjwIAxowZA39/f7z++uvCT7khlWBxlbKCggKEhoYiJCQEsbGxaNKkCXx9feHv7w8vLy+92tiv7bKyshASEoKQkBCkp6fjtddew6RJkzB58mS4ubmJjkdEdSCXy3H06FGEhIQgLCwMxcXFcHNzg7+/PyZNmqQVR1HRHx4+fIiwsDCEhIQgOjoahoaG8PHxqS2x3E4gWSyuUpSUlIQNGzZg586dqKmpwahRo+Dn54cJEybU3hqVtFdOTg5CQkIQGBiICxcuwMHBATNnzsSsWbNgY2MjOh4R/Zfbt29j586d+Pnnn3H9+nX06NEDfn5+mD59Ojp16iQ6Hr1EYWEhDh48iNDQUERFRaFp06aYPHky3nvvPfTp00d0PKofFlepuH//PrZt24bNmzcjKysLAwcOxJw5czBlyhSWVQlLSkrCpk2bsHv3blRWVuLNN9/E3LlzMXz4cO5DJhKoqqoKBw4cwMaNGxEdHY1WrVph5syZmD17NsuqhN27dw/bt2/n/0uli8VVmymVSkRHR2PDhg04cOAAmjZtimnTpmHu3LlwcnISHY9UqLS0FCEhIdi4cSMSExNhb2+P2bNnY/bs2VyFJdKgK1euYP369di+fTvy8/Ph5eWFOXPmYNy4cTAyMhIdj1REqVQiNjYWmzZtwi+//AJjY2O89dZbmD9/Pvr27Ss6Hj0fi6s2qqqqwu7du7F69Wqkp6dj8ODBmDNnDvz8/LgvRw9kZmZi48aN2LFjB8rLyzF9+nR8/PHHcHBwEB2NSGclJCTgm2++QVhYGNq1a4dZs2Zh1qxZaN++vehopGYFBQXYsWMHNm3ahIyMDAwfPhyLFy+Gj48P3/nSPiyu2qSoqAhbt27F119/jXv37uGNN97AkiVLMGDAANHRSIDKykoEBwfjyy+/xMWLFzFy5Ej86U9/gq+vr+hoRDqhpqYGhw8fxqpVqxAfH4++ffsiICAAb7/9NldX9VRcXBxWrVqFw4cPo3Pnzli4cCHmzZvHRSPtweKqDXJycrB+/XqsW7cONTU1mDlzJpYsWcJX+gTg3/9z/f777xEdHY0+ffrgo48+4v9ciRqooqICISEhWLlyJbKysuDj44OAgACMGjVKdDTSEtnZ2Vi7di02btwIMzMzvP/++1i4cCGsra1FR9N3LK4iXb9+HV988QW2bNmCdu3a4b333sP8+fN55io9V3JyMr777jsEBQWhXbt2WLp0KWbNmsUCS1QHZWVl2LhxI7788ksUFhbC398fS5cuRffu3UVHIy11//59/PTTT1i7di3Ky8sxZ84c/O1vf0OrVq1ER9NXLK4i3LhxA//4xz+wdetWdOzYEcuWLcOUKVNYPqjOrly5ghUrVmDnzp3o0qULli9fjkmTJvGmBkTPUFlZifXr12PlypUoLi7Ghx9+iMWLF3P1jOqstLQU69atw6pVq1BRUYGPPvoIixYt4kKT5rG4atKDBw/wzTffYM2aNWjZsiU+/fRTrpbRK7l27RpWrlyJzZs3o1u3bli2bBkmTZrECwqI8MctQYOCgrB8+XLcvn0bM2bMwPLly3mjAGqw0tJSbNq0CV988QXKy8vx/vvvY+nSpby1rOZc4PKMBhQUFGDx4sXo2LEjdu7cidWrVyM7Oxvz5s1jaaVXYmtri/Xr1yM1NRXdu3fH5MmT0b9//9rbHRLpo5qaGmzfvh0ODg6YO3cufHx8aq8lYGmlV2FqaoqAgABkZWVh0aJFWLduHezt7fH111+jsrJSdDy9wOKqRnK5HGvXrkWXLl2wc+dOrFy5EpcvX8aCBQtgYmIiOh7pkJ49eyI0NBTJycl47bXXMGbMGIwbNw6XLl0SHY1Io+Li4jBgwADMmTMHI0eOrL3I5rXXXhMdjXSIhYUFli9fjqtXr2Lu3LlYvnw5evTogX379omOpvNYXNXk+PHj6Nu3LxYtWoRp06YhKysLAQEBaNy4sehopMN69+6NAwcO4MSJE7h16xYcHR0xf/585OXliY5GpFa3bt3C9OnTMWTIEFhYWCApKQkbN25Ehw4dREcjHWZpaYkvvvgCWVlZtbdfHz58OM6fPy86ms5icVWx7Oxs+Pv7Y9SoUWjVqhXOnz+PNWvWcP8LadSwYcOQnJyMTZs2ITw8HA4ODlizZg3kcrnoaEQqVVZWhlWrVqF79+5ITExEcHAwjh8/zrsLkka99tprWL9+Pc6cOYPq6mq4uLhg+vTpuHfvnuhoOofFVUVKSkqwZMkS9OrVC7///juOHTuGY8eOoUePHqKjkZ4yMDDA9OnTcfHiRbz77rv485//DBcXF5w6dUp0NCKVCAoKQteuXbFy5UosW7YMmZmZ8PPzEx2L9Fi/fv1w+vRpbNu2DTExMXBwcMC3334LhUIhOprOYHFVgcjISDg6OmLr1q349ttvkZKSwoOsSWs0b9689vbBbdu2xbBhw/Dee+/h0aNHoqMRNciNGzcwduxYTJ06Fd7e3sjKysKSJUuOf4U+AAAgAElEQVR47QBpBZlMhnfeeQeXLl3CwoULsXTpUgwaNAipqamio+kEFtdXUFhYiPnz58PHxwe9evVCWloa3n//fZ4UQFrJwcEBR44cQXBwMPbv349u3bph7969omMR1ZlSqcSGDRvQq1cvXLp0CdHR0di4cSNatmwpOhrRU0xNTbFixQpkZGSgWbNm6NevHwICAlBaWio6mqSxuDZQaGgounXrhoMHDyI0NBQHDx5E27ZtRccieik/Pz9cunQJr7/+Ovz9/eHr64tbt26JjkX0QtnZ2RgxYgQ++OADvP/++8jIyMCIESNExyJ6KXt7exw/fhw//vgjtm3bBmdnZxw/flx0LMlica2nmzdvYuzYsZg8eTImTpyIixcvYuLEiaJjEdVL8+bNsX79ekRGRiIzMxNOTk7YsmULeD8S0jZVVVX47LPP4OjoiNLSUiQlJeHLL7/kCS0kKTKZDPPmzUNGRga6d+8OT09PzJ8/n1u2GoDFtR727NkDJycnXL16FbGxsfjpp59gbm4uOhZRg40ePRrp6emYMWMG5s2bh/Hjx+PBgweiYxEBAC5dugQ3Nzf885//xMqVK5GYmMjTAkjS2rdvj4MHDyIoKAhhYWFwdnZGXFyc6FiSwuJaB0VFRZg/fz7efvtt+Pv7IykpCYMHDxYdi0glTE1NsXr1asTFxeHChQvo1asXDh8+LDoW6bnAwED069cPMpkMycnJ+Pjjj2FoaCg6FpFKTJ48GRkZGXB2dsbQoUMREBCAqqoq0bEkgcX1Jc6cOQMXFxfs378f4eHhWL9+PZo2bSo6FpHKDRo0CMnJyRgzZgx8fX0xf/58lJWViY5FeiYvLw9vvPEGZsyYgVmzZiE+Ph5du3YVHYtI5WxsbBAeHo6tW7di8+bN8PDwQHZ2tuhYWo/F9TnkcjlWrVqFwYMHo1OnTkhNTYWvr6/oWERqZW5ujsDAQAQHByM0NBT9+/fnHWBIY6Kjo9G7d28kJyfjxIkTWLNmDY+4Ip03ffp0nDt3DgqFAs7OzlizZo3oSFqNxfUZbt68iSFDhuCzzz7Dt99+i8jISLRp00Z0LCKN8fPzQ3JyMlq0aAFXV1f89NNPoiORDpPL5ViyZAlGjx6NwYMHIy0tDUOHDhUdi0hjunXrhsTERHzwwQdYtGgRJk+ejOLiYtGxtJJMycuInxATE4MpU6bAxsYGoaGhvPMV6TWFQoHPP/8cn3/+OaZNm4Z169ahSZMmomORDrl37x4mT56M3377DT/99BPeffdd0ZGIhDp+/DimTp0KS0tL7Nu3D926dRMdSZtc4Irrf9iwYQO8vLzg5uaGhIQEllbSe4aGhli+fDkOHTqEQ4cOwdXVFVevXhUdi3REUlISBg4ciJycHMTGxrK0EgEYOXIkkpKS0Lx5c/Tv3x+hoaGiI2kVFlcAJSUl8Pf3x/vvv4/PP/8c+/fvh4WFhehYRFrD29sbKSkpMDExQZ8+fRAeHi46Eknchg0b4Obmhh49euD8+fPo16+f6EhEWqNt27Y4deoUPvjgA0yePBkBAQGorq4WHUsr6H1xzc7OhqurK06cOIHIyEh88sknkMlkomMRaZ0OHTrg1KlTmDRpEt5880389a9/RU1NjehYJDEVFRWYM2cO3nvvPXz88cc4dOgQWrRoIToWkdYxMjLCl19+icDAQGzatAmenp64d++e6FjC6fUe14iICEyZMqX2nu3t27cXHYlIEn744QcsXrwYY8eOxa5du3hEHNVJbm4ufH19ceXKFezYsQPjxo0THYlIEpKTkzFx4kTU1NTg0KFDcHR0FB1JFP3d47p+/Xq8/vrreOONN3Dq1CmWVqJ6+PDDD3H8+HGcPn0aw4YN4yoAvVRGRgYGDRqEkpIS/PbbbyytRPXQt29fnDt3DnZ2dvDw8MDRo0dFRxJG74qrUqnE8uXLsWDBAnz66afYtm0bGjVqJDoWkeQMHjwYZ8+eRVFREVxcXJCamio6Emmp48ePw8PDA+3atcPp06dhb28vOhKR5FhZWeHo0aMYP348xo4di59//ll0JCH0qrhWVlZi6tSpWLlyJbZv347ly5dzPyvRK+jUqRMSEhLQuXNnDBs2DCdOnBAdibTMtm3b4O3tjdGjR+P48eOwsbERHYlIskxMTLB9+3Z8+umn+OCDDxAQEKB31xroTXEtKCiAp6cnIiMjERkZiXfeeUd0JCKdYGlpiaNHj8LHxwdeXl4IDAwUHYm0wON3t2bOnIkFCxZgz549aNy4sehYRJInk8mwfPlybNmyBevWrcPkyZNRXl4uOpbGGIkOoAk5OTkYPXo0FAoF4uPj0b17d9GRiHRKo0aNsHPnTrRv3x4zZszAzZs38emnn4qORYLI5XLMnDkTwcHB2Lx5M2bNmiU6EpHOmTFjBtq3b4+JEyfCy8sLBw4c0IujPHX+VIFLly5h1KhRsLGxQUREBFq1aiU6EpFO+/nnn7Fw4UIsWbIEq1atEh2HNKyyshJTpkzBsWPHsH//fnh6eoqORKTTMjMzMXr0aLRp0wZRUVGwsrISHUmdLuh0cb1w4QI8PT3Rtm1bREZGwtLSUnQkIr0QFBSEd999F7Nnz8aPP/4IAwO92ZWk18rKyjBhwgT8+uuvOHz4MNzd3UVHItIL165dw6hRo2BiYoJjx46hbdu2oiOpi+4eh5WUlIQhQ4bA3t4ex48fZ2kl0qC33noLv/zyC7Zt24Z33nkHcrlcdCRSs9LSUvj6+uLs2bOIiopiaSXSIFtbW5w+fRoGBgYYPHiwTt+aWyeL6+nTpzFixAgMGDAAkZGRaNasmehIRHrH19cX+/fvx/79+zFx4kRUVlaKjkRq8vDhQ4waNQqZmZk4efIkBg4cKDoSkd5p06YNYmJiYG5ujuHDhyM7O1t0JLXQueJ69OhReHl5wdPTE2FhYWjSpInoSER6y8vLC0eOHMGJEycwceJEVFRUiI5EKnb//n0MGzYMd+7cwenTp+Hk5CQ6EpHeatmyJWJiYtCqVSsMHToUmZmZoiOpnE4V15iYGLzxxhuYMGEC9uzZAxMTE9GRiPTesGHDcOzYMcTHx8PPzw/V1dWiI5GKPD5msKSkBKdOnUKXLl1ERyLSe5aWloiOjoa9vT1GjhyJrKws0ZFUSmcuzvr1118xevRojB49Gnv27IGRkV6c9EUkGWfOnIGnpyc8PT0RHBzM/0YlrqioCKNGjcLdu3dx6tQp2Nraio5ERP+htLQUXl5euHbtGk6dOgU7OzvRkVRBN04VSE1Nrd3TGh4ezpVWIi0VHx+PMWPGYOLEidi6dStPG5Co8vJyeHt74/fff0dsbCy6desmOhIRPcOjR48wYsQIPHr0CKdOncJrr70mOtKrkv6pApcuXcKYMWPQt29f7N+/n6WVSIu5u7tj//79CA4Oxp/+9CfRcagBqqqqMGnSJGRmZiImJoallUiLWVhYIDIyEo0aNcLw4cNx79490ZFemaSL65UrVzBixAh06tQJ+/fv5+0EiSTA09MTe/bswfr167Fo0SLRcageFAoFpk2bhvj4eERERKBnz56iIxHRS9jY2ODo0aOQy+UYM2YMCgsLRUd6JZItrrdv38bIkSNrby5gZmYmOhIR1dEbb7yBLVu2YM2aNVi5cqXoOFQHSqUS06dPR0REBI4cOYJ+/fqJjkREddS2bVtER0cjPz8f48aNQ3l5uehIDSbJ4lpcXIxx48bB1NQUkZGRMDc3Fx2JiOrpnXfewffff49PP/0Uu3btEh2HXmLp0qXYu3cvwsLC4ObmJjoOEdWTnZ0djh07hkuXLmHatGmoqakRHalBJFdcH79Vdfv2bYSHh/OOWEQS9sEHH2Dx4sWYNWsWYmJiRMeh59i8eTO++uorbNiwASNHjhQdh4gaqFu3bggLC8ORI0fwl7/8RXScBpHceTQBAQE4duwYYmJiYG9vLzoOEb2ir776Crdv34afnx8SEhLg4OAgOhL9h6ioKLz33ntYtmwZ3n33XdFxiOgVeXh4YPv27ZgyZQo6duyIDz/8UHSkepHUcVirVq3C3/72N+zduxdvvvmm6DhEpCLl5eUYNWoUcnNzkZiYiFatWomORAAyMzPh7u4Ob29v7N69GzKZTHQkIlKRf/zjH1i2bBl++eUXjB8/XnScupLOOa6hoaGYMmUKVq9ejYCAANFxiEjF8vLy4ObmBgsLC5w8eRKmpqaiI+m1O3fuYNCgQbCzs8PRo0fRqFEj0ZGISMUWLFiAwMBAxMTEYODAgaLj1IU0iuuvv/6K4cOHY+7cufj+++9FxyEiNbl06RLc3NwwYsQIhISEcIVPkNLSUnh4eKCyshLx8fFo0aKF6EhEpAbV1dUYO3YsMjIycPbsWbRr1050pJfR/uJ67949uLi4wMnJCQcPHoShoaHoSESkRidPnoSnpydWrFiBTz75RHQcvTR16lRERUXht99+05XbRBLRcxQVFWHgwIFo3rw5YmNjtf1GTtp95yy5XI7JkyfD2NgYO3bsYGkl0gPDhg2r3c8eFRUlOo7e+e6777Bnzx7s3LmTpZVID5ibmyMsLAwXLlzARx99JDrOS2l1cf3LX/6CM2fO4JdffoGVlZXoOESkIYsWLcLUqVPx9ttvIycnR3QcvZGQkIBPPvkEK1asgJeXl+g4RKQhDg4OCAwMxLp167BlyxbRcV5Ia7cK7NmzB2+99Ra2bt2KGTNmiI5DRBpWWlqKQYMGwcjICAkJCWjSpInoSDrt7t27cHFxQb9+/RAWFsb9xUR66JNPPsH333+PuLg4uLi4iI7zLNq5x/XixYsYMGAAZs6ciTVr1oiOQ0SCZGdnY8CAAfD19UVgYKDoODqruroaI0eOxL1793D27FlYWFiIjkREAtTU1MDHxwcXL17EuXPnYG1tLTrSf9O+4lpUVIT+/fujZcuWiImJgbGxsehIRCRQeHg43nzzTWzcuBGzZ88WHUcnffjhh9i2bRvOnDmDHj16iI5DRAI9ePAALi4u6NmzJw4fPgwDA63aVap9F2ctXLgQDx8+REhICEsrEWH8+PH45JNP8Kc//QkXL14UHUfnHDhwAGvXrsWmTZtYWokINjY22Lt3L44fP45vv/1WdJynaNWK6969e+Hv74/w8HD4+vqKjkNEWkIul2Pw4MGoqqpCYmKith/XIhn379+Hk5MTfHx8tP6CDCLSrJUrV+Kzzz5DYmIi+vTpIzrOY9qzVeDWrVtwdnbG22+/jR9++EF0HCLSMleuXEGfPn2wYMECrFq1SnQcyVMqlfD19cXvv/+OlJQUmJubi45ERFqkpqYGnp6eyM3Nxblz59C0aVPRkQBt2SpQU1OD6dOno3Xr1vjqq69ExyEiLdS5c2d8++23+Prrr3H8+HHRcSTv+++/R1RUFHbu3MnSSkRPMTAwwPbt23Hv3j38+c9/Fh2nllYU1y+//BIJCQnYtWsXj7whoueaPXs2/Pz88O677yI/P190HMnKzMzE0qVLsWzZMri6uoqOQ0Raql27dtiwYQN+/vlnHDhwQHQcAFqwxzUpKQlubm748ssv8fHHH4uMQkQS8PDhQzg7O8PFxQX79u0THUdyKisrMXDgQJiZmSE2NpZ3JCSil5oxYwaOHDmC1NRUtGnTRmQUsXtcKysr0adPH7Rr1w5RUVE88JqI6uTEiRMYNWoUAgMDMXXqVNFxJOWvf/0r1q1bh/Pnz8PW1lZ0HCKSgOLiYvTp0wc9e/ZEeHi4yChi97iuWLECN27cwPr161laiajOhg8fjvfeew8BAQG4f/++6DiSkZqaitWrV+Orr75iaSWiOmvWrBk2b96MgwcPIjQ0VGgWYSuu6enp6NevH77++mt8+OGHIiIQkYQVFRWhV69eGDp0KHbs2CE6jtaTy+UYNGgQTE1NcfLkSS4WEFG9zZ07F4cOHUJmZiYsLS1FRBCzVaCmpgaDBw+GQqFAfHw891gRUYMcOXIEY8eOxYEDB3j280usWrUKy5YtQ0pKCrp37y46DhFJ0KNHj9CzZ0+MGTMGmzdvFhFBzFaBNWvW4Ny5c9i8eTNLKxE1mI+PD/z9/bFw4UKUlJSIjqO1srOz8dlnn2HZsmUsrUTUYBYWFvjuu++wdetWHDt2TEgGja+4Xr9+Hb169cLixYuxfPlyTQ5NRDooLy8P3bt3x7Rp07Ty9oSiKZVKjB49Gvfv38e5c+d4K20iemUTJkxASkoKMjIyYGpqqsmhNb/iOn/+fHTo0AFLly7V9NBEpIOsra3x1Vdf4YcffsCZM2dEx9E6mzdvxokTJ7B582aWViJSibVr16KwsBCfffaZxsfW6Irr/v37MXHiRJw6dQoeHh6aGpaIdJxSqcTIkSNRUlKCX3/9FQYGWnFvFeEePnyILl26cDWaiFTu559/RkBAANLT0+Hg4KCpYTV3cVZVVRV69eqFAQMGYOfOnZoYkoj0yIULF+Ds7IxNmzbh3XffFR1HK3z88cfYtWsXsrKy0Lx5c9FxiEiHKBQKuLi4oG3btjh8+LCmhtXcVoHVq1fj1q1b+OKLLzQ1JBHpkR49emDu3Ln45JNPUFRUJDqOcBcvXsSPP/6IFStWsLQSkcoZGhri22+/xZEjRxAREaGxcTWy4nrv3j107doVixcvxv/93/+pezgi0lMFBQXo2rUr5s+fj3/84x+i4wjl4+ODGzdu4Pz58zAyMhIdh4h01MSJE3HhwgWkpaVpYh+9ZlZcly5dCnNzcyxevFgTwxGRnrK0tMT//M//4Ouvv8bly5dFxxEmOjoaERER+Pbbb1laiUitvv76a1y7dg0//fSTRsZT+4prSkoK+vXrh127dmHKlCnqHIqICHK5HL1790a3bt2wd+9e0XE07vHv7+DggF9++UV0HCLSA3/729+wbt06ZGVlwdraWp1Dqf/irKFDh0KhUOD06dO8xSARaURERAR8fHxw8uRJDB06VHQcjVq7di2WLFmCCxcuoFOnTqLjEJEeKC4uhoODAyZMmIC1a9eqcyj1FtfIyEh4e3sjMTERgwYNUtcwRERPGT16NMrKyhAXFyc6isaUlZWhc+fOmDp1Kr7++mvRcYhIj2zatAkffPABLl26BFtbW3UNo97iOmjQINjY2ODgwYPqGoKI6JnOnTuHAQMGICIiAmPGjBEdRyO++uor/P3vf8fVq1fRsmVL0XGISI8oFAr06NEDHh4e2Lx5s7qGUV9xDQ8Px5tvvokzZ86gf//+6hiCiOiFxo0bh7t37+K3337T+a1KJSUl6Ny5M+bMmaP3JyoQkRiBgYGYNWsWMjMz1XVTAvUUV6VSib59+6JTp068OICIhElOTka/fv0QHh4OX19f0XHU6vPPP8c333yDq1evwtLSUnQcItJDCoUCjo6OcHFxwY4dO9QxhHqKa2hoKKZMmYLk5GQ4Ozur+umJiOpswoQJuHz5Ms6fP6+zt4J99OgR7OzsEBAQgGXLlomOQ0R6bM+ePZg2bRrS09PRvXt3VT+96otrTU0NevfujV69emH37t2qfGoionrLzMyEk5MTQkJCMHHiRNFx1OJ///d/sXbtWuTk5PAuWUQkVE1NDfr27QsHBwcEBwer+ulVX1x3796N6dOnq3N/AxFRvUyZMgUZGRlIS0vTuVXX/Px82NnZYenSpVi6dKnoOERE2LdvH/z8/JCSkgInJydVPrXqi2vv3r3Rs2dP7Nq1S5VPS0TUYJmZmXB0dNTJva4rVqzA6tWrcePGDZiZmYmOQ0QEpVIJZ2dnODs7q3qvq2qL69GjRzFmzBgkJyejT58+qnpaIqJXNm7cOBQXFyM2NlZ0FJWprKyEra0tZs2axZMEiEirbN++HXPnzsXly5fRoUMHVT3tBZW+Z/bNN99g5MiRLK1EpHUWL16MU6dO4cyZM6KjqMyOHTtQWFiIhQsXio5CRPSEt99+G61bt8YPP/yg0udV2YprRkYGnJyccPjwYXh7e6viKYmIVGrgwIGws7PDnj17REd5ZUqlEr169cLAgQOxZcsW0XGIiJ6yatUqfPHFF7hx4wYsLCxU8ZSqW3H95ptv4ODgoDd3qCEi6fnoo4+wd+9eXLlyRXSUV3bkyBFcuHABAQEBoqMQET3TggULIJPJsGnTJpU9p0pWXO/duwdbW1v8+OOPmDVrlipyERGpnEKhQNeuXeHr64vvvvtOdJxXMmLECDRq1AgRERGioxARPdeiRYsQGhqKq1evwtjY+FWfTjUrrt9//z2aN2+OqVOnquLpiIjUwtDQEAsXLsTmzZtRWFgoOk6DpaSk4MSJE1i0aJHoKERELxQQEIC7d+8iNDRUJc/3ysW1qqoKGzduxIIFC9CoUSNVZCIiUps5c+bAwMAAgYGBoqM02I8//ghHR0d4enqKjkJE9EIdO3bEhAkT8OOPP6rk+V65uIaFhaGgoAAzZ85URR4iIrVq1qwZpkyZgvXr14uO0iAlJSUICQnBvHnzREchIqqTefPmISEhAZmZma/8XK9cXDdu3AgfHx+0b9/+lcMQEWnCnDlz8PvvvyMxMVF0lHrbvXs35HI5t2YRkWSMGDEC9vb2KrlI65WKa05ODmJiYjB37txXDkJEpCn9+/dHnz59sHHjRtFR6m3jxo2YNGkSWrRoIToKEVGdyGQyzJw5Ezt27EBFRcUrPdcrFdeNGzeiVatWPLeViCRn9uzZ2LNnDx4+fCg6Sp2lpaXh3LlzXCwgIsmZNWsWioqKsH///ld6ngYXV7lcju3bt2P27NkwMjJ6pRBERJo2bdo0yGQyBAcHi45SZ+vWrYODgwM8PDxERyEiqpfWrVvDx8fnlbcLNLi4Hjp0CLm5uZgxY8YrBSAiEsHCwgKTJk2SzHaB8vJyBAUFYe7cuZDJZKLjEBHV29y5c3HixAlkZ2c3+DkaXFy3bNkCT09PdO7cucGDExGJNHfuXCQlJSE1NVV0lJfau3cvysrKMH36dNFRiIgaxMvLC23btsW2bdsa/BwNKq4PHz7E0aNHMW3atAYPTEQkmru7O2xtbSWxXWDPnj3w8vKCjY2N6ChERA1iaGiIt956C3v27EFDb9zaoOL6eGPt66+/3qBBiYi0gUwmg5+fH4KDgxs8iWpCYWEhoqOj4e/vLzoKEdEr8ff3x9WrV5GcnNygn29QcQ0JCYG3tzcsLCwaNCgRkbZ4PIkmJSWJjvJc+/btg4GBAXx9fUVHISJ6Jf369YO9vX2D3+mqd3EtLCxETEwM/Pz8GjQgEZE2eTyJhoSEiI7yXI8XC8zNzUVHISJ6ZZMmTWrwdoF6F9e9e/fCwMAA48aNq/dgRETayM/P75X2XKlTXl4eYmJiuE2AiHTG5MmTcfPmTZw9e7beP1vv4hoSEoKxY8fylT8R6Qx/f3/cvHkTZ86cER3lKfv27YOJiQkXC4hIZ/Tu3RvdunVr0HaBehXXvLw8nDx5kq/8iUin9O7dG927d9fK7QIhISHw8fGBmZmZ6ChERCozadIkhIaGoqampl4/V6/ieujQIRgZGWHs2LH1GoSISNu9+eabCA8PFx3jCQ8fPkRsbCwmTpwoOgoRkUpNmjQJt27dqvfpAvUqrhERERgyZAhMTU3rNQgRkbbz9vbG1atXkZWVJTpKrejoaCiVSnh6eoqOQkSkUk5OTmjbti0iIyPr9XN1Lq4KhQLR0dHw9vaudzgiIm3n6uoKS0tLREREiI5SKyIiAgMHDoSVlZXoKEREKiWTyTBmzBj1Fddff/0VBQUFLK5EpJMMDQ0xYsSIek+i6qJUKhEVFcU5l4h0lpeXV22/rKs6F9fIyEjY2trCwcGhQeGIiLSdt7c3Tp48ibKyMtFRkJ6ejtu3b8PLy0t0FCIitfD09IRMJkN0dHSdf6bOxTUiIoKv/IlIp3l7e6OyshKnTp0SHQURERGwsbFB3759RUchIlKL5s2bY9CgQfV6p6tOxfXBgwdISUlhcSUindamTRs4OjpqxXaByMhIeHl5wcCgQXfmJiKSBC8vL0RERNT5BjB1mhGjoqJgbGyM4cOHv1I4IiJt5+3tLfwCreLiYsTHx3ObABHpPG9vb9y9exdpaWl1enydimtsbCwGDBjAA7CJSOeNHDkSWVlZyM3NFZYhMTER1dXVGDFihLAMRESa0KdPH1haWiI2NrZOj69TcY2Li4OHh8crBSMikgJXV1cYGRkhISFBWIa4uDjY29ujdevWwjIQEWmCTCaDq6sr4uPj6/T4lxbXgoICXLp0Ce7u7q8cjohI25mZmcHR0bHOk6g6xMfHc84lIr3h7u6OuLi4Oj32pcX18eTt6ur6aqmIiCTC3d1dWHFVKBQ4e/YsiysR6Q0PDw/cuXMH169ff+ljX1pcExIS0L17d1haWqokHBGRtnN3d0dKSoqQ81xTU1NRUlLC4kpEeqNfv34wMTGp06prnVZcOYESkT4ZPHgwqqurcfbsWY2PHR8fj+bNm6Nbt24aH5uISIQmTZqgb9++dXqn64XFtbq6GklJSXBzc1NZOCIibde2bVu0b99eyHaB+Ph4uLm58fxWItIrdd2i9cKZMTk5GWVlZSyuRKR33N3dhZwskJiYyDmXiPSOu7s7MjIyUFRU9MLHvbS4WlhYoEuXLioNR0Sk7VxcXJCSkqLRMfPz83Hjxg30799fo+MSEYnm4uKCmpqal96I4IXFNT09HY6OjpDJZCoNR0Sk7ZycnJCbm4sHDx5obMzHE7ajo6PGxiQi0gYdOnRA8+bNX724Ojk5qTQYEZEUPC6PGRkZGhszLS0N1tbWaNOmjcbGJCLSFo6OjkhPT3/hY55bXJVKJTIyMvjKn4j0Ups2bWBjY1Pn+2erAhcLiEifvVJxvX79Oh4+fMjiSkR6qy6TqCqlpaWxuBKR3nJ0dERaWhqUSuVzH/Pc4pqWlgaZTMbiSkR66/EkqgkKhQKZmZmcc4lIbzk5OaG4uPiFd9B6YXG1tbWFubm5WsIREWG/e8cAACAASURBVGk7R0dHZGRkQKFQqH2sy5cvo6ysjCuuRKS3Hh8I8KIFg+cW14yMDPTq1UstwYiIpMDJyQnl5eW4evWq2sfKyMiAoaEhevToofaxiIi0UbNmzWBra/vCLVrPLa6XL1+Gg4ODWoIREUlB165dAfwxH6pbdnY22rVrh6ZNm6p9LCIibdWlSxdcuXLlud9/bnHNycmBra2tOjIREUmChYUFWrRogWvXrql9rGvXrsHOzk7t4xARaTM7Ozvk5OQ89/vPLK7FxcUoKCjgJEpEeu9lk6iqXLt2jYsFRKT3bG1t619cH/8AJ1Ei0ne2trYaW3HlnEtE+s7Ozg63bt1CdXX1M7//zOL6eJLu2LGj2oIREUmBJlZclUolrl+/zuJKRHrPzs4OCoUCt27deub3n7vi2rJlS5iamqo1HBGRtnvZ21aqkJubi4qKCm7PIiK99/gF/PPm3eeuuHICJSL649V/fn4+iouL1TbG43e5uOJKRPquZcuWMDMzq39x5QRKRITaF/HqXHW9du0ajI2N0bZtW7WNQUQkFS96p+uZxTU3N5cTKBERUDsX5ubmqm2M3NxctG7dGoaGhmobg4hIKtq2bfvcOfeZxTUvLw/W1tZqDUVEJAUWFhYwMTFBXl6e2sbgnEtE9G9WVlbIz89/5veeW1ytrKzUGoqISCosLS2fO4mqAosrEdG/WVtbP3ex4KniKpfLUVRUxEmUiOhfXvTqXxXy8/O5WEBE9C/1WnHNz8+HUqnkJEpE9C/W1tZqL65cLCAi+kO9iysATqJERP9iZWWl9j2uXCwgIvqDtbU1CgoKUFNT89T3nltcOYkSEf1BEyuunHOJiP5gZWUFhUKBR48ePfW9p4rr41UFS0tL9ScjIpIAde5xVSqVKCgo4LtcRET/8ng+fNY7XU8V10ePHsHU1BQmJibqTybIpk2bIJPJEBkZ2eDnWL16NaysrGBiYoIjR46oMJ1u8vLygpmZmegYwr3qv3tS+Tuq4r8xbdKiRQs8fPhQLc9dVlaG6upqNG/eXC3Prw0452qeVOYKdeOcK02P58NnzbtPFdfKyko0btxY/akkLCcnB0uWLIGnpycePnyI0aNHi45ERGpkYmKCyspKtTz34+dt1KiRWp5fF3DOJdIvj+fDqqqqp75n9N9fqKys1OnVVlXIzMyEUqnE2LFj0bRpU9FxiEjNGjVqpPbiynn3+TjnEumXx8X1WfPuUyuuVVVVnEBfoqKiAgBgbGwsOAkRaYI6i+vjFQWuuD4f51wi/VKv4lpZWalTE+iaNWvQuXNnmJiYoEOHDli6dOkzl54B4Pz583jjjTdgZWWFRo0aoVOnTliyZMkTV7WNGjUKfn5+AIC33noLMpkMYWFhAID4+Hh4e3ujRYsWMDExQceOHbFw4cKnLurw8vJCly5dkJqaCicnJzRu3BgKhQI+Pj6wt7dHWloahg8fDjMzM7Ro0QLvvPMOiouLERwcjN69e6Np06bo1KkTvv/++wb/XYYMGYIOHTogJSUFw4YNg5mZGUxNTTFy5EikpqbWKW99fmcAMDQ0RGpqKjw9PWFubo6mTZti+PDhSElJeeJxqvg7xMTEYNSoUbXjdO/eHV988cVT/xHU5+9QX6r+d+956vK7Dh06FKampigqKnrq51euXAmZTIajR482KM//s3ffYVFcbRvA7210QVHEioiNoKDYpVjBiho12I2agiYmaIx5SRWT+BoSSzAmKolGsUTFbmJAiaIiKIqRakdRBCwgCCJ19/n+8INXBJSFXWaXfX7XxRWzOzvnngUOz545c0aZ49RWenp6ajum+jbiyn1u5bjPVf59UBb3ufVHaX9Y6YABvWDx4sXUpUuXFx/WSuvXrycA5OPjQ/fv36fU1FT66quvqFWrVgSAgoODy7Y9f/48GRoa0ujRo+nKlSuUm5tLf/75JzVt2pR69+5NxcXFZdvu3r2bANCOHTvKHjt27BhJpVKaOHEiXb16lXJzcyksLIxatGhB9vb2lJ+fX7btmDFjqHnz5uTq6kpffvklrVu3jhQKBY0dO5bMzMzI2dmZzp49S7m5ufTDDz8QABowYAANGzaMbt68SVlZWTR9+nQCQGfPnq3Re+Pm5kYGBgbUtWtXCgsLo7y8PIqLiyMrKytq3LgxPXz48JV5lTnmYcOGkaGhITk4OFBoaCjl5ORQdHQ02dnZUaNGjcq1V9v3ITw8vCxXamoqPXnyhLZt20YikYjmz59f4/dBGer62Rs2bBgZGxsrfazbtm0jALR+/foKWR0cHMjKyorkcrnSeZQ5Tm1W+juvUChUvu/4+HgCQJcuXVL5vusa97lV4z5X+fdBGdzn1q8+l4hILBbTrl27Xnw4sULh+umnn1L37t3rJpWatWvXjqytrct+OEr16dOnwjfY1dWVWrZsSQUFBeW23bhxIwGg7du3lz1WWSfas2dPsrCwKNdxEBFt2bKFANCmTZvKHhs7dixJpVJasWJFuW3Hjh1LAOivv/4qe6y4uJhMTExIJpNRWlpa2eOlf+yWLVumxDvyP8OGDatwXEREO3fuJADlslWVV5ljLm1v69at5bY9cOAAAaCVK1eWa68278OiRYvIxMSEbt++Xa6tgQMHkpmZWY3fB2Wo62fvxU60usdaUFBAjRs3pt69e5fb7vLlywSAfH19a5RHmePUZgcPHiQAFd4TVYiOjiYAlJSUpPJ91zXuc6vGfa7y74MyuM+tX30uEZGBgQFt2bLlxYcT6+1UgQcPHiApKQlOTk4Qi8sf5otXpObk5CAiIgKDBg2qcOzDhw8HAERFRVXZVlZWFqKjozFw4MAKKzK4ubkBAMLCwso9XlJSgkmTJlW6PxcXl7J/S6VSmJubw9raGs2bNy973NLSEgBw7969KnNVx7Bhw8r9/6BBgwAAcXFxL81bk2MGgBEjRpT7fycnJwDAuXPnKmxb0/dh+fLlyM3NhZWVVbn9tW3bFo8fP0ZWVlaFtqr7PlRHXf7sVfdY9fX18eabb+LcuXNISEgo227Hjh0QiUSYPXu20nmUOU5t97L5VrVVeopP26cKcJ9bPdznPsN9Lve5r1LVai6VXpxVHybAl/5SWVhYVHju+V9CAEhLS4NCocC2bdsgEonKfbVs2RIAkJKSUmVbqample4X+N8veek2pUQiUaXbSyQSmJmZVdj2xRtCiEQiACib91QTMpmswt16Stu5f//+S/PW5Jj19PQqtFe6yPDDhw/LPV6b96GgoACrVq2Cs7MzmjdvDn19fUilUmzatKnCtoBy70N11OXPnjLH6uXlBQD4/fffyx7btWsX3Nzc0KZNG6XzKHOc2u6l861qqbRw1fZ+l/vcV+M+9xnuc7nPrY6qLoqtULhKJJJa/WJqmtJfsudVdu9bAHjnnXdARJV+7du375VtEVGVj72YQywWQyKRVOcQ1ObFT2zA//K++FxVeZU55sq+F9V5TlmTJk3CokWLMHToUJw+fRqPHj1CQUEB3nrrrUq3V+Z9UEZd/Owpc6y2trbo378/tm3bhpKSEly8eBFXr16tdFtl8ihznNqqtE+USiusIFhrpb9X9eU94z63atznPsN9Lve51VFSUlJpn1vhEX19/XpxdVrpJ5LKrrR88dNUq1atIBaLcfv27Rq11bp1a4hEIqSlpVV4Lj09vWwbTVNYWIjHjx+X+5Rd+n6VfoKvSk2OubL2Sm/n9qr2qistLQ2HDh3C5MmT4evrW+65qr6/tXkfKlNXP3s1OdY5c+Zg2rRpCA0NxfHjx2Fubo5x48bVKI8yx6nt1HmTAHWO5tYl7nNfjfvcqnNxn8t97ouqmrpa4aONOpd9qUvNmzdHq1atEBkZWeET6pEjR8r9v4mJCVxdXXHixIkK85fCw8NhZ2eH6OjoKtsyMzNDv379cOLECeTn51fa1ovzeTRFaGhouf8vnSM1YMCAl76upsf8/PIfAHD69GkA/5t3VVulf/xfvO/75cuXcfLkSQCVj1jU9H2oTF397NXkWCdMmIDGjRtj27Zt+OOPPzBt2rRyHYMyeZQ5Tm2nzsL1ZXeI0Sbc51YP97nPcJ+rfB5d6nOBZ31ipX3ui5drffPNN2Rra6vMhV8aq3Q5j0WLFtGDBw8oJSWFPvnkE7Kysqpw9d3Zs2fJwMCAevToQZcvX6b8/HwKCwsja2tr6tatW7mrOCu7wvX06dOkp6dHkyZNops3b1Jubi6FhoZSs2bNyNnZudxyFmPHjiWJRFIhb1WPt2nThvr06VPusYcPHxIAmjdvXo3em+eXSjl69Cjl5eVRbGwstW7dmpo1a0Z5eXmvzKXMMZcugdK9e3c6ceIE5ebmUlRUFLVt25aaNWtG2dnZKnkf5HI52djYUMuWLSk+Pp7y8/Pp8OHDZGtrS1OmTCEAdPjwYSopKVH6fVCGun72nr/CVdljLbVw4UISi8UEgGJiYipkVyaPMsepzXbs2FHpz6QqlF5lHB8fr5b91yXuc6vGfS73udznVp9cLicAtHfv3hefqrgclp+fH9nY2NRNMjVTKBT07bffkpWVFUmlUmrZsiUtWrSobNmNgwcPltv+woULNHbsWDI3NyepVEqtWrWijz/+mDIzM8ttV1knSkR05swZGjp0KJmZmZFMJqN27dqRj48PPXnypNx2mtKJmpmZ0YULF2jQoEFkYmJCRkZG5ObmVmE9yapyEVX/mF1dXal169Z08eJFGjx4MJmYmJChoSG5ublRQkJCtdqr7vsQExNDAwYMIBMTE2rYsCGNGDGCYmNjKSkpiWxtbUkqldIXX3yh9PugDHX97L24NIsyx1rqypUrBOCly95VN4+yx6mtNm/eTEZGRmrZd1JSEgGg6Ohotey/LnGfWzXuc7nP5T63+p4+fUoA6M8//3zxqYqF648//kitWrWqm2RMMMOGDSMTExOhYwhOF9+H0nUYN2zYIHQUrfHrr79Sw4YN1bLvu3fvEgCKjIxUy/6ZZtDFvqYyuvg+cJ+rvOzsbAJAR48effGpiuu4VrVuFqt/qJJ5R7pI196H5cuXo1mzZpg2bZrQUbSGOte3Lr04S9vnuLJX07W+piq69j5wn6u8l11XUG9XFWCM/Y9cLkdhYSECAgKwZcsWBAUFVVjEnFVNnYWrOm9uwBgTBve5tfOywrXCiKuJiQny8vJ07hORNgsJCamwcHFVX3379hU6rtapD+/vrl270KBBA6xatQpbt26Fp6en0JG0Sl5eHoyNjdWybyMjI4hEIjx58kQt+2eqVx/6BE1WH95f7nNrp7Q/NDIyqvCciF6oUP/55x+4u7vj0aNHaNSoUd0kZIwxDebt7Y2YmBicOnVKLftv1KgRvv/++7I77TDGmC4LDw9H//79kZ6ejmbNmj3/1KUKI66lt2GrbIFbxhjTRRkZGRXWblSlJk2acJ/LGGP/r7Q/fPGWw0AlUwVKO+fSu2swxpiuy8zMrHBvdVVq3LgxF66MMfb/MjIyYGpqWnbx6vN4xJUxxl4hIyND7YUrDxYwxtgzLxssqFC4GhkZwdDQkDtRxhj7f+oeceWpAowx9j+ZmZlVTs+qULgCfNqKMcaep+45rjziyhhj//Oys1xcuDLG2EsUFBQgLy+P57gyxlgdUWqqAAA0bdoU9+/fV2soxhjTBg8ePAAAtY64WlhYcJ/LGGP/78GDB7CwsKj0uUoLVysrK9y+fVutoRhjTBskJycDAKytrdXWRps2bZCTk4OsrCy1tcEYY9ri1q1baNOmTaXPVVq4Wltb49atW2oNxRhj2uDWrVswMDB4cRFslSotikuLZMYY01X5+fl48OAB2rZtW+nzlRaubdu2xZ07dyCXy9UajjHGNF1ycjLatGkDsbjS7lIlSvfPAwaMMV2XnJwMIlKucLW2tkZxcTHS0tLUGo4xxjTdrVu3quxAVaV0RJdHXBljuq70A7xSUwVKO2n+9M8Y03W3bt1S6/zWUtbW1ly4MsZ03q1bt2Bubg4zM7NKn6+0cG3evDkMDAy4E2WM6bzk5GS1j7gCzwYMeLCAMabrXtXnVlq4ikQiWFlZcSfKGNNpxcXFSE1N5RFXxhirI6+anlXl1QY2Nja4efOmWkIxxpg2SE5Ohlwur5MRVxsbG9y6dQsKhULtbTHGmKa6efNmzQrXzp07Iz4+Xi2hGGNMG8THx0MsFuO1115Te1t2dnbIy8vjM12MMZ1VUlKCy5cvo3PnzlVuU2Xham9vj0uXLqGkpEQt4RhjTNPFx8fDxsYGJiYmam/L3t4eYrEYcXFxam+LMcY00fXr11FQUAAHB4cqt6mycHVwcEBhYSGuXbumlnCMMabp4uPjX9qBqpKxsTFsbGy4cGWM6ay4uDhIpdKXnuWqsnC1s7ODTCbj6QKMMZ0VFxcHe3v7OmvPwcGB+1zGmM6Kj49Hx44dYWBgUOU2VRau+vr66NixI3eijDGdlJ+fj5s3b9bZiCvwbLoA97mMMV0VHx//ysGCl97D0N7enk9bMcZ0UkJCAuRyeZ2PuN64cQN5eXl11iZjjGmK6pzl4sKVMcYqERcXByMjI7Rr167O2rS3t4dCocClS5fqrE3GGNMEubm5uH379ivPcr20cO3atSvu3LmDrKwslYZjjDFNFxcXh86dO0Msfmk3qVLt2rWDiYkJYmJi6qxNxhjTBHFxcSCi2o249unTBwBw9uxZ1SVjjDEtEBERgX79+tVpm2KxGL169cKZM2fqtF3GGBNaREQELC0tX3mnwpcWrk2aNEHHjh0RERGhymyMMabR8vLyEBsbC2dn5zpv29nZmftcxpjOiYiIgIuLyyu3e+U5MO5EGWO6JioqCiUlJXBycqrztp2dnXH9+nU8ePCgzttmjDEhEBHOnDlTrcGCahWuUVFRKCoqUkk4xhjTdBEREbC2tkarVq3qvG0nJyeIxWKeLsAY0xnXrl3Dw4cPVTfimp+fj9jYWJWEY4wxTRcRESHINAEAMDU1hZ2dHZ/pYozpjNOnT8PQ0BBdu3Z95bavLFw7duwICwsL7kQZYzpBoVDg7NmzghWuAE/RYozploiICPTp0wd6enqv3PaVhatIJEK/fv24E2WM6YT4+Hg8fvxY8ML1woULKCgoECwDY4zVlepemAVUo3AFABcXF4SHh4OIahWMMcY0XXh4OMzMzNC5c2fBMjg7O6OwsBBRUVGCZWCMsbpw7949XL9+vdoXw1arcHV3d8f9+/d5UWzGWL0XHBwMNzc3SCQSwTK0bdsW7du3x5EjRwTLwBhjdeHIkSPQ09ODq6trtbavVuHatWtXtGjRAsHBwbUKxxhjmqywsBAnT57E8OHDhY6CESNGcJ/LGKv3QkJCMGDAAJiYmFRr+2oVriKRCEOHDkVISEitwjHGmCY7efIk8vLyMHToUKGjYPjw4YiNjUVaWprQURhjTC3kcjlCQ0OVGiyo9k24R4wYgcjISDx69KhG4RhjTNOFhITA3t4eVlZWQkfBoEGDYGBggKNHjwodhTHG1OLcuXPIzMxUT+Hq7u4OkUiE48eP1ygcY4xpuuDgYI2YJgAAhoaG6N+/P08XYIzVWyEhIWjdujVee+21ar+m2oVro0aN0Lt3b+5EGWP1UnJyMq5cuaIxhSvwbLpAaGgoSkpKhI7CGGMqFxwcjFGjRin1mmoXrsCzTjQ4OJiXxWKM1TvBwcEwNjYWdP3WFw0fPhxZWVm8LBZjrN7JyMjAhQsXMGzYMKVep1Th6uHhgfT0dJw/f16pRhhjTNMdOnQI7u7u0NfXFzpKGVtbW7Rv3x4HDx4UOgpjjKnUoUOHoKenhyFDhij1OqUKV0dHR3To0AFBQUFKNcIYY5osIyMDx44dw8SJE4WOUoGnpyd27tzJZ7oYY/XKrl27MGLECDRo0ECp1ylVuALPOtGgoCDuRBlj9ca+ffsgk8kwevRooaNUMHHiRKSkpPB0AcZYvZGRkYHjx4/XaLBA6cK1tBM9e/as0o0xxpgmCgoKwsiRI6u9AHZd6tatG2xtbflMF2Os3ti3bx/09PTg4eGh9GuVLly7du2K1157jTtRxli98PDhQ5w8eRKTJk0SOkqV3njjDezevRsKhULoKIwxVmu7du3CqFGjajRYoHThCjybLrBr1y7uRBljWm/37t3Q09PDiBEjhI5SpUmTJuHu3bs4c+aM0FEYY6xWHj58iFOnTtX4moIaFa5TpkxBeno6IiIiatQoY4xpiqCgIIwZMwbGxsZCR6lSly5dYGdnx2e6GGNab/fu3dDX16/xYEGNCldbW1t07twZu3btqlGjjDGmCdLS0nD69GmNXE3gRRMnTsSePXsgl8uFjsIYYzW2a9cujB49usaDBTUqXAFgxowZ2L59O54+fVrTXTDGmKA2b96Mhg0bavQ0gVIzZszAvXv3EBISInQUxhirkaSkJISHh2PGjBk13keNC9dZs2YhLy8P+/fvr3HjjDEmFCLCpk2bMGPGDBgYGAgd55VsbGwwcOBA/Pbbb0JHYYyxGvn111/RsmVLpe+W9bwaF66WlpYYPXo0d6KMMa107Ngx3LhxA++8847QUart3XffxeHDh5GWliZ0FMYYU0pJSQm2bt2Kt99+GxKJpMb7qXHhCjzrRE+ePInLly/XZjeMMVbnNmzYACcnJ3Tu3FnoKNU2fvx4NGrUCJs3bxY6CmOMKeXgwYO4f/8+Zs+eXav91KpwHTp0KNq0aYNNmzbVKgRjjNWlzMxMHDhwQKtGWwFAT08P06dPx4YNG3g5QsaYVtmwYQOGDRuGNm3a1Go/tSpcxWIx3nrrLWzatAmFhYW1CsIYY3UlMDAQenp68PT0FDqK0ry8vJCcnIxjx44JHYUxxqolJSUFoaGhKhksqFXhCgBvvfUWsrKycOjQoVqHYYyxurBx40ZMmzZNI2/x+iq2trZwcnLi6wsYY1pj48aNaNKkCUaPHl3rfdW6cG3VqhVGjhyJNWvW1DoMY4yp2z///INLly7By8tL6Cg1NmfOHBw4cAApKSlCR2GMsZcqLCzEr7/+itmzZ0Mmk9V6f7UuXAFg4cKFCA8Px9mzZ1WxO8YYU5sVK1Zg8ODBcHR0FDpKjU2ePBnNmjXDTz/9JHQUxhh7qW3btiEjIwPz5s1Tyf5ERESq2FGfPn1gbW3Nd9NijGmshIQEODg44K+//sLIkSOFjlMr33//PZYtW4Y7d+7AzMxM6DiMMVYBEcHe3h69evVS1YX8l1Qy4goACxYswN69e5GUlKSqXTLGmEqtWLECnTp1wvDhw4WOUmvvvfcegGdzxxhjTBP9/fffSExMxIIFC1S2T5WNuMrlcnTo0AFjxoyBv7+/KnbJGGMqk5aWhrZt22LdunV46623hI6jEqUDBjdv3lTJ3DHGGFOlwYMHQ19fH8HBwarapepGXCUSCT744ANs2LABmZmZqtotY4ypxE8//YRGjRph6tSpQkdRmQULFuDevXvYvXu30FEYY6ycCxcuICwsDB9//LFK96uywhV4dictmUzGy7QwxjRKbm4uAgIC4O3tDQMDA6HjqIy1tTXGjx+PH374QegojDFWzsqVK+Hg4IAhQ4aodL8qLVwbNGiAd999F6tXr8bTp09VuWvGGKux9evXo6SkBHPnzhU6isotWrQIsbGxOHLkiNBRGGMMAHDjxg3s3r0bn3zyCUQikUr3rbI5rqUyMjJgY2ODxYsXY9GiRarcNWOMKe3Jkydo164d3n77bSxbtkzoOGoxcuRIPHz4EOfOnVP5HwnGGFPWjBkzEBUVhUuXLkEqlapy16qb41qqSZMmeP/99/H9998jNzdX1btnjDGl+Pv7o6CgoF5/kP72229x4cIFHD58WOgojDEdd+3aNezcuRNff/21qotWAGoYcQWAzMxM2NjYwMfHB59//rmqd88YY9Xy+PFj2NjY4MMPP8SSJUuEjqNWr7/+Om7evImYmBiIxSofk2CMsWqZNGkSEhMTERcXp46+SPUjrgDQuHFjzJ8/H8uXL0dWVpY6mmCMsVdauXIlFAoF5s+fL3QUtVu6dCkSExNx4MABoaMwxnRUQkIC9uzZg6+//lptH6DVMuIK6NZIB2NM8+jimZ+JEyfi0qVL6hrpYIyxlxo3bhySkpLUeeZHPSOuAGBmZoaPPvoIK1euxMOHD9XVDGOMVWr58uXQ09PDhx9+KHSUOrN06VJcvXqVb73NGKtz//77Lw4ePIj//ve/av3grLYRV+DZ2ont2rXDjBkzsHLlSnU1wxhj5aSmpqJTp05YsmRJvb4oqzJvvvkmzpw5g8TEROjp6QkdhzGmI4YOHYrs7GxERUWpc3UT9Y24As/WdV2yZAnWrFmDq1evqrMpxhgr4+Pjg6ZNm+KDDz4QOkqdW7ZsGdLT07F69WqhozDGdMShQ4cQGhqKFStWqH1JPrWOuAKAXC5H9+7dYWVlhT///FOdTTHGGM6ePQsnJyfs2bMH48ePFzqOIHx9ffHjjz/i6tWraN68udBxGGP1WFFREezt7eHo6IidO3equ7lLai9cAeD48eMYMmQIgoODMXz4cHU3xxjTUUSEvn37wtjYGMePHxc6jmDy8/Nha2uLoUOH8i24GWNqtXz5cvj6+uLSpUuwtrZWd3N1U7gCz9YYvHbtGmJjYyGTyeqiScaYjgkMDMTbb7+NCxcuoGvXrkLHEdT27dvx5ptvIioqCj179hQ6DmOsHnrw4AE6duyI+fPn4+uvv66LJuuucL158ybs7OywYsUKnZx3xhhTrydPnqBTp04YPXo01q9fL3QcwRER+vfvDyJCeHg43wqWMaZy77zzDkJCQnD16lUYGxvXRZPqvTjreTY2NvD29oavry8ePXpUV80yxnSEn58fnj59im+//VboKBpBJBJhxYoViIyMxJ49e4SOwxirZy5evIhNmzbBz8+vropWAHVwcdbzcnJy0KlTJ3h4ePC8K8aYyly5cgXdunXDd999q+6ASQAAIABJREFUh48++kjoOBpl5syZCAsLQ0JCAkxNTYWOwxirB+RyOZydnSGRSHD69Om6PKNTd1MFSgUFBWHy5Mk4evQo3Nzc6rJpxlg9pFAoMHDgQOTk5OD8+fM8h/4FmZmZsLOzg6enJ37++Weh4zDG6oHVq1dj0aJFOH/+PLp161aXTdd94Qo8uyVYbGws4uPj63R4mTFW/6xbtw7e3t6IiopC9+7dhY6jkbZu3YpZs2bh5MmTcHFxEToOY0yL3blzB126dMFHH31UVxdkPU+YwjUtLQ2dO3fGnDlz4OfnV9fNM8bqifT0dNjZ2WHu3Ln47rvvhI6j0caMGYNr164hJiYGBgYGQsdhjGkpgfuSurs463ktWrTAsmXLsHLlSly4cEGICIyxeuD999+HhYUFFi9eLHQUjffzzz8jNTWVC3zGWI1t374dhw8fxoYNGwT7ACzIiCvA89IYY7Wze/duTJo0iefLK0HAeWmMMS1XOl/+jTfewC+//CJUDGGmCpS6evUqunXrhiVLlsDHx0eoGIwxLZOZmYkuXbpg1KhR2LBhg9BxtIZCoYCTkxMA4PTp05BKpQInYoxpi+nTp+PkyZNITEwUcoUSYaYKlOrUqRO+/vprLF68GBcvXhQyCmNMi3h5eUEmk2H58uVCR9EqYrEYv//+O+Li4vDf//5X6DiMMS2xc+dO/PHHHwgICBB8WT1BR1yBZyMA7u7uSE9PR3R0NIyMjISMwxjTcL/99hvmzp2L0NBQDB48WOg4WmnNmjVYuHAhTp06hX79+gkdhzGmwe7evYuuXbti6tSpWLNmjdBxhJ0qUCo1NRUODg6YNGkS1q5dK3QcxpiGunHjBrp374558+bxRUa1QEQYM2YMEhMTERMTI/gICmNMMykUCri5ueH+/fuIjo6GoaGh0JE0o3AFgH379uGNN97AgQMHMGbMGKHjMMY0TElJCVxcXFBcXIwzZ85AT09P6Eha7eHDh3BwcMDQoUMRGBgodBzGmAZaunQpli5diqioKHTt2lXoOIDQc1yfN378eMycORNvv/020tPThY7DGNMwX331FRISEvDHH39w0aoCFhYW2LRpE7Zu3YodO3YIHYcxpmEuXLiAb775Bt99952mFK0ANGCO6/Nyc3Ph6OiIDh064O+//67Le98yxjTYiRMnMGTIEKxfvx7vvvuu0HHqlQ8++ADbt29HbGwsrKyshI7DGNMAT548gaOjI2xsbBASEqJJ9ZjmTBUodfbsWfTv3x9LlizB559/LnQcxpjA0tPT0aNHD/Tr1w979+4VOk69k5+fj169esHExAQnT56Evr6+0JEYYwKbPHkyjh8/jtjYWDRv3lzoOM/TnKkCpfr27YsVK1bgq6++QnBwsNBxGGMCKi4uxuTJk2FiYoKNGzcKHadeMjQ0xL59+3DlyhXMnz9f6DiMMYGtXLkSu3fvxtatWzWtaAUAaFzhCgDe3t6YMWMGpk+fjps3bwodhzEmkI8//hgXLlzAvn370LBhQ6Hj1FsdO3bEli1b8Ouvv/IHBMZ0WEREBD777DN89913GDZsmNBxKqVxUwVK5efnw8XFBXK5HJGRkby+K2M6ZseOHZg6dSoCAwPx5ptvCh1HJ3z22Wfw9/fHqVOn0KtXL6HjMMbqUOm0rN69e2P//v2aNK/1eZo3x/V5ycnJ6NmzJ0aMGIGtW7cKHYcxVkfi4+PRr18/eHl5YdWqVULH0RkKhQKjRo3CpUuXEB0dDQsLC6EjMcbqQHFxMQYPHowHDx7g3LlzMDMzEzpSVTS7cAWAv/76C2PHjsUvv/yCuXPnCh2HMaZm2dnZ6NWrF5o2bYqwsDBe+qqOPXr0CD179oSNjQ2OHDkCiUQidCTGmJq9//772Lp1K86ePYvOnTsLHedlNO/irBd5eHjgyy+/xPz58xEWFiZ0HMaYGhUXF2PSpEl4+vQp9u7dy0WrAMzNzREUFISIiAgsWrRI6DiMMTVbv3491q9fj02bNml60QpAQy/OetGSJUvwxhtv4PXXX0d8fLzQcRhjajJ//nyEh4dj3759aNasmdBxdFbPnj2xZcsW/PTTT/jpp5+EjsMYU5OQkBB8+OGHZXWWNtD4qQKlCgoKMGTIEKSlpeHs2bOwtLQUOhJjTIW+++47fPnll9i7dy9ef/11oeMwAMuWLcNXX33F3xPG6qGEhAS4uLhg5MiR2L59u6ZejPUizZ/j+rzMzEw4OTnB1NQUJ06cgLGxsdCRGGMqsHv3bkyePBk//vgjvL29hY7DnvP+++9j8+bNCAsLQ58+fYSOwxhTgbS0NPTt27dsLrsW3XhEuwpXAEhKSkK/fv3Qp08fHDhwgC8cYEzLnT59Gu7u7njvvfd4BQENJJfL8frrryM6Ohpnz55FmzZthI7EGKuF3Nxc9O/fH4WFhYiIiECjRo2EjqQM7StcAf5Dx1h9cf36dfTr1w+urq7Yu3cvxGKtmHavc3JycuDq6gq5XI6IiAhNXiqHMfYSJSUlGD16NGJiYnDmzBlYW1sLHUlZmr+qQGVcXFywadMm+Pv7w8/PT+g4jLEauHv3LoYNG4Z27dph+/btXLRqMFNTUxw+fBjZ2dkYPXo0nj59KnQkxpiSFAoFZs+ejfDwcPz555/aWLQCAKRCB6ipyZMn49GjR5g3bx5kMhk+/vhjoSMxxqrp4cOHGDp0KPT09HDo0CG+M54WaNWqFY4fP47+/ftj7Nix+PPPP2FgYCB0LMZYNRAR5s2bh6CgIBw4cAA9e/YUOlKNaW3hCjy7aKCoqAgLFy6Eqakp3n33XaEjMcZe4fHjxxg+fDiKiopw6tQpXiFEi3Ts2BFHjhzB4MGDMWnSJOzZswcymUzoWIyxV/j000/x22+/YceOHRgxYoTQcWpFqwtXAFiwYAEyMzPx3nvvwcTEBFOmTBE6EmOsCnl5efDw8MCDBw9w6tQptGjRQuhITEldu3bF4cOH4e7ujilTpmDnzp2QSrX+Twlj9daSJUuwYsUKbN26FZ6enkLHqbV6Mans22+/xcKFCzFz5kwcOnRI6DiMsRfcuHED+fn58PDwwLVr1xAaGoq2bdsKHYvVUN++fXHw4EEcPnwY77zzDuRyOW7cuCF0LMbYC1avXo1vvvkGa9euxdSpU4WOoxL1onAFgO+//x6zZs3CpEmTcPToUaHjMMaeExgYiBYtWuD8+fM4dOgQbG1thY7Eamnw4MHYuHEjtm3bBgsLC/z7779CR2KMPWfdunX46KOPsGrVKsyZM0foOCpTbwpXkUiE9evXw9PTE2PGjOGRV8Y0RF5eHk6fPo2cnBzk5eVh0KBBmDNnDhc6WoqIcOzYMUycOBEzZ86EXC5HdnY2jh07BoVCIXQ8xhiAVatWYd68eVi6dCkWLFggdByVqjeFKwCIxWIEBgbCy8sL48ePx5YtW4SOxJhOe/z4MYYNG4ZLly5h6dKlAID8/Hz8/vvv6NGjBxwcHBAQEICcnByBk7JXuX//Pr7//nu0bdsWbm5uOHDgAEpKSiASifDjjz9iy5YtmDZtGoqLi4WOyphO+/7777Fo0SIsX74cn3/+udBxVI/qIYVCQR9//DFJJBL67bffhI7DmE569OgR9e7dm5o1a0bx8fGkUCiob9++JJVKCQABIJFIRBKJhGQyGb3xxhsUGhoqdGz2HLlcTqGhoTRhwgSSSCTlvncASCaT0axZs4iIKCwsjBo0aEAeHh6Un58vcHLGdI9CoaBFixaRSCSin376Seg46pJYLwvXUn5+fiQSiWjVqlVCR2FMp6Snp5O9vT21adOGrl+/XvZ4dHQ0iUSicsXP80UQAGrfvj35+flRRkaGgEeg29LT08nPz49at25NACoUrKVfhoaGlJaWVva6c+fOkbm5OQ0aNIhyc3MFPALGdItCoSBvb2+SSCS0efNmoeOoU/0uXImI1qxZQyKRiHx8fISOwphOuH37NnXo0IE6depEKSkpFZ6fNm0a6enpVVoIPT8Kq6+vT2+++SadP39egKPQTSEhITRmzJiyUfCqvkcASCKR0LJlyyrs48KFC9SkSRNydXWlx48fC3AUjOmWkpISmj17Nunp6dHevXuFjqNuiSIiorqYkiCkgIAAvP/++3jnnXfwyy+/8JqDjKlJfHw8Ro0aBVNTU4SGhqJ58+YVtrl79y46dOiAgoKCV+5PIpHgyJEjGDJkiDrishcEBARg7ty5r9xOLBajRYsWuH79eqV3z7p8+TLc3d1hbm6Ow4cPo3Xr1uqIy5jOy8vLw5QpU3Ds2DHs27cPw4YNEzqSul2qVxdnVWXOnDnYvXs3tm7ditGjRyM3N1foSIzVO0ePHoWLiws6duyI06dPV1q0As9uHfrZZ59BIpG8dH8ikQgbNmzgorUOzZkzBz4+PhCLX/6ngYjw448/VnnL19deew3h4eEoKSlB3759cfHiRXXEZUynpaenY8CAAYiMjMSRI0d0oWgFUM9WFXiZ8ePHIywsDP/++y9cXV1x9+5doSMxVm9s2LABo0aNwvjx4xEcHIyGDRu+dPtPPvkElpaWVRZIYrEYixcvxqxZs9SQlr3Md999h0mTJlV5ZkoqlaJ3796YMGHCS/fTtm1bREREoFOnTujfvz8OHz6sjriM6aSEhAT07dsXjx8/xpkzZ+Di4iJ0pDqjM4UrAPTp0wdnzpxBYWEh+vbti5iYGKEjMabViAhLliyBl5cXvvjiC2zatKla9643NDTEihUrUNlMJalUCmdnZ/j6+qojMnsFkUiE3377De3bt6/0eymXy/Hzzz9DJBK9cl+NGjVCSEgIxo0bh7Fjx2Lt2rXqiMyYTvnnn3/g4uKCVq1a4cyZM+jQoYPQkeqWoFNsBZKZmUkDBgygBg0a0N9//y10HMa0UkFBAU2ePJn09PRo69atSr++suWxZDIZdenShUQiEb333ntUXFyshuTsZR4/fkwjR44kAwMDsrKyKneRlkwmo9mzZyu9T4VCQb6+viQSicjb25vkcrkakjNW//3+++8kk8nI09NTV5edq/+rClQlPz+fJk+eTDKZrD6vd8aYWty+fZt69epFjRo1ohMnTtR4PxcuXChbHksmk1H79u3p0aNHtHfvXjIyMiI3NzfKyspSYXL2MikpKeTo6EhNmjShU6dOUVJSEpmbm5NEIql0+Stlbdq0ifT09GjcuHG84gBjSiguLqYFCxaQSCSir776ihQKhdCRhKK7hSvRs1GAb775hsRiMU2fPp3y8vKEjsSYxvvnn3/IwsKCOnfuTFevXq31/qZPn04AqHHjxnTr1q2yx2NiYsjKyorat29PV65cqXU77OUiIyPJ0tKS7O3tKTk5uezxiIiIsuXLKlv+SlknT54kS0tL6tSpEyUmJtZ6f4zVd+np6dS/f38yMjKi7du3Cx1HaLpduJY6fvw4NW3alBwcHOjGjRtCx2FMIykUCvL39yepVEpjx45V2YjZ3bt3ycLCgs6dO1fhudTUVOrVqxeZm5vT8ePHVdIeq2jHjh1kaGhII0aMqPT7GhQURDY2Nio7NZmamkpOTk5kYmJCu3btUsk+GauPzp8/X/YBPjY2Vug4moAL11J37tyhXr16kampKe3fv1/oOIxphNLTUTk5OfTGG2+QVColPz8/lZ+munfvXpXP5efn09SpU0kqldIvv/yi0nZ1nTJzT1/2PaqJ4uJi8vHxIQDk5eVFRUVFZZkYY0QBAQGkp6dHo0aNokePHgkdR1Nw4fq8p0+f0syZM0ksFtOSJUv4AgKm8wICAujnn38mW1tbsrS0rNV81tp4scAqKSkRJEd98uTJExo3bhzp6enRpk2bBMsRGBhIhoaGNGjQIFqzZg0dOXJEsCyMaYK8vDyaMWMGicVi+uabb/jDXHlcuFam9FPOoEGDKr1lJWO6YunSpQSAmjRpQgkJCULHoZ07d5KhoSENHz6cL+6phdTUVOrZsyc1btyYwsLChI5DR44cIUNDQxKJRLRnzx6h4zAmmISEBHJwcCBzc3MKDg4WOo4mStSpdVyry8vLC9HR0cjIyECXLl2wY8cOoSMxVqeys7MxZcoUfPXVVzAxMUFGRgbc3d1x7NgxQXNNmjQJx48fx8WLF+Hi4oLk5GRB82ijmJiYsoXLIyMjMXDgQEHzBAYGYsKECcjPz0fz5s3h6emJOXPm4OnTp4LmYqwuERFWr16NHj16wNjYGOfPn8fw4cOFjqWRuHCtgr29PaKiojBz5kxMnToVb775Jp48eSJ0LMbU7vjx4+jSpQsiIiJw/PhxvPvuu5BIJHjw4AHc3d0xb9485OXlCZavb9++iI6OhlQqRa9evRAeHi5YFm2zZ88eODs747XXXsO5c+fQsWNHwbLcu3cPHh4emD17NvLy8iASifD1119j165d2L17N3r37o3Y2FjB8jFWV+7fvw8PDw8sWrQIn376KcLDw2FjYyN0LM0l9JivNti/fz81adKE2rZtSxEREULHYUwtioqKyNfXl8RiMU2YMIEyMzOJiOjEiRNlC9ADIKlUSq1atRL8FHNOTg6NGjWKDAwMaNu2bYJm0XSlS/+JRCL68MMPBZ8jHBQURA0bNix3cwORSETp6elERJScnEyurq5kYGBAfn5+fL0Bq7eCg4OpWbNmXF9UH89xra7U1FRyd3cnmUxG33zzTdkVsIzVB7GxseTo6EgNGjSocKFOSUkJNWzYsFzxKpFISCQS0bvvvktPnjwRJvT/Z1u4cCEBoE8++UTwgkwT5ebm0oQJE0gmk9G6desEzZKVlUXTpk0rK1SfL1r79OlTbtvi4mLy9fUlqVRKI0eO5OsNWL2SnZ1NXl5eBIDefvttys3NFTqStuDCVRkKhYJWrVpFRkZGZG9vT1FRUUJHYqxW8vPz6fPPPyeZTEYuLi5VrmM8a9ascqNjz4++WllZ0alTp+o4eXl//PEHGRkZ0dChQ3nZmOckJSWRvb09NWnShI4dOyZolsOHD5OFhUWlP0cymYyWL19e6esiIyOpQ4cOZGpqSr/88guPvjKtd+DAAWrZsiU1bdqU9u7dK3QcbcOFa03cvHmT3N3dSSwWk5eXF+Xk5AgdiTGlhYeHk62tLRkbG7/ydOyBAwfKjZC9OPoqFovJx8eHCgoK6vAIyvv333+pTZs21K5dO4qPjxcsh6Y4efIkNW3alLp27VrujmR1LTs7m9555x0CQGKxuNKfIQAvvQtbfn4++fr6kp6eHjk5OfEdt5hWunfvHs2YMYMAkKenJz18+FDoSNqIC9faCAoKoiZNmpC1tTWFhIQIHYexasnOziZvb28Si8U0cuRIun379itf8/TpU9LX16+y6CgtYG1tbenff/+tg6Oo3MOHD2ngwIFkYmKi08sqBQQEkEwmo0mTJgl6K+vg4GBq2rRppaOsz3916NChWvuLjY2l3r17k0wmE/yDEmPVpVAoKDAwkBo3bkxt27bltYprhwvX2kpPTydPT08CQNOnT1f53WUYU6WgoCBq3rw5WVpa0s6dO5V67ZgxY0gikby0AAFA5ubmlJqaqqYjeLXi4mLy9vYmkUhEPj4+OnVquaCggGbNmkUSiUQtdzhTRlRUFEml0ipH6ku/9PT06Isvvqj2fktKSmjFihVkZGREXbp0odOnT6vxKBirnStXrtDAgQNJIpHQwoULBf0gWU9w4aoqBw8epFatWpGZmRktX76cCgsLhY7EWJmYmBgaNGgQiUQimjVrVtmKAcrYvHnzS0/1SqVSsre3p+vXr6vhCJT3/O0Ss7OzhY6jdnfv3qXevXuTqakpHTx4UOg4RER07tw5at26NUml0pcWr+fPn1d630lJSeTu7k4ikYimTp3KF28xjZKVlUUfffQRyWQy6tatG507d07oSPUFF66qlJeXR35+fmRiYkLt27enoKAgoSMxHZeZmUne3t4kkUioR48eFB4eXqt9VTbiWjqi9u6772rcqdvTp09Ts2bNqGPHjnT58mWh46iNJh9ndnY2jR8/vsqR16ZNm9ZqZPjQoUPUrl07MjIyIh8fH746mwlKLpdTYGAgWVpakrm5Ofn7+1NxcbHQseoTLlzVISUlhWbMmEEikYgGDx5MsbGxQkdiOqaoqIgCAgKoSZMm1KJFCwoICFDJKXNXV9dyo64ymYwkEglNmDBBBanV4/mRyEOHDgkdR+W0ZWS5e/fuJBaLy42+6unp0QcffFDrfRcVFZG/vz+ZmppSy5YtKTAwkO/vzupcWFgYde3alWQyGXl5efHFV+rBhas6nTp1irp3705SqZTmzZtH9+/fFzoSq+cUCgUdPHiQOnXqRAYGBvTFF1+odATK39+/rPAoHcVdunQpicViOnr0qMraUbX8/HyNmfupKsXFxeTj46MVc3nXrFlDYrGYfvnlF2rTpk25i7VU+XOTlpZGs2fPJrFYTC4uLnTmzBmV7Zuxqly9epUmTJhAAGjkyJF05coVoSPVZ1y4qptcLqcNGzZQ8+bNydjYmHx8fCgjI0PoWKweCg4Opl69epFIJCJPT0+1LIF069atsukBixYtKrsRx9SpU6lp06aUlpam8jZVacWKFSSRSGjKlCmC3jihttLS0sjFxYVMTExo3759Qsd5qbi4ODI0NKQlS5YQEdHjx4/pjTfeIABkYmKilpu5nD9/nlxcXAgAeXh40IULF1TeBmM3b96kWbNmkVQqJTs7O/r777+FjqQLuHCtKwUFBRQQEEDNmjUjExMT8vHx4YXSmUqEh4fTwIEDCQC5ubnV6EIXZbi5udFff/1V7rHc3Fzq2LEjDRo0SOPvXnX06FFq3LgxdenS5aVrh2qqkydPUvPmzalDhw4av15tbm4u2dra0oABAyr8XAQGBpKXl5da2w8NDaVevXqV/W4IuVQbqz/u3LlD3t7epK+vT9bW1hQQEKDx/V49woVrXXvy5An5+/tT06ZNqUGDBuTj46PR89KY5oqMjKQhQ4YQAHJ2dqaTJ0/WSbtVddDR0dGkr69P3377bZ3kqI2UlBTq27cvNWjQQKsuoixdn3X06NGUlZUldJxXmj59OllYWFS5PFpd/bEPDQ2lHj16kEgkIg8PD77ugNXI/fv3ycfHhwwMDMjKyooCAgL4wqu6x4WrULKzs8nX15fMzMyocePGtHjxYp4Dy15JoVBQcHBwWcE6YMAAwW+3+jx/f38Si8WC3160OgoKCsjb25sAkJeXl1pOWatKTk4OeXp6kkQiIV9fX42ez1rq119/JbFYrDE3Z1EoFLR7926ys7MjiURCkydPpujoaKFjMS1w/fp1ev/998nQ0JBatWpF69at4yUvhcOFq9AyMzNp8eLF1KRJEzIwMCAvLy+e2M0qKCwspE2bNpG9vT0BIHd3d40sDhUKBY0bN45atmypNVfUbtu2jYyNjcnV1VXQGydU5fLly2RnZ0cWFhYUGhoqdJxqSUhIICMjI/r888+FjlKBXC6nP/74gxwdHQkADRw4kP766696ccEeU63IyEgaP348icVisrGxoTVr1lB+fr7QsXQdF66aoqCggAIDA+m1114jsVhMbm5u9XLpHqacx48fk7+/P7Vq1YpkMhl5enpq/ELWWVlZZG1tTSNGjNCaYuD54vCff/4ROk6Z7du3k7GxMbm4uGhkUV2ZJ0+ekJ2dHfXp00ejR7GJns0P9/DwIJFIRO3btyd/f396+vSp0LGYgORyOR06dIjc3NwIAHXv3p0CAwN5SoDm4MJV08jlctq3bx85OTkRAOrduzdt2bKFO1Mdk5CQQN7e3tSgQQMyMzOjTz75RKvuDBQVFUV6enr0ww8/CB2l2kpPx0ulUvL19RW06C5d6kobpjG8aNasWdSoUSNKTk4WOkq1xcfH0+zZs0lfX58sLS1pyZIlWvX7xmrv0aNHtHr1aurQoQOJxWIaO3asRk3DYmW4cNVkkZGR5OnpSTKZjBo2bEgffPABX1RQjz158oR+//33sg8t7dq1o5UrV9Ljx4+FjlYj33//PUmlUq26l7xCoSB/f3+SyWQ0ZswYQS6ASklJoX79+lGDBg1o165ddd5+bezYsYNEIhEdOHBA6Cg1kpaWRp999hk1bdqUJBIJjRo1ivbv38+jbfWUQqGgsLAwmjZtGhkYGFCDBg1o7ty5WrnaiA7hwlUbPHr0iAICAqhLly4EgHr06EEBAQGUk5MjdDSmAgkJCeTj40Pm5uakp6dHnp6eFBoaqjWn2auiUChozJgx1Lp1a61bu/jUqVNlS07V5YfF48ePk6WlJdna2lJCQkKdtasK165dowYNGtDHH38sdJRaKywspEOHDpVdENesWTPy8fGhGzduCB2NqcC9e/fI39+f/6ZqJy5ctUllnw7feustOnLkCI8IaJk7d+7QypUryy4QsbOzo1WrVmnNBU3VlZmZSVZWVuTh4aF1hfj9+/dpyJAhZGBgQBs3blRrWwqFgvz8/EgikdDUqVO17uYI+fn51K1bN+rVq1e9u9r61q1b9OWXX1LLli3LbuO9YcMGyszMFDoaU0JeXh7t2rWLxo0bRzKZjBo1akQffvghn8XUPly4aqvMzExavXp12eLaTZo0oTlz5tCxY8d4IWQNlZqaSqtXryYnJycSiUTUqFEjeuutt7TqVHpNnDp1iqRSKa1evVroKEp7/raqM2bMUEtB+eDBAxoxYgRJpVLy8/NT+f7rgpeXFzVs2JBu3rwpdBS1KSkpoUOHDtG4cePIwMCAZDIZjRw5kjZv3sxrcWuop0+f0t69e2nSpElkbGxMEomE3NzcaOvWrbw6gPbiwrU+SEpKou+++466detGAMjS0pLef/99OnnyJBexAktPT6eff/6Z+vfvT2KxmExNTWnGjBn0559/1ruRqZf55ptvSCaTae294/fv30/m5ubUuXNnld6tKjQ0lJo1a0Y2NjYav1pEVYKCgkgkEtHevXuFjlJncnJyaNu2bTR69Gj6pu4lAAAgAElEQVTS19cnfX19GjNmDG3btk1r56TXF/n5+XTw4EGaNm0aNWjQgMRiMQ0cOJDWrl3La6XXD1y41je3bt0if39/cnZ2JgBkbm5Onp6eFBAQQHfv3hU6Xr1XUlJC0dHR5OfnR87OziQWi8nQ0JA8PDwoMDBQ604Bq4pcLid3d3dq166d1o5O3blzh1xdXcnAwID8/f1rta/i4mLy9fUlsVhM48eP19rbP9+4cYPMzMzogw8+EDqKYLKzsykwMJA8PDxIT0+PJBIJ9ejRg3x9fSk6Olrrpshoo6SkJAoICCBPT08yNTUtm7fq7++vNcvIsWpLFBERgdVLV65cweHDhxESEoLw8HAUFRXB0dERI0aMwPDhw9G3b19IpVKhY2q9tLQ0hISEICQkBP/88w+ysrLQtm1bDB8+HCNGjICbmxsMDQ2Fjim4Bw8eoFu3bnBxcUFQUJDQcWqkpKQES5cuxdKlSzFmzBhs3LgRjRo1UmofKSkpmDp1KqKjo+Hn54f58+erKa16FRYWwtnZGcXFxTh79iz/jAN49OgRQkJCEBwcjKNHj+LBgwdo2bIlhg8fjuHDh8PNzQ0NGzYUOqbWy8/Px4kTJxAcHIyQkBBcv34dpqamcHNzw/DhwzFy5Ei0bNlS6JhMPS5x4aoj8vLyEBYWVvaLfvPmTZiZmcHZ2Rn9+vWDq6srevXqBSMjI6GjarwbN24gMjISERERiIiIwKVLl2BgYID+/fuXfSjo1KmT0DE10okTJ+Dm5oaff/4Zc+fOFTpOjYWFhWH69OmQSqXYsWMHnJycqvW6gwcP4q233oKlpSV27twJBwcHNSdVH29vb2zatAnR0dH8814JhUKBf//9t6yQjYqKgkgkQvfu3eHk5AQXFxc4OTmhefPmQkfVeFlZWYiMjERkZCROnz6Nc+fOobCwEF27di37UODk5ASZTCZ0VKZ+XLjqqmvXriE0NBQRERE4ffo0UlJSIJPJ4OjoWNap9uvXDy1atBA6ap25f/8+LC0tyz1WVFSEixcvlnWYkZGRuHfvHgwMDNCzZ084OztjwIABGDhwII84VdNXX32FFStWIDIyEo6OjkLHqbGHDx9i1qxZOHr0KL744gssXrwYYrG40m0LCwvxn//8B2vWrMH06dOxbt06GBsb13Fi1fnrr78wZswYbNmyBdOnTxc6jlbIysrCP//8g/DwcJw+fRpxcXGQy+WwsbGBs7Nz2ddrr70GiURS7rWV9U31FREhKSmp3ODA5cuXQUSwtbWFk5MTXF1dMXToUC76dRMXruyZ9PR0REdHlxWy58+fR1FRERo2bIjOnTujc+fOsLOzQ48ePeDo6KjVf3SrMmjQIHz66ae4cuUKLly4gEuXLiExMREFBQUwNTVF79694ezsDBcXF7i4uMDAwEDoyFpJoVDA3d0dKSkpiI6OhqmpqdCRaoyI8NNPP+E///kPXF1dsXXr1gp/TK9evYrJkyfj5s2bWL9+PaZMmSJQWtVISUmBo6MjJkyYgICAAKHjaK28vDxcvHixrM+NiIhAVlYWZDIZOnToUNbndurUCUFBQdi/f7/QkVUuJycH169fR2JiYlmfGxMTg4yMDEilUnTt2rWszx04cCAsLCyEjsyEx4Urq1xubi6io6MRFxeHhIQExMbGIjExEU+fPoVYLEa7du1gb2+Ptm3bom3btrC2ti77t6aOPBIR0tPTcevWLSQnJ5f99+rVq4iLi0NOTg4AwNraGvb29ujSpQu6du2Kbt268alQFUtNTUW3bt0wZMgQ7Ny5U+g4tRYdHY3JkycjNzcXW7ZswbBhwwAAW7Zswbx582Bra4sdO3agffv2AietnZKSEgwYMACPHz/GuXPneGqRCsnlcsTHxyMmJgYJCQmIi4tDXFwc7t+/DwBo2rQpHBwc0KFDh7L+tvS/TZo0ETh91R4/flyhzy0tVu/cuQMAaNiwIRwcHGBvbw97e3t07doVjo6O0NfXFzg900BcuLLqUygUSEpKQlxcHOLj45GYmFjWGWVmZpZtZ2lpWdapNm3aFI0bNy77atKkSdlX48aNa13kEhEyMzPLfWVkZJT9NyMjA6mpqUhOTkZycjIKCgoAAHp6erCysoK1tTXat28PU1NT/PDDD2jUqBFu376NBg0a1CoXe7Xg4GB4eHhgw4YNmD17ttBxai0nJwdz587Fzp07MXfuXOTk5OCPP/7Ahx9+iOXLl0NPT0/oiLX2ySefYN26dTh37hzs7OyEjlPv3bp1Cx07dkRJSQmWLVuGGzdu4MaNG0hOTkZqairkcjkAwMTEpKzPbdmyZbk+t7Tfbdy4MSwsLGBmZlbrXE+ePEFmZiYePnxY1t8+/5Wenl7W5z569Kjsdc2bNy8b4OjSpUtZoWplZVXrTExncOHKVCM3N7fcp+rSf7/YqSkUigqvNTQ0LDvt3rBhQ4hEIshkMpiYmAB4NhJROhr69OlTFBYWAng2Z6wyxsbGZR22hYVFuc6ydISiRYsW5eaRbdy4EXPmzIFIJMIXX3yBJUuWqPLtYVXw8fHBTz/9hKioKK2+UOl5//nPf7BixQpIpVKsXbsW77zzjtCRVCI4OBijRo3Cpk2bMHPmTKHj6ARPT0/s378fcrkckZGR6NevX9lzRUVFSElJKdfv3r59G2lpaeX63NIP68+TSCRlU3SMjIzKRjafXyEjJycHcrkcJSUlyM3NBfBsekNRUVGF/clksnKFsqWlJaytrSuMDPP0KqYCXLiyuvXo0aNyxWx+fj4KCwvx9OlTAM9OKykUChQVFSEvLw8AIBaLy0YJSjtZkUhUVuS+OLpQk85x4cKF+OWXX1BUVAQ9PT0kJSWhVatWqjtwVqmSkhIMHDgQ2dnZWn/quaioCL6+vli+fDmcnJyQlZWFW7du4YcffsB7770HkUgkdMQau3v3LhwdHeHm5oYdO3YIHUcnREVFoV+/fiAiSKVSrFu3rkYfgvLy8sr624cPH5b1sY8fPwbwv8EAIkJ2dnbZ6xo0aACpVFpuEKH0MRMTk7KBgcaNG2v1PHWmdS7xIp6sTpmbm8Pc3FzoGBXExMSUjSQQEXx9fbFx40aBU9V/pctJOTo6Yv78+fjtt9+EjlQjCQkJePPNN3H16lWsXLkS3t7ekMvlWLlyJRYsWIADBw7g999/18oPQ3K5HDNnzkSjRo3w66+/Ch1HZ8yfPx8SiQQlJSUQi8VITEys0X6MjY1hbGzMp+NZvVH52i2M6Zj4+PiyfxcXF2Pz5s3lHmPq07p1awQGBmLjxo3YunWr0HGUolAosHr1avTs2RMGBgaIiYnB/PnzIRKJIJVK4ePjU7bcXJcuXbSy8Fu8eDEiIyMRFBTEc7/ryJ49exAVFYWSkhIAz0bzY2NjBU7FmGbgqQJM52VlZVUYBZZKpRg0aBCOHj0qUCrds2DBAmzcuBHnz5+Hra2t0HFe6datW5g1axaioqLw9ddfY9GiRRXW3yyVn5+Pr7/+GsuXL8f48eOxbt06jb4SvFRYWBjc3d2xdu1aeHl5CR1HJxQXF6Njx45ISUkpu/gKABo3boyMjAwBkzGmES7xiCvTeZWdgispKUFoaChCQ0MFSKSbli9fji5dumDixInIz88XOk6ViAi//vorHBwckJWVhbNnz8LHx6fKohV4dgGin58fjh49iqioKHTu3BkHDx6sw9TKu3//PqZNm4YJEyZw0VqH1q5dW6FoBVA2T5UxXceFK9N5iYmJkEorTveWSCRYsGBBpSshMNWTyWTYvn077ty5g0WLFgkdp1L37t3DmDFjMG/ePMybNw/R0dHo1q1btV8/ZMgQJCQk4PXXX8frr7+OiRMnVrk6hpAUCgVmzJgBIyMjrZ13rI2ys7OxZMmSCkVrqUuXLtVxIsY0DxeuTOclJiZWeqtOuVyOK1euYMuWLQKk0k02NjbYsGED1q5dq3FXr+/evRudO3fGpUuXEBYWBj8/vxqtzWpqaoqAgAAc/j/27jssqmvRAvgaqgiIBntFQUBAFLsoGMDkGY0lFqwQE1uspFhvEq/RJGrURGPUqLEBiogaYzAWFBDBiKiIAoIVjb0iTaTt90cePE0soJzZM8z6fZ/fd+84nr2UnZk1Z/bZZ9cuREdHw8XFBREREQokfnVz5sxBVFQUtmzZwivG1ejbb79FVlbWM3/PwMDglS/QIqpIWFxJ5z25o8A/CSEwbdq0ku26SHn9+/fHRx99hLFjx+LixYuy4+DGjRvo168fBg4ciGHDhiExMRGdO3d+7eN2794dJ0+eLNlm6uOPP35uaVGnqKgozJkzBwsXLkSrVq1kx9EZaWlpWLx4cckFWf/0OjsLEFUkLK6k8xITE5/7e0II3L9/Hz/88IMaE9HixYvRpEkTDBw48LkfKpRWvJbVwcEBJ0+exP79+7FkyZJyvaVxzZo18euvv2LdunUICAiAk5MTdu/eXW7HL6s7d+5gyJAheOeddzB+/HhpOXTRjBkzXvj7eXl5iI+PV1MaIs3F4ko67e7duy9dY1h8u8Xbt2+rKRUZGxtjy5YtOHv2LKZPn6728S9cuIC33noL48ePh6+vLxISEuDp6anYeL6+vjhz5gzc3d3RvXt3eHt7q32+CSEwYsQI6OnpYcOGDVp9wwRtc+zYMQQHByM/P/+Fz+MZVyIWV9Jx/zzbamhoWLLeVaVSoW7duujevTsmTZqEO3fuyIios2xsbLBq1SosXrwYO3bsUMuY+fn5mD9/PpycnHD37l0cPnwYS5YsKblzkJJq1qwJf39/7Nq1C0ePHoWdnR1WrVoFde1YOH/+fOzZswebN2/WyJuEVGQ5OTn45JNP4OnpiZo1a5Y8bmBg8NSdANPT03Hr1i0ZEYk0BvdxJZ22bNkyTJgwAbVq1ULz5s3RsmVLREVFwcTEBLt27YKpqansiDpvxIgR+PXXX3HixAlYWVkpNs6JEycwatQonDlzBlOnTsXnn38OQ0NDxcZ7kZycHMyePRsLFy5Ep06dsGrVKtjZ2Sk2XmxsLNzc3DB37lx89tlnio1DpfPgwQM4OzujZcuWsLKyQkJCAk6fPo309HQcOHBA0bP/RBoumcWVdNrNmzdhYmICCwuLksfmzJkDf39/nDt3TmIyKpabm4v27dujUqVKiI6OLvcy+WRJ7Ny5M1atWgVbW9tyHeNVxcfHY9SoUUhOTsbUqVPxn//855V2MniRBw8eoFWrVmjWrBl27drFJQIaIDc3F2ZmZggODka/fv1KHr9z5w709fV5Rpx0GW9AQLqtdu3aT5VWAHB0dMTFixeRnZ0tKRU9qVKlSti0aRMSExMxc+bMcj32H3/8gWbNmmHVqlVYvnw5IiIiNKa0AoCLiwuOHDmCuXPnYuHChWjbti2OHj1abscXQuDDDz9EQUEB/P39WVo1RHJyMgoLC+Ho6PjU4zVq1GBpJZ3H4kr0D05OTigqKkJKSorsKPR/HB0d8eOPP2L+/Pn4/fffX/t4t27dgq+vL3r06IH27dsjJSUFo0eP1sjiZmBgAD8/PyQkJKBmzZro2LEjxowZUy5bZy1evBihoaEICgrSilvQ6oqkpCQYGxvDxsZGdhQijcPiSvQP1tbWMDExeeE2WaR+I0aMwLBhwzBixAhcu3btlY5RVFSElStXolmzZjh06BB2796NLVu2PHVBjKaytrbGvn37sHLlSoSEhMDZ2fm1SvyxY8cwffp0fPXVV+WyLy2Vn6SkJNjb2z/zjn5Euo7Flegf9PX1YWdnx61nNNDy5cthaWmJIUOGPPe2mM8TGxuLdu3aYeLEifjwww+RmJiIbt26KZRUGSqVCiNHjkRycjLat2+PXr16oWfPnrhw4UKZjvPw4UMMHDgQnTp1wrRp0xRKS68qMTERTk5OsmMQaSQWV6JncHJyYnHVQGZmZtiyZQvi4uIwe/bsUv2Z+/fvw8/PD506dYKZmRlOnDiBhQsXavWOEbVr10ZQUBAiIyORlpYGBwcH+Pn5lXr5wNixY5GdnY1NmzZBX19f4bRUVklJSf9a30pEf2NxJXoGR0dHLhXQUM2bN8fChQvx9ddfIyws7LnPKyoqgr+/P+zs7BASEoK1a9ciIiKiQp3J6tKlC+Lj4/Hdd99h/fr1aNasGfz9/V/4Z5YtW4bg4GAEBgaidu3aakpKpZWVlYXLly+zuBI9B4sr0TM4OTnhr7/+wsOHD2VHoWcYN24cBg0aBB8fH9y4ceNfv3/s2DG4urpi5MiRGDJkCFJSUuDr66uRF1+9ruKLt1JSUuDh4YHhw4eja9euOHPmzL+ee/r0aUyZMgVffvklunbtKiEtvUxSUhKEEBXqAxZReWJxJXoGR0dHCCGQnJwsOwo9x88//wwLCwsMHTq0ZL1r8bKA9u3bw8TEBPHx8ViyZAmqVKkiOa3y6tSpA39/f0RGRuL27dto0aLFU8sHsrKy4O3tjXbt2uHLL7+UnJaeJzExEZUrV1b0ZhtE2ozFlegZrKysYG5uznWuGszc3BwbN25ETEwM5s6dC39/f9ja2mLr1q1Yt24dwsPDdfLrVnd3d5w4cQILFizAhg0bYG9vD39/f4wdOxb37t3julYNV7y+tfjW00T0NO61QfQMKpUKzZo1Y3HVcG3atMH48eMxc+ZM6OvrY9y4cfj6669hbm4uO5pUxcsHBg4ciKlTp2L48OEQQmDZsmWoW7eu7Hj0Arwwi+jF+JGO6Dl4gZZmu3r1Knx9fbF48WJYWlrC0tISX375pc6X1ifVrl0b06ZNg7GxMWrWrImPP/4Yfn5+SE9Plx2NniMxMZHFlegFWFyJnsPR0ZFnXDVQVlYWvvjiC9ja2uLw4cPYtm0bzp49CxMTE/j6+kIIITuixsjOzoa3tzdatGiBtLQ0/PDDD9i4cSOaNm2K5cuXo6CgQHZEesKDBw9w/fp1XphF9AIsrkTP4eTkhBs3buDu3buyoxAAIQRCQkLg6OiIJUuWYOrUqUhMTMR7772HatWqITg4GAcOHMCiRYtkR9UYEydOxI0bN7B582aYmJhg/PjxOH/+PEaMGIFPP/0UTk5OCA0NlR2T/k/xNzw840r0fCyuRM9RfNaDOwvId+TIEbi6umLQoEHo0qULzp8/j1mzZqFSpUolz2nXrh1mz56NGTNm4PDhwxLTaobNmzdj/fr1WLdu3VNXqFetWhXz5s1DYmIinJ2d0bNnT7z11ls4ffq0vLAE4O/1rRYWFqhfv77sKEQai8WV6Dnq1auHN954g+tcJbpy5Qp8fX3RsWNHmJmZIT4+Hv7+/qhVq9Yznz916lS88847GDRoEO7du6fmtJrj3LlzGD16ND755BP07t37mc+xsbHBli1bEB4ejnv37qFVq1YYM2YMbt++rea0VKz4wqyKuN8wUXlhcSV6Ae4sIEdWVhZmzZoFOzs7HD16FFu2bEFYWBicnZ1f+OdUKhXWrFmDoqKikivpdU1ubi4GDhwIe3t7zJ0796XP9/DwwLFjx7BmzRr8/vvvsLOzw/z58/H48WM1pKUnJSYmcn0r0UuwuBK9gJOTE4urGhXfptXGxgZLly7FrFmzcOrUKQwYMKDUx6hRowY2bdqE3bt346efflIwrWb6+OOPcenSJQQHB8PIyKhUf0ZPTw++vr44d+4c/Pz88NVXX8HJyQkhISEKp6UncSssopdjcSV6AW6JpT6hoaFwdnbGqFGjMHToUFy4cAHTpk0rdfl6kru7O2bOnIkpU6bg+PHjCqTVTCEhIVi5ciWWL1+Oxo0bl/nPm5qaYtasWUhJSUHbtm0xcOBAeHh4IC4uToG09KRbt27hzp07LK5EL8HiSvQCjo6OuHfvHm7evCk7SoV15MgRdOnSBb169YK9vT2SkpKwaNEiVK1a9bWO+8UXX8Dd3R0DBw7Ew4cPyymt5rpw4QJGjRqF8ePHY/Dgwa91rIYNG2LTpk04fPgw8vPz0b59e3h7e+PcuXPllJb+qfibHS4VIHoxFleiFyheU8nlAuUvNTUV3t7ecHV1RX5+Pg4ePIitW7fCxsamXI6vp6eHwMBA5OTkYNSoUeVyTE2Vn5+PYcOGoWHDhliwYEG5HbdDhw6Ijo7Gvn37kJqaCkdHR4wZMwY3btwotzHob4mJiahevfpzLzwkor+xuBK9QPXq1VGjRg0uFyhHd+7cgZ+fH5ycnJCYmIjg4GAcPnwYbm5u5T5WzZo1sXHjRmzfvh0rV64s9+NrismTJyMxMRFbtmyBiYlJuR+/a9euiI+Px8aNG7Fv3z40bdoU06dP14kz2eqSlJTEs61EpcDiSvQSvECrfGRlZWH+/PmwtrbG9u3bsWzZMpw+fbpMF169Cg8PD0yfPh0ff/wxTp48qehYMoSGhmLp0qVYsWIF7O3tFRtHT08PAwYMQGpqKr755husXLkS1tbW3IGgnPBWr0Slw+JK9BK8QOv15OXlYdWqVbC2tsZ3332Hzz//HGfPnsXo0aOhr6+vlgyzZ8+Gq6srvL29kZmZqZYx1eGvv/7C8OHDMXLkSAwbNkwtYxoZGcHPzw8XLlzAyJEj8dVXX8HW1harVq1CYWGhWjJURMnJySyuRKXA4kr0Eo6OjkhKStLJPUFfR1FREUJCQtCsWTNMnDgRgwYNKtkpQImvs19ET08P/v7+ePDgAUaPHq3WsZVSUFCAQYMGoXbt2li8eLHax3/jjTcwb948nD17Ft26dcO4cePQokULbqH1Cq5evYr09HQuFSAqBRZXopdwcnJCRkYGrl69KjuKVhBCYOfOnXBxccHgwYPh4eGBCxcuYMmSJa+9U8DrqFevHvz9/REcHIz169dLy1Fe/vOf/yAhIQFbtmxB5cqVpeWoX78+Vq5cifj4eFhZWcHb2xtdu3bFkSNHpGXSNsXf6PCMK9HLsbgSvUTxmwmXC7xcWFgYOnTogD59+sDGxganTp3CL7/8ojH3Xn/nnXcwefJkTJgwAcnJybLjvLLdu3dj4cKF+Omnn+Dg4CA7DgCgefPmCA0NRWRkJHJzc9GxY0f06tULCQkJsqNpvMTERNStWxdvvPGG7ChEGo/FleglqlWrhnr16vECrRf4888/4eXlhbfffhtVqlTB0aNHsW3bNo0pVU/69ttv0aJFC3h7eyMnJ0d2nDK7du0afH19MXDgQAwfPlx2nH/p0qULoqOjERYWhhs3bsDFxQU9e/bEqVOnZEfTWLxjFlHpsbgSlULxOld62unTp0v2Yn38+DEiIiIQFhaGNm3ayI72XAYGBti8eTNu3ryJjz/+WHacMikqKoKvry+qVauGVatWyY7zQl27dkVcXBz27duHq1evwsXFBd7e3jh//rzsaBqHW2ERlR6LK1EpFO85Sn9LTk6Gt7c3WrRogStXrmDnzp2Ijo7Gm2++KTtaqTRo0ADr16/HL7/8gsDAQNlxSm3mzJk4fPgwtmzZAnNzc9lxSqVr1644fvw4Nm/ejISEBDg4OMDX1xeXLl2SHU0jFBUVcUcBojJgcSUqBUdHRyQnJ6OoqEh2FKnS0tIwZswYODs748yZMwgODsaff/6Jnj17yo5WZu+++y4mTpyIsWPHIiUlRXacl4qIiMC8efOwePFitGzZUnacMineA/bMmTPYuHEjDh8+DHt7e96FC3//N5Wdnc0zrkSlxOJKVAqOjo7IycnR2bNEaWlpGDlyJJo2bYpDhw4hKCgIp06dwoABA6BSqWTHe2ULFy6Ek5MTvL298ejRI9lxnuv27dsYOnQo+vbtizFjxsiO88qKC2xycjIWLVqE33//Hba2tvjPf/6De/fuyY4nRWJiIlQqFZo1ayY7CpFWYHElKgVHR0eoVCqdW+d66dIljBo1Cra2toiIiMCaNWtK7nalzYW1mKGhIQIDA3HlyhVMmTJFdpxnKioqwrBhw1C5cmWsXr1adpxyYWRkhAkTJuD8+fOYOXMmVq9ejcaNG+Pzzz/XuQKblJSEhg0bokqVKrKjEGkFFleiUjAzM0OjRo10Zp3r5cuX4efnh2bNmmH//v346aefkJqaCl9fX7Xd7UpdrK2tsXr1aixbtgxBQUGy4/zL119/jaioKAQHB8PCwkJ2nHJVuXJlTJkyBWlpaZgzZw7Wrl0LKysr+Pn54ebNm7LjqQUvzCIqG5Xg7YBISxQUFCA3N1fa+AMGDECVKlWwZs0aaRleRqVSwdTU9JX//OXLl/H9999j5cqVqFOnDmbMmIEPP/wQBgYG5Ziy/D169Oi1bzfq5+eHbdu2ISYmBo0aNSqnZK8nJiYGPXr0wLx58/DRRx+91rEMDQ1hbGxcTsmUkZ2djV9++QXz589HRkYGRowYgRkzZqB27dqvfMysrKxyTFj+XF1d0bVrV8yePVtaBhMTkwr3gZQqrGQIIi2xbNkyAYC/XvDL0tLylf5tL126JEaPHi0MDAyElZWVWLlypcjPzy/nn6ByunTpIv3fXtN/jR07VvaPqdSysrLE4sWLRZ06dYSpqamYNGmSuHHjRpmPc/v2ben/7trwKzw8XIGfIpEikjT7NArRP1SpUkUjv87VBLt27UJwcHCZ/kxaWhrmzp2LtWvXokGDBli2bJlWnGF9lh49emDcuHGyY2ik6dOny45QJqampvDz88PIkSNLzsCuWbMGI0aMwPTp01GnTp0yHW/u3LlwdnZWKK32ysjIwODBg2XHICoT7Xt3Ip1maGiI7t27y46hkdLS0kr93NTUVMydOxcbN25EkyZNsHbtWgwZMkSrvy5s2LAh58ZzfPfdd7IjvJLiAjtq1CisWLECCxYswJo1azB27FhMnjwZtWrVKtVx2rdvDw8PD4XTap87d+7IjkBUZrw4i0iHnDp1CoMGDYKDgwNiY2Oxdu1aJCcnw8fHR6tLK1VslStXxmeffYaLFy9i9uzZCAwMROPGjTFx4kRcuXJFdjwiUiMWVyIdcPLkSXh7e6Nly5ZITk7GunXrkJiYyMJKWvF9iE0AACAASURBVKVy5cr49NNPcfnyZfz888/Ys2cPbGxs4Ovri9TUVNnxiEgNWFyJKrDo6Gj07NkTLi4uOH/+PIKDg5GQkFAht7Ui3WFkZARfX18kJyfjl19+QVxcHBwcHNCzZ08cP35cdjwiUhCLK1EFFB0dja5du8LNzQ0PHjzAzp07ceLEiQpz4wAi4O81776+vkhKSsKOHTtw48YNtG3bFj179kRsbKzseESkABZXogokPz8frVu3hru7O4yNjRETE1Ny1pWootLT00PPnj0RFxeHX3/9Fbdv30aHDh0wcOBA2dGIqJyxuBJVIEIING7cGMePH8euXbvg6uoqOxKR2qhUKvTu3RuxsbHYu3cv8vLyZEcionLG7bCIKhAjIyNs3bpVdgwi6d5++224uLigZs2asqMQUTniGVciIiIi0gosrkRERESkFVhciYiIiEgrsLgSERERkVZgcSUiIiIircDiSkRERERagcWViIiIiLQCiysRERERaQUWVyIiIiLSCiyuRERERKQVWFyJiIiISCuwuBIRERGRVmBxJSIiIiKtwOJKRERERFqBxZWIiIiItAKLKxERERFpBRZXIiIiItIKLK5EREREpBVYXImIiIhIK7C4EhEREZFWYHElIiIiIq3A4kpEREREWoHFlYiIiIi0AosrEREREWkFFlciIiIi0gosrkRERESkFVhciYiIiEgrsLgSERERkVZgcSUiIiIircDiSkRERERagcWViIiIiLQCiysRERERaQUWVyIiIiLSCiyuRERERKQVWFyJiIiISCuwuBIRERGRVmBxJSIiIiKtYCA7AFFZZWVlyY4AACgoKMCOHTvQv39/2VEAAI8fP5YdQaqCggKNmRsHDx6EjY0N6tWrJzsKAKCwsFB2BKlyc3M1Zm4EBQVh8ODBsmMAALKzs2VHICozFlfSKvfu3YO5ubnsGE/54IMPZEcoYWlpKTuCNKtXr8bq1atlx9BYzZs3lx1Bmu7du8uO8JTRo0fLjkCktVhcSWu8++67sLKykh2jxPfff48DBw7gl19+QZ06dWTHAQAYGRnJjiDF/Pnzce/ePdkxAAD5+fkYPHgwateujZ9++kl2nBKNGjWSHUHtLCwssGvXLtkxSsTFxWHWrFn44IMPNOabGgBo0aKF7AhEpaYSQgjZIYi0TW5uLiwtLZGTk4M5c+bgiy++kB2JNMSOHTvw3nvvAQBSU1Nha2srORFpiqFDh2LTpk1o1qwZkpOTZcch0kbJvDiL6BWEhobi0aNHAIB169ZJTkOaJDAwEAYGBjAyMkJQUJDsOKQhcnJysH37dgDAmTNnkJSUJDkRkXZicSV6BYGBgdDX1wcAXLx4EQkJCZITkSbIzMxEaGgoCgoKkJeXxw81VOK3334ruYDSyMgImzdvlpyISDuxuBKVUUZGBnbv3o2CggIAgKGhIc+sEYC/lwnk5+eX/P/Lly/j+PHjEhORpggMDISe3t9vuXl5eVi/fj24Uo+o7Fhcicpo27ZtJaUV+PtiHH9/f74JEQIDA6FSqUr+P5cLEAA8ePAA+/bte2pbsqtXr+Lo0aMSUxFpJxZXojIKCAh4qpwAwI0bN3D48GFJiUgT3L17FwcOHHiqnOTl5cHf31/n91HVdSEhISgqKnrqMX6oIXo1LK5EZXD79m0cPHjwX0WEywVoy5Ytz3z8zp07iI6OVnMa0iQBAQH/eqz4Q82T394Q0cuxuBKVwebNm0vWqT0pPz8fGzdu5JuQDgsICHjmchFDQ0Ns2rRJQiLSBNevX8fhw4f/dcYV+HsJQWRkpPpDEWkxFleiMnjR177p6enYv3+/mhORJvjrr78QGxv7zHKSn5+PoKAg5OXlSUhGsgUFBT3zwy7ADzVEr4LFlaiULl68iBMnTjz3Iiy+CemuoKCgku3RniUrKwv79u1TYyLSFC/6sJufn4/g4GDk5uaqORWR9mJxJSqloKAgGBg8/y7J+fn52Lp1a8mNCUh3vOwCLH19fWzcuFGNiUgTnD9/HqdOnXrhjiOPHj3C7t271ZiKSLuxuBKVUkBAwFN7dD7Lo0ePEBoaqqZEpAmK74L0onJSUFCAHTt2IDs7W43JSLZNmzY9d5lAMZVKxQ81RGXA4kpUCqdPn0Zqamqpnss74uiW0v68c3NzsXPnToXTkCYJCgp65rrnJxUVFWHXrl3IzMxUUyoi7aYS3DWd6JUsX74c//3vf3Hnzh3ZUUjDeHh4wMHBAcuWLZMdhTTInTt3ULNmTYSHh8PDw0N2HCJtlMwzrkRERESkFVhciYiIiEgrsLgSERERkVZgcSUiIiIircDiSkRERERagcWViIiIiLQCiysRERERaQUWVyIiIiLSCiyuRERERKQVWFyJiIiISCuwuBIRERGRVmBxJSIiIiKtwOJKRERERFqBxZWIiIiItAKLKxERERFpBRZXIiIiItIKLK5EREREpBVYXImIiIhIK7C4EhEREZFWYHElIiIiIq3A4kpEREREWoHFlYiIiIi0AosrEREREWkFFlciIiIi0gosrkRERESkFVhciYiIiEgrsLgSERERkVZgcSUiIiIircDiSkRERERagcWViIiIiLQCiysRERERaQUWV6Iyys7Oxu3bt3H37l0UFhbiypUrePDgAYqKimRHI8nS09Nx7do15OTk4OHDh7hx4wYyMzNlxyLJ8vPz8eDBA1y5cgUAcOPGDdy7dw+5ubmSkxFpH5UQQsgOQaQpioqKcOXKFaSmpiI1NRUpKSk4e/Yszp8/j4yMDKSnp+NF/8mYmJjA1NQU9evXh62tLezs7GBvbw87OzvY2trC3NxcjX8bKk+PHz9Gamoqzp49+9T8uHLlCrKzs5GVlfXCP29hYQFTU1NYW1uXzIfi+dGkSRMYGBio6W9C5e3evXtPvV4Uz5MbN24gOzsbeXl5z/2z+vr6qFKlCqpXrw4bG5unXi/s7e1Rp04dNf5NiDReMosr6byUlBSEh4cjIiICkZGRuHv3LgCgRo0aJW8iTZs2RdWqVVG1alWYmprC1NQU5ubmMDQ0RE5ODrKyspCeno7s7GxkZ2fjypUrOHv2LFJSUnDhwgXk5eVBX18fLVu2hIeHBzw9PeHm5gYzMzPJf3t6nry8PBw5cgTh4eEIDw9HbGxsyc/RysqqpFg0adIEpqamMDMze2p+FBYWlsyHzMxMPHz4EFlZWTh79mzJr7/++gsAYGZmBjc3N3h6esLDwwMuLi7Q0+MXYprq7t27iIyMREREBMLDw5GSkgIAqFy5MmxtbUs+lNSrV++p1wsLCwsYGxsjPz//qdeLzMxM3L59+6kPRQ8fPgQANGjQAB4eHvDy8oKHhwcaNGgg869OJBuLK+mewsJCHDhwAJs2bcK+fftw48YNVKlSBe7u7vD09ESHDh1gb2+PatWqlct4BQUFSEtLw6lTpxAZGYnw8HAkJSXBwMAA7du3R58+fTBkyBDUrVu3XMajV5eeno6QkBCEhIQgJiYGOTk5sLKyeqpQ2tjYwNjYuFzGKy6ycXFxiIiIQEREBG7fvo1q1arBw8MDgwYNQs+ePVGpUqVyGY9eXWpqKgICAhAaGorTp09DpVKhdevW8PT0hLu7OxwcHNCwYUOoVKpyGe/WrVtITk5GdHQ0IiIi8OeffyI3NxdNmzZFt27dMGzYMLRr165cxiLSIiyupDsSExPh7++PjRs34vr16+jYsSN69uwJDw8PtGnTRq1f1d66dQvh4eHYv38/fv31V2RkZKBr167w8fHBe++9h8qVK6sti64rKCjAnj17EBAQgJ07d0KlUqFnz554++234enpicaNG6stixACiYmJCA8Px+7du7F//36Ym5vD29sbPj4+6NSpU7kVI3q5e/fuYfPmzQgICEBsbCzq16+Pfv36wcvLC+7u7rCwsFBblkePHuHw4cOIiIjA9u3bcebMGdjb22PYsGHw8fFBw4YN1ZaFSKJkCKIKrKCgQAQFBYnWrVsLAMLKykp8+eWX4uzZs7KjlcjNzRUhISGiV69ewtDQUJibm4tx48aJtLQ02dEqtLt374qZM2eKmjVrCpVKJdzd3cUvv/wi0tPTZUcrcf36dbFw4ULh7OwsAAhra2uxdOlSkZOTIztahRYfHy+8vb2FkZGRMDMzE76+viIsLEwUFhbKjlbi6NGjYuLEiaJGjRpCT09PdO3aVezfv192LCKlJbG4UoX0+PFjsWbNGtG0aVOhr68vBg0aJA4ePCiKiopkR3uh27dvi8WLFwsrKythaGgohg8fLlJTU2XHqlCuX78uJk+eLMzMzISlpaWYOXOmuHTpkuxYL5WQkCDGjx8vTExMRK1atcR3330nMjIyZMeqUGJiYkSPHj2ESqUSLVu2FBs2bBBZWVmyY71QXl6e+O2330TXrl0FANGhQwexc+dOjX+tI3pFLK5UsRQUFIjly5eLhg0bCiMjIzFixAiNOrtaWnl5eWL9+vXCzs5O6OnpiYEDB7LAvqabN2+KcePGiUqVKok6deqIhQsXiszMTNmxyuzmzZti6tSpwtzcXLzxxhviq6++EtnZ2bJjabXo6Gjh4eEhAAhXV1exa9curSx+R44cEb169RIqlUq0aNFC/Prrr7IjEZU3FleqOA4fPixatmwpjI2NxcSJE8WVK1dkR3pthYWFIjg4WDRv3lwYGxuLL774gl8Tl1FBQYFYunSpqFq1qmjYsKFYvny5ePTokexYr+3evXti1qxZomrVqqJRo0Zix44dsiNpndu3b4vhw4cLlUolPD09RUREhOxI5SIhIUF4e3sLlUolunXrJs6dOyc7ElF5YXEl7Xf//n0xadIkoaenJ958802RlJQkO1K5KywsFCtXrhQWFhaifv36IiQkRHYkrXD8+HHRvn17YWhoKCZNmqSVZ1hf5ubNm8LHx0eoVCrh5eUlUlJSZEfSeEVFRWLDhg2ievXqom7dumLDhg2yIyni0KFDonnz5sLQ0FBMmzatQnxgI53H4krabdOmTcLS0lLUrVtXbN68WXYcxV2/fl0MGTJEABB9+vQRt2/flh1JI+Xk5Ijx48cLPT094eHhIc6cOSM7kuIiIyOFo6OjMDExEfPnz9fKr7rVISUlRbRr104YGhqKyZMnV8gPM0/Kz88XixYtEubm5sLa2lpERUXJjkT0OlhcSTvl5OSIUaNGCZVKJSZMmKBzF6kcOHBAWFlZiXr16omDBw/KjqNRzpw5I5ydnUW1atVEYGCg7DhqlZeXJ+bOnSuMjIxEt27d+MHmHwIDA4WZmZlo166dSExMlB1Hra5evSp69eolDAwMxLfffqtROyQQlQGLK2mflJQU0aJFC1GlShWxZcsW2XGkefjwoRgwYIDQ19cX//3vf/lGJIQICAgQZmZmok2bNuLChQuy40gTFxcnmjRpImrVqiXCwsJkx5Hu0aNHYtKkSQKAGD16tHj8+LHsSNKsXLlSGBkZCU9PT3Hjxg3ZcYjKisWVtMvGjRuFmZmZaN++vVZsYaS0oqIi8cMPPwgjIyPx9ttvi3v37smOJEVubq748MMPhUqlEp988olOF5Ni9+/fF3369Ck5w6arUlNThZOTk6hWrRovYPs/sbGxwsrKStStW1ccOnRIdhyismBxJe3x3XffCZVKJfz8/FhM/uHo0aOiYcOGwsHBoULsplAWGRkZwsvLS1hYWIjffvtNdhyNUvzBxsDAQIwePVoUFBTIjqRWR48eFTVq1BBt27blDT3+4f79+6JXr16iUqVK3DaLtAmLK2m+oqIiMXXqVKFSqcSCBQtkx9FY169fFy1atBB169YVCQkJsuOoxd27d0WHDh1ErVq1xIkTJ2TH0Vg7d+4UJiYmonfv3jqzndqBAwdElSpVhJeXl86tgS+tgoIC8dFHHwl9fX3x888/y45DVBpJejJvOEv0MoWFhRg1ahS+//57rFmzBpMnT5YdSWPVqVMHkZGRsLa2xptvvomYmBjZkRSVlpYGV1dX3Lp1C4cOHYKLi4vsSBqrZ8+eiIiIQHR0NN555x08fPhQdiRF/frrr+jRowfeffdd7N69G+bm5rIjaSR9fX2sWLEC33zzDT766CNMnz5ddiSil2JxJY1VUFCAfv36YfPmzQgNDcUHH3wgO5LGq1q1Kvbu3Qs3Nzf8z//8D6KiomRHUsSFCxfQqVMnmJqa4s8//0TTpk1lR9J47du3R2RkJM6fPw9PT88KW17XrVuH/v3746OPPkJgYCAMDQ1lR9J406ZNw/Lly7Fw4UKWV9J4KiGEkB2C6J+EEBgxYgSCg4MRFhYGV1dX2ZG0SkFBAQYPHoz9+/fj4MGDcHZ2lh2p3Ny6dQudOnVCtWrVcODAAVSpUkV2JK2SlpaGzp07w8bGBnv27EGlSpVkRyo3O3fuRL9+/TB16lR88803suNoncDAQLz//vv47rvv8Nlnn8mOQ/QsySyupJGmTZuGH374ATt27ED37t1lx9FKeXl56NmzJ06ePIno6OgKcVYyIyMDHh4eyMjIQHR0NGrVqiU7klZKSkqCu7s7OnfujG3btsHAwEB2pNd25MgRdO3aFUOHDsXKlStlx9Fay5cvx4QJE7BmzRp+y0WaiMWVNM9PP/2ESZMmYe3atRg+fLjsOFotMzMTb775Jh4+fIjo6GjUrl1bdqRXlpeXh3fffRdJSUmIiYmBlZWV7EhaLTY2Fl5eXujXrx/Wr18PlUolO9IrS0xMhLu7O9zc3CpMEZdpxowZWLBgAUJCQvDee+/JjkP0JBZX0izbt29H//79sWjRInzyySey41QIxV+tW1pa4tChQzAyMpId6ZUMHToUu3fvxsGDB9G8eXPZcSqE4q/WZ8+ejRkzZsiO80pu3bqF1q1bw9bWFn/88UeFWvogy5NLtQ4fPowWLVrIjkRUjMWVNMelS5fQqlUrDBo0CCtWrJAdp0JJTU1FmzZtMGLECCxevFh2nDJbtWoVxo4diz179uCtt96SHadCWbx4MaZMmYIDBw7A3d1ddpwyKSoqQrdu3XDx4kUcP34cFhYWsiNVGAUFBfDy8sKtW7dw7NgxmJmZyY5EBLC4kqbIz89Hly5dkJWVhdjYWJiYmMiOVOEEBwdj8ODB2LZtm1Z9/ZeYmIh27dph8uTJmD17tuw4FY4QAv369cPRo0cRHx+PGjVqyI5Ual9//TVmz56NqKgodOjQQXacCufmzZtwcXFBly5dsHnzZtlxiAAWV9IUH3/8MdasWYO4uDjY29vLjlNhjRo1Clu3bsWJEyfQuHFj2XFeKisrC+3atUONGjUQHh4OfX192ZEqpPT0dLRq1Qp2dnbYtWsX9PQ0f6fEqKgoeHl54fvvv8fEiRNlx6mw9uzZgx49emDVqlUYMWKE7DhELK4k386dO9GnTx9s3LgRgwcPlh2nQnv06BHat28PU1NTREdHa3wR9PX1xd69exEfH4+6devKjlOhxcbGws3NDd988w2mTJkiO84L3bt3D87OzujQoQO2bt2q1ReWaYP//Oc/WLJkCeLi4uDg4CA7Duk2FleSKysrC82aNYOnpyc2bNggO45OSE5OhouLCxYuXKjRZ6rCwsLw9ttv4/fff8e7774rO45OmDt3LubMmYOkpCSNPiM/evRo7Nq1C0lJSahatarsOBVeQUEBXF1dYWJigsjISH5QIJlYXEmuKVOmYM2aNUhJSUHNmjVlx9EZn3/+OX766SecOXNGI89k5uXloUWLFnBwcMC2bdtkx9EZBQUFaNWqFerVq4fdu3fLjvNMcXFx6NChAzZu3IhBgwbJjqMzjh8/jvbt22Pt2rXw9fWVHYd0F4sryZOUlAQXFxcsXboUY8aMkR1Hpzx69AiOjo5wdXVFYGCg7Dj/MmfOHMybNw9JSUncr1XNDh06hC5duuDXX39F7969Zcd5SmFhIdq2bQtLS0uEhYXJjqNzJkyYgJCQEKSkpKBatWqy45BuYnElOYQQ8PT0LNlFQBsuBqlodu/eje7du+PAgQPw9PSUHafElStX4ODggJkzZ2Lq1Kmy4+gkHx8fREVFITk5GaamprLjlPjxxx8xZcoUJCQk8CJOCTIyMmBvb4/33nsPy5Ytkx2HdBOLK8kREhKCwYMHIzY2Fq1bt5YdR2f17t0bly5dQkJCgsasW/P29kZSUhJOnjwJQ0ND2XF00s2bN2Fvb4/PPvsMX375pew4AP7e+aBx48YYN24cvvnmG9lxdFZAQAA++OADJCQkwNHRUXYc0j0sriRH8Z1ugoKCZEfRaWfOnIGTkxO2b9+uEV8Lp6SkwNHRESEhIejbt6/sODpt1qxZWLp0KdLS0mBubi47DubMmYNFixbh8uXLvNGAREIItGjRAs7Ozhq5zIgqvGR+P0tqFxoaivj4eH4NrAGaNWuGXr16Yfbs2dCEz7Bz586FnZ0d+vTpIzuKzps0aRLy8/Px888/y46C7OxsLF26FH5+fiytkqlUKkyfPh2bN2/GuXPnZMchHcQzrqR2nTt3hqWlJX777TfZUQhAfHw8WrdujT179uDtt9+WluPKlSuwsbHB2rVrMWzYMGk56P9NmzYNGzZswKVLl6Teze7777/HzJkzkZaWhurVq0vLQX8rLCyEg4MD3N3dsXr1atlxSLdwqQCpV3h4OLy8vBATEwNXV1fZcej/dOvWDY8ePcLBgwelZRg7diz27duH1NRUGBgYSMtB/+/WrVto3LgxFixYgPHjx0vJ8PjxY1hbW2Pw4MFYsGCBlAz0b2vWrMHYsWNx7tw5NGrUSHYc0h0srqRePXv2RE5ODg4cOCA7Cj0hKioKXbp0wbFjx6RcLJeeno46derghx9+wEcffaT28en5JkyYgD179uDcuXNSLuDz9/fH6NGjcenSJdSpU0ft49Oz5eXlwdraGkOHDsW8efNkxyHdwTWupD63b9/G3r17MWrUKNlR6B/c3d1hb2+PgIAAKeMHBwdDpVLxlr8aaOTIkbhw4QIOHz4sZXx/f3/06NGDpVXDGBkZ4f3330dgYCAKCwtlxyEdwuJKarNp0yaYmJigV69esqPQMwwdOhSbNm1Cfn6+2scOCAjAe++9xwtvNFDLli3h7Ows5UPNtWvXEBkZCR8fH7WPTS/3/vvvl/yMiNSFxZXUJiAgAAMGDEDlypVlR6Fn8PHxwd27d7F37161jlt8No/lRHMNGzYMW7ZswePHj9U6rr+/PywsLPDOO++odVwqnaZNm6Jt27bSvqkh3cTiSmqRnJyMEydOsJxosEaNGsHNzU3tb0IBAQGoWbMmunbtqtZxqfSGDh2KjIwMhIaGqnXcTZs2YciQITA2NlbruFR6Pj4+2Lp1K7KysmRHIR3B4kpqERQUhIYNG8LNzU12FHoBHx8f7Ny5Ezk5OWobMzg4GEOHDuVOAhqsbt268PT0xObNm9U25qlTp5CYmIihQ4eqbUwqu8GDByMvLw9//PGH7CikI1hcSS0OHDiAd955B3p6nHKarHv37sjNzUVMTIxaxrt+/TpSUlL4VbAW6NatG8LDw1FUVKSW8fbv3w9LS0u0a9dOLePRq6levTratGnDnWJIbdgiSHGZmZk4duwYPDw8ZEehl6hbty5sbW0RERGhlvH2798PIyMj7umrBby8vHD//n0kJCSoZbyIiAh4eHjww64W8PT0RHh4uOwYpCP4ikCKi4qKQkFBAd58803ZUagUvLy81PYmFBERAVdXV16wpwWcnZ1Ro0YNtcyNwsJCREdH88OulvD09MT58+dx+fJl2VFIB7C4kuIiIiLg5OSEWrVqyY5CpeDh4YFjx44hPT1d8bGKz6qR5lOpVHjzzTfVcja+eP5xbmgHV1dXmJiYqO2bGtJtLK6kuMjISL4BaREPDw8IIRAdHa3oOBcvXsTly5fh6emp6DhUfjw9PREVFaX4hvORkZGoU6cO7O3tFR2HykelSpXQsWNHFldSCxZXUlRhYSGSkpLQtm1b2VGolKpXr45GjRrh1KlTio6TkJAAPT09tGrVStFxqPy0adMGmZmZuHTpkqLjJCQkoE2bNlJuMUuvpk2bNoq/ZhABLK6ksLS0NOTm5sLOzk52FCoDOzs7pKamKjpGamoqGjRowPWtWsTOzg4qlUotc4OvGdrFzs4OZ8+eVduuE6S7WFxJUcVvcE2bNpWcpHx07doVVatWlR1DceoqrhWpnOjC3DA3N0ft2rUVnRtCCJw7d45zQ8vY2dkhJycH165dkx2FKjgWV1JUSkoK6tSpU+FftCsadRVXrmHUPvb29orOjWvXriEzM7NCFVddUPzfckpKiuQkVNGxuJKitPms2tWrV6FSqZCWllby2P79+5+62v5Zz6kI7O3tkZ6ejlu3bik2BueGdrKzs1O0nBSXYm39UKOrc8PS0hKWlpaKf+AlYnElRaWlpaFJkyayY7ySyMjIcnmONrK2tgbw95X/Snj48CHu37/PuaGFrK2tFb04Ky0tDebm5qhRo4ZiYyhJl+eGjY2N4hfuEbG4kqIePnyolmUCS5cuha2tLYyNjdG4cWN8++232LFjB1QqFXbu3PnUc0+ePIk+ffrA0tISxsbGaNKkCSZPnoyHDx+WPKdbt27w8fEBADRu3BiVKlUC8PRatec9p7RjAH/fYtXGxganTp2Ch4cHzMzMUK1aNfj4+CAzMxPBwcFo2bIlKleujCZNmuDHH38s/3+8Zyj+O2ZmZipy/IyMjKfGURLnRvmqWrVqyc9PCQ8fPoSFhYVix38S50b5srCwUHRuEAEABJGCHB0dxX//+19Fx1i+fLkAID799FNx7do1cenSJTFkyBDRrFkzAUDs3r275LlxcXHCxMRE9OzZU6SkpIjMzEzx+++/i5o1a4p27dqJ/Pz8kud+9tlnAoC4dOlSyWNeXl7CwsLihc8pyxi9e/cWFhYWolOnTuLIkSMiMzNTfPfddwKA6NKli/if//kfcfHiRfHgfSwoRgAAIABJREFUwQMxbNgwAUAcOXJEmX/IJxQWFgqVSiW2bt2qyPGTkpIEAJGYmKjI8YtxbpS/zZs3C319fVFUVKTI8WfNmiWaNWumyLGfxLlR/vr16ycGDhyo+Dik05JYXElRDRs2FAsWLFB0jCZNmggrKytRWFhY8lheXp6wsrL61xuQm5ubqFevnsjNzX3qGGvWrBEAxMaNG0see9U3oLKM0bt3bwFAhIaGljyWn58vzMzMhKGhobh+/XrJ46dPnxYAxLfffluGf51XZ2pqKtatW6fIsWNjYwUAkZaWpsjxi3FulL/Q0FABQGRnZyty/MmTJ4t27dopcuwncW6Uv+HDh4vu3bsrPg7ptCQuFSBFZWZmwtzcXLHjZ2Rk4OLFi3Bzc4Oe3v9PZ0NDQ/Tt2/dfz42JiYGHhweMjY2f+r1u3boBAGJjY187z6uM0blz55L/bWBggDfeeANWVlaoU6dOyePFt8y9efPma2UsLTMzM8WWChQfl3Pj5WNo2two/pkpOTfMzMwUOXYxzg1lKPmaQVSMxZUUlZWVpeibUPGLcc2aNf/1e//cO/b69esoKipCYGAgVCrVU7/q1asHAPjrr79eK8+rjKGvr/+vNX0qlQpvvPHGvx4DoPjtNouZm5srXlw5N7RvbihdXLOyshT9QANwbihFydcMomIsrqQoIcRTZzTK26NHjwD8/4vzk553u8iRI0dCCPHMX9u3by+XXOoYQ2n6+vqKvdkJIQCAc0ML54a+vj4A5YpQUVGR4rd65dxQhpKvGUTFWFxJUaampsjKylLs+NWrVwcA3Lt371+/98+tnOrXrw89PT1cvnxZsTzqGENdlFzmUXymlXND+yi9zMPMzEzReQFwbiglMzMTVapUkR2DKjgWV1KU0l8d1atXD7Vr18aRI0eeejw/Px9bt2596jEzMzO4ubkhMjLyX+u9Dh06BAcHBxw7dqzkseKzgcVnB5/ln88p6xiaTMk3IaW/bgY4N5RS/DNTcm4oXVw5N5Sh9DUNRACLKylMHW9CY8eOxZkzZzBjxgzcuXMHly9fxqBBg565F+T8+fOhr6+Pd999FykpKcjNzUVkZCR8fX1hbGwMJyenkucWry2LjY1Fbm4uCgoK/nW8Zz2nLGNoKiEEsrOztfqMK8C5oYTMzEzo6emhcuXKihxfXeskOTfKH4srqQOLKylKHVeZfv7555gxYwb8/f3RoEEDdOvWDV5eXpg0aRKAp9estW/fHjExMahfvz46deoEc3Nz+Pj4oF+/fjhw4MBTm4H7+PjAzc0Nvr6+qF+/Pq5fv/6vsZ/1nLKMoamys7NRVFSk2JuQOs64ApwbSsjMzISpqali65PVdWU650b5Y3EltVBkly2i/+Pl5SVGjx4tZeyFCxcKAOLw4cNSxtdm165dEwDEoUOHFDn+vXv3BAARFhamyPFfhnPj1f3www+ibt26ih1/5cqVomrVqood/2U4N16dq6ur8PPzkx2DKjbu40rKatCgAdLS0hQdY8OGDRg6dChyc3OfejwuLg5GRkZwdHRUdPyKqPh+440aNVLk+NWqVYO5uTnnhha6dOkSGjZsqNjxGzRogPT0dKSnpys2BsC5oQSl5wYRwKUCpDA7OzukpqYqOoaFhQWCgoIwbtw43Lx5ExkZGVi9ejVCQkIwbtw4XuX6ClJSUmBqaor69esrcnyVSgVbW1vODS2UmpoKe3t7xY5vZ2dXMo6SODfKV0ZGBm7evFny8yNSCosrKcre3h5XrlxBTk6OYmP06dMH27dvL3lDrVGjBhYvXox58+Zh0aJFio1bkaWmpsLW1lbR/TTt7OyQkpKi2PEBzg0lpKSkKFpOrKysUKlSJcWLK+dG+UpNTYUQQtEPNUQAYCA7AFVsdnZ2EELg3LlzaNGihWLj9OnTB3369FHs+LomNTVV8TMndnZ2CAwMVHQMgHOjPD169Ah//fWXonNDT08PNjY2ihdXgHOjPKWmpsLIyEix5UVExXjGlRRlbW0NAwMDtbwJUflRV3G9dOkS8vLyFB2Hys+5c+dQVFSklrnB1wztkpqaChsbGxgY8HwYKYvFlRRlZGQEW1tbxMfHy45CpZSZmYkLFy4ofnGKk5MTCgoKkJiYqOg4VH5OnjyJSpUqwdraWtFxnJyc+JqhZU6ePKkVe82S9mNxJcV16dIFERERsmNQKUVFRaGwsBDu7u6KjuPg4IBatWohPDxc0XGo/ISHh6Njx44wNjZWdJwuXbrg4sWLWn8LVF1RUFCAqKgodOnSRXYU0gEsrqQ4Dw8PHDt2TPHtbah8REREwMnJCbVq1VJ0HJVKxQ81WiYyMhIeHh6Kj+Pq6goTExPODS1x7NgxZGRkwNPTU3YU0gEsrqQ4T09PCCFw6NAh2VGoFMLDw9X2BuTh4YGoqCjk5+erZTx6defOncPly5fVMjeMjY3RsWNHFlctER4ejjp16nBHAVILFldSnKWlJZo3b843IS1w//59JCQkqK24enp6IisrC3FxcWoZj15deHg4zMzM0K5dO7WM5+Hhgf3796tlLHo9ERER8PLykh2DdASLK6mFp6cn9u7dKzsGvURYWBj09PQUX99azNbWFg0aNODc0AL79u2Dm5sbDA0N1TKel5cXrl+/jqSkJLWMR68mKysLMTExXCZAasPiSmrRv39/JCcn80phDRcYGIiuXbuiatWqahuzf//+2LRpE4QQahuTyubhw4fYvXs3BgwYoLYx27dvjwYNGmDTpk1qG5PKbvv27SgsLETPnj1lRyEdweJKauHq6go7OzsEBATIjkLPcefOHezduxc+Pj5qHdfHxwfnz5/HkSNH1DoulV5wcDAAoG/fvmobU09PD8OGDcOGDRtQVFSktnGpbAICAtCjRw9Ur15ddhTSESyupDZDhgzBxo0bUVBQIDsKPUNQUBCMjY3Ru3dvtY7r4uKC5s2b80ONBgsICECfPn1gYWGh1nF9fHxw7do1HDx4UK3jUulcv34dERERav+wS7qNxZXUxtfXF3fu3MG+fftkR6FnCAgIQP/+/WFqaqr2sYcNG4bNmzfj8ePHah+bXiwtLQ0xMTFSykmzZs3Qpk0bfqjRUIGBgahSpQq6d+8uOwrpEBZXUhsrKyt07twZa9eulR2F/uH06dM4duyYtDMnw4YNQ0ZGBnbs2CFlfHq+tWvXombNmnjrrbekjO/r64utW7fi4cOHUsanZxNCYP369Rg4cKDiN6QgehKLK6nVxIkTsWPHDt6HXMPMmzcPDg4OePPNN6WMX7duXfTt2xfz5s3jRVoaJCsrCytWrMDYsWOl3YP+/fffh76+PpYvXy5lfHq2HTt2ICUlBePGjZMdhXSMSvBdgtSoqKgIzs7OaNu2LdatWyc7DgG4cOEC7O3t4e/vj8GDB0vLkZCQABcXF4SGhvKrRw0xf/58fPvtt0hLS0O1atWk5fj888+xcuVKpKWlwczMTFoO+n/t2rVDgwYNsG3bNtlRSLck84wrqZWenh6mTJmCjRs3Ii0tTXYcAjB37lw0atRIrVsdPUuLFi3QvXt3zJkzR2oO+ltubi6WLFmCcePGSS2tAPDpp5/i8ePHWLNmjdQc9Lc9e/YgLi4OM2bMkB2FdBDPuJLa5efnw87ODu+88w6WLVsmO45O++uvv2BjY4MVK1bgww8/lB0HsbGx6NChAyIiIqQtW6C//fjjj5g2bRouXryIOnXqyI6DTz75BFu3bsX58+e5plIyd3d3mJmZ4Y8//pAdhXRPMosrSfHzzz/jk08+QVJSEpo0aSI7js4aOXIk9u/fj3Pnzqntjkgv4+XlhcePH+PQoUNQqVSy4+ikzMxM2NvbY8CAAVi8eLHsOACAa9euwdraGvPnz4efn5/sODpr79696NatG6Kjo9GpUyfZcUj3sLiSHAUFBWjdujXq1KmDPXv2yI6jk+Li4tChQwds2rQJAwcOlB2nxIkTJ9CuXTusWbMG77//vuw4Oumzzz7D+vXrkZKSgho1asiOU+KLL77A0qVLcebMGdStW1d2HJ2Tl5cHZ2dnNG/eHCEhIbLjkG5icSV5oqOj4e7uju3bt6NPnz6y4+iUwsJCtG3bFpaWlggLC5Md518mTpyIoKAgpKamwtLSUnYcnZKUlAQXFxcsW7YMo0aNkh3nKY8ePYKjoyNcXV0RGBgoO47OmT17NubPn4/k5GQ0atRIdhzSTSyuJJePjw8OHjyIM2fOSNn4Xlf9+OOPmDJlChISEmBvby87zr9kZGTA3t4effr04TZIaiSEgKenJ7KyshAbGws9Pc27fnfnzp3o3bs3Dhw4AE9PT9lxdMbly5fh4OCAWbNmYcqUKbLjkO5icSW5bt26BXt7e4wZMwbz5s2THUcn3LhxA82aNcP48ePxzTffyI7zXIGBgXj//fdx5MgRtG3bVnYcnbB+/XqMHDkSR48eRatWrWTHea5evXrh/PnziI+P54VaavLuu+8iLS0N8fHxGrMennQSiyvJt3LlSowfPx779+/nleQKKyoqwttvv43Lly8jISEBlStXlh3puYQQeOutt3DlyhUcP34c5ubmsiNVaBcuXEDr1q3xwQcf4IcffpAd54XS0tLg7OyMDz74AEuWLJEdp8JbsWIFJk6ciIiICLi5ucmOQ7qNxZU0Q79+/RATE4OTJ0+idu3asuNUWF999RXmzp2LmJgYtG7dWnacl7p16xZatmwJd3d3BAcHy45TYT1+/BidOnVCfn4+jhw5AhMTE9mRXmrLli0YNGgQtm7dir59+8qOU2GdOnUKHTp0wNSpUzFr1izZcYhYXEkzpKeno3Xr1mjUqBHCwsKgr68vO1KFc/DgQXh5eWHx4sWYMGGC7DilFhERgbfeegvLly/H6NGjZcepkCZMmIANGzbg2LFjsLOzkx2n1MaMGYMtW7bgxIkTaNy4sew4FU5WVhbatGmD2rVr48CBA3xdJk3A4kqa49ixY+jUqRNmzpyJzz//XHacCuX27dtwcXFBx44dsXXrVtlxyuyLL77AokWLcPjwYbi4uMiOU6Fs3boVAwYMQGBgIIYOHSo7Tpnk5ubC1dUVBgYGiI6OhpGRkexIFcqwYcMQFhaG+Ph4bj9GmoLFlTTLkiVL8Nlnn2HLli38+q+c5OTkoGvXrrh16xaOHz+OqlWryo5UZoWFhfDy8sLly5cRExPDN9FycuzYMXh6emLo0KFYsWKF7DivJDU1FW3btkXv3r3h7+/Pm1aUk6+//hqzZs3C7t278dZbb8mOQ1SMxZU0z8cff4wVK1YgNDSUL5ivqbCwEP3798ehQ4cQHR2tkVtflda9e/fg5uYGPT09REVF4Y033pAdSatduHABnTp1gpOTE3bt2qXVV+eHh4eje/fuGDlyJH766SfZcbTe6tWrMXr0aCxZsgSTJk2SHYfoSSyupHmKioowePBg7NmzB5GRkfxq+BUlJibCz88PR44cQVhYGFxdXWVHem1Xr15Fp06dULduXezfv597/76i27dvo3PnzqhatSrCw8NhZmYmO9Jr27x5M4YOHYq+ffti+fLlGnXHL23y+++/o2/fvvj88895MRZpomTN212adJ6enh78/f3Rpk0bdO/eHRcvXpQdSSv5+/sjIiIC5ubmiI+PR3Z2tuxIr61+/fr4448/cPbs/7J353FRlYsbwJ8ZhhlZBAREcWNREcOtNE0QFELFygUXNLdMTUsry8xuq7Zcr2allUsaaSqKolmKCu4LuACa4gqWuKOGCgwYO+/vj3vll7nEsL1zZp7v5zOfz+0wzDznvePMwzvvOecshg4diuLiYtmRFCc7Oxs9evSAWq3G5s2bTaK0ZmRk4OzZs7CyssK6deuwZcsW2ZEUKS4uDoMHD8aYMWNYWsl4CSIjlZ2dLZ544gnRqFEjcfLkSdlxFKO0tFS8+eabQq1Wi9dff10AEABE7dq1xbvvvivS09NlR6y0/fv3C2tra9G3b1/x559/yo6jGNevXxdPPPGEaNiwoTh//rzsOJWWkpIixo0bJ7RarQAgVCqVGDt2rLCwsBDfffed7HiKsnXrVmFraysGDBggiouLZcchephTLK5k1DIzM4W/v7+oU6eOiIuLkx3H6BUVFYnRo0cLrVYrVq1aJUpLS0W7du2EWq0WAISlpaXQaDRiwIABIjExUXbcSklISBDOzs7iqaeeEjdv3pQdx+ilpaWJ5s2bCw8PD3H27FnZcSolLi5ODBgwQKjVamFpaSkACI1GI4YMGSKEEGLmzJkCgHjnnXckJ1WGdevWCZ1OJ4YNGyYKCwtlxyF6FBZXMn75+fli4MCBQqfTiZ9++kl2HKOVm5srevXqJWxsbERMTEzZ9ujo6LJZ17s3jUYjAIhOnTqJjRs3itLSUonJK+7UqVOicePGwsfHR1y+fFl2HKN1/Phx0bBhQ9G+fXtx48YN2XEqpLi4WGzcuFG0b9/+ntfw3ZtarRZnzpwpu//SpUuFRqMREyZMECUlJRKTG7dvvvmm7NsZjhMpAIsrKUNRUZEYM2aM0Gg0YsGCBbLjGJ3Lly+LJ598UtStW1ckJSXd9/Mnn3zyvg/6v374u7u7i7lz5yrya/eLFy8Kb29v4e7uLo4dOyY7jtHZtGmTsLOzE8HBwUKv18uOYzC9Xi/mzp0rGjRoIFQqlbCwsLjvdWxpaSlGjRp13+/+9NNPQqfTiQEDBihy36tTUVGRmDx5slCpVGL27Nmy4xCVF4srKUdpaamYPn26UKvVYsiQIfwg+p/NmzcLZ2dn0bJly4d+Bbxjx477Puz/elOpVEKtVgtHR0fxySefiIyMjBrei8rJyMgQXbt2FbVq1eLaxv8pKioSU6dOFSqVSrzwwguioKBAdiSDpKWliUmTJglra+sH/tH19z/AHrZmd8+ePcLFxUV4eXmJo0eP1uxOGKlLly4JPz8/YW1tLSIiImTHITIEiyspz65du4Srq6to3ry5WX8QFRUViWnTpgm1Wi1GjBghcnJyHnl/f3//fywAd2/Dhg2rob2oOsXFxWLatGnCwsJC9O/fX2RmZsqOJM3ly5dFly5dRK1atcTcuXNlxzFYYWGh6NixY7leq5aWluLll19+5OPduHFDdO/eXeh0OkWOR1Xavn27qFevnmjRooVITk6WHYfIUCyupEzp6ekiMDBQ1KpVS3zzzTdmtzbr999/F76+vsLa2losWbKkXL8THx9frhIQGBgo8vPzq3kPqs+2bdtEvXr1RPPmzUVCQoLsODVu/fr1wsnJSTz22GOKPhtHRkaG8PLyKjv46lGv2fKsby4uLhYffvihUKvVYvDgwWZ3QN+ff/4ppkyZUjYDn5ubKzsSUUWwuJJy3Z1hs7S0FB07dhSHDx+WHana5eXlienTp4tatWqJ1q1bG1xMunfv/tBZV0tLS/Hkk0/+48ytEqSnp4vg4GChVqvFyy+/LG7fvi07UrVLS0sTzz33nFCpVGL06NEmUUxu3LghPDw8HlpeLS0txeTJkw16zB07dogGDRoIJycnER4ertgDEw2xadMm4enpKezs7MTSpUtlxyGqDBZXUr7U1NSykjJixAiTnUnZuXOn8Pb2FtbW1mLatGkVWrN4+PBhoVKpHlgAvL29Ta7gbdy4UTRq1Eg4OjqKuXPnmuTMfGFhoZg7d66wtbUVXl5eYuvWrbIjValLly6JevXqPfAPrlq1aonr168b/Ji5ubli2rRpQqvVivbt2yv+1HAPc+XKFTFixAgBQDz33HPi0qVLsiMRVRaLK5mG0tJSsWzZMuHi4iLq1asn5s2bJ/Ly8mTHqhLHjh0T/fr1EwDEoEGDKn3apz59+twzg2VpaSkaN24srK2txQ8//FBFqY1HVlaWeO2114SFhYXw8/MTu3btkh2pShQXF4vIyEjh5eUlbGxsxKxZs0zuHJylpaVi6tSpom7dusLJyeme8mppaSnef//9Sj1+cnKy8PX1FRqNRrzyyivi4sWLVZRcrlu3bomPPvpIWFtbixYtWogdO3bIjkRUVVhcybRkZmaKSZMmCSsrK1G/fn0xe/ZsxX71fejQIdG7d2+hUqlEu3btqmwm7eTJk2WzrhqNRjRp0kRcvXpVzJw5U6hUKvHll19WyfMYm19//VU8/fTTAoDw9fUVmzZtUuTXxIWFhWLp0qXCy8tLWFhYiKFDh5rkTFppaamYNGmSsLCwEEuXLhXJycnCzs6u7HRYNjY24tatW1XyPEuWLBFubm5Cq9WK0aNHK/YCDdevXxdTp04VtWvXFk5OTmLmzJmKO5sE0T9gcSXTdP36dfH222+XvYF//PHHirjUaUlJidi6dasIDg4WAETnzp2rpWANHjxYABD16tW75zRC3377rVCpVCZ9xaGDBw+WrQV9/PHHxerVqxVxMFpWVpaYP3++cHd3F5aWloouWP+kuLhYvPjii0Kr1Yp169aVbT9w4ICwsrISAMQnn3xSpc9ZWFgolixZUvYHwfPPP6+YJQRnz54Vr732mkn8wU70D1hcybTdunVLTJs2TTg6OgoLCwsREhIiVq5cKe7cuSM72j1OnDghpk6dKho2bCgAiKCgILFz585qe77U1FRRv379e640dNeiRYuEWq0Wr732miJnJMvr2LFjIiwsTFhYWIg6deqI8ePHi/j4eKPa56KiIrFp0yYxePBgYWVlJaysrMTEiRNN5ivtBykoKBADBw4U1tbWIjY29r6f79ixQzRs2LDazuNcUlIiIiMjRdu2bQUA0bJlSzFjxgyjG/ObN2+KefPmiaeeekoAEG5ubia1RIroIVhcyTzk5eWJqKgo0bt3b2FpaSlq164tRo0aJX766acq+brRUCUlJeLXX38Vs2bNEo8//njZ1as++OADkZqaWiMZHnWRgcjISGFpaSnGjx9vkgc0/dXVq1fF7NmzRZs2bQQA0bRpU/HBBx+IuLg4KWtGc3NzRUxMjHj99deFi4uLUKlUIiAgQHz//fciKyurxvPUpDt37oiePXsKe3t7ER8f/9D71dQFMhISEsSrr74qnJ2dhVqtFoGBgWLhwoU19m/0765cuSKWLVsm+vbtK7RarbCxsREjRowQ27ZtE8XFxVIyEdWwUyohhACRGcnIyMDq1auxatUqJCUlQQiBdu3aITAwEEFBQfD19YWDg0OVPmdJSQlSU1Oxe/du7Nq1C3v37sWtW7dQt25d9OnTByNHjoS/vz9UKlWVPm9lbNq0CYMGDUJoaCiWLVsGS0tL2ZGqXXJyMpYvX46ffvoJFy9ehI2NDfz9/REUFITAwEC0adMGWq32Hx+noKAAOp2uXM95584dHD58GLt27cKuXbuQkJCAoqIitGrVCoMHD8bw4cPh7u5eyT0zfrm5uejbty+OHTuGLVu2oFOnTrIjlSkqKkJMTAxWrFiBrVu3IicnB40aNUJQUBCCgoIQEBAAd3f3Kv/3e+3aNcTHx2PXrl3YvXs3UlNTodPp0LVrVwwfPhyhoaGwtbWt0uckMnKnWVzJrGVlZWHv3r1lpeHUqVMQQsDFxQXe3t5o0aIFvLy84OXlhTp16sDW1hb29vaws7ODjY0NrKyskJmZidzcXOTm5uLOnTvIysrC5cuXcfbsWaSmpiI1NRW///47CgsLYW9vj4CAgLIPvNatWxtVWf27PXv2oE+fPujatSvWrl2LWrVqyY5UY37//feyPzR2796NGzduwMLCAu7u7mjRogW8vb3h5eUFd3d3ODg4wNbWFjY2NrC3t0d0dDS8vb3RrFkzZGVllb0+srKycO7cOaSkpJS9Pi5fvgwA8PDwKHtdBAYGwtXVVfII1JzMzEz06tULFy9exLZt29C6dWvZkR6quLgYiYmJZa+NAwcOID8/H9bW1mXvF3dfH/Xq1YO9vT1q164NW1tb2Nraws7Oruy94u5rIicnBzdv3ix7Tdx9fWRlZUGj0aB9+/Zlrw0/Pz9YWVnJHgYiWVhcif7qxo0bOHbsGFJSUspKZ2pqKq5evWrQ41hZWZV9gHl5ecHb2xstW7ZE27ZtYWFhUU3pq0dSUhJCQkLQtm1bbNiwAbVr15YdqcYJIXDmzBmcOnUKZ8+evef1odfrDXosZ2fnsj+K7r4+2rVrBzc3t2pKb9yuX7+OHj16QK/XY8eOHWjWrJnsSAbJz8/H0aNHcebMGaSmpuLs2bM4c+YM0tLSUFRUVO7HUavVcHd3L3u/uPv6aN++Pezs7KpxD4gUhcWVqDz+/PNPZGdnIzc3F3q9Hnq9Hrm5ucjPzy+bbbt7c3BwgL29PdRqtezYVebo0aPo2bMnPDw8EBMTA0dHR9mRjEZWVhays7PLZtCuXr2KQYMGoXbt2oiKioKjo+M9s7HmWPwf5uLFiwgODoZGo8H27dvRqFEj2ZGqTHFxMbKzs5GdnV32fnHnzh3o9XrY2NiUvSb++k1OeZeXEJkxFlciKp+UlBR0794dLi4uiI2NRd26dWVHMkqLFi3ChAkTUFpair179yIgIEB2JKOUmpqK7t27w9nZGVu3buXriYjK47TpTAkRUbXy9vZGfHw89Ho9AgICcOXKFdmRjNLy5csBAJaWlli1apXkNMbp1KlTCAwMRP369bFjxw6WViIqN864EpFB7q5JzMnJwfbt2xW3JrE6Xb58GW5ubrj7tmpnZ4eMjIxynYnAXCQlJaFXr15o3bo1Nm7cyKUTRGQIzrgSkWHq16+PPXv2wMXFBf7+/jh58qTsSEZj9erV9xx8d/eAI/qvvXv34umnn0bnzp0RExPD0kpEBmNxJSKDOTo6Ytu2bWjatCm6du2KxMRE2ZGMwvLly1FSUlL235aWlli5cqXERMZj8+bN6NWrF5599lmsX7/erE6tRkRVh0sFiKjC/vzzT4SGhiIxMRGbNm2Cn5+f7EjSpKSkoGXLlvdtr1WrFm7evAkbGxsJqYzD6tWrMXLkSLz44otYuHChSZ1xg4hqFJcKEFEleu0AAAAgAElEQVTFWVtbIzo6GkFBQejRowe2bdsmO5I0kZGRD7y6WEFBATZt2iQhkXFYsWIFRowYgfHjx+O7775jaSWiSuE7CBFVilarRVRUFMLCwtC7d2+sX79ediQpVqxY8cATzqvVakREREhIJN/8+fPxwgsv4K233sK3335r1FeJIyJlYHElokqzsLDAkiVL8PLLLyMsLAzLli2THalGJSUl4fz58w/8WUlJCWJjY3H79u0aTiXXrFmz8Nprr2H27NmYOXOm7DhEZCI0sgMQkWlQqVSYO3cudDodXnzxRej1erz22muyY9WIu8sEHnaJTyEE1q9fj7Fjx9ZwsponhMDUqVMxZ84cLFq0CC+99JLsSERkQnhwFhFVuVmzZuHdd9/F559/jilTpsiOU61KS0vh6uqKP/7446H3UavV8PPzw759+2owWc0TQmDSpElYsGABlixZgpEjR8qORESm5TRnXImoyr3zzjuwtbXF66+/jps3b5r0V8X79u17ZGkF/ltu4+PjkZ6ejgYNGtRQsppVUlKCMWPGYPXq1Vi7di1CQ0NlRyIiE8TiSkTVYuLEibC3t8eLL76I3Nxckz04JyUlBYGBgSgtLS3bdvHiReh0OtSvX79sm1qtxrFjx0yyuBYWFuL555/H1q1bER0dje7du8uOREQmiksFiKharVmzBiNGjMCQIUOwZMkSaDSm//dyYGAgHnvsMcyfP192lGp3584d9O/fH4mJidi8eTN8fX1lRyIi08WlAkRUvQYPHozatWtj4MCBKCwsxIoVKx54vlNSnqysLDz77LP4/fffsXv3brRr1052JCIycTwdFhFVu2eeeQYxMTGIiYlBaGgo8vLyZEeiSvrjjz8QGBiI8+fPY+fOnSytRFQjWFyJqEZ07doVO3fuxKFDh9CrVy/k5OTIjkQVdO3aNTz99NPIyspCXFwcWrVqJTsSEZkJFlciqjEdOnTA3r178dtvv+Hpp5/GrVu3ZEciA124cAH+/v4oKSlBfHw8mjZtKjsSEZkRFlciqlE+Pj7YtWsXrl+/jq5du+LatWuyI1E5paSkoEuXLrC3t8e+ffvQsGFD2ZGIyMywuBJRjWvRogXi4+NRWFiIwMBAXL58WXYk+ge//vorAgIC4OnpiV27dsHZ2Vl2JCIyQyyuRCRFkyZNEBcXB51OB39/f/z222+yI9FDxMfHIygoCK1atcKWLVtgb28vOxIRmSkWVyKSpl69etizZw9cXV0REBCA48ePy45Ef7N792706tULAQEB2LJlC2xtbWVHIiIzxuJKRFLVqVMH27dvh4+PD7p164aEhATZkeh/oqOj8cwzz6BPnz5Yv349atWqJTsSEZk5Flciks7W1hYbN25Ep06dEBwcjF27dsmOZPZWrVqFAQMGYNSoUVixYoVZXPGMiIwfiysRGQVra2ts2LABISEh6N27N2JjY2VHMluLFi3CiBEjMHnyZCxYsABqNT8qiMg48N2IiIyGVqvF6tWrMWTIEPTt2xfr1q2THcnsfP7553jllVfw9ttvY+bMmVCpVLIjERGVYXElIqNiYWGB8PBwTJgwAUOGDMHSpUtlRzIbs2bNwr/+9S98+eWXmDlzpuw4RET34aIlIjI6KpUKc+bMgb29PcaMGQO9Xo9JkybJjmWyhBB466238M033yA8PByjR4+WHYmI6IFYXInIaE2fPh1WVlZ44403kJWVhWnTpsmOZHJKSkowfvx4rFixApGRkRg0aJDsSERED8XiSkRG7Z133oG9vT0mTpyIvLw8foVdhYqKijB8+HBs2LABUVFR6Nu3r+xIRESPxOJKREbv5ZdfRu3atTFq1Cjo9XrMmzePR7pXUkFBAYYMGYLt27dj06ZNCA4Olh2JiOgfsbgSkSIMGzYMtWvXxuDBg6HX6/Hjjz/y3KIVdOfOHfTr1w9HjhzBjh078NRTT8mORERULpyyICLF6NOnDzZv3owNGzZg4MCBKCgokB1JcbKystC9e3ecOHECu3fvZmklIkVhcSUiRQkKCsKWLVuwe/duhIaGIi8vT3Ykxbhx4wa6deuGq1evIi4uDm3btpUdiYjIICyuRKQ4/v7+2LVrF5KSkhASEgK9Xi87ktG7dOkSAgICoNfrsXv3bjRv3lx2JCIig7G4EpEitW/fHvv27cO5c+cQFBSEmzdvyo5ktM6fP4/AwEBoNBrEx8fD09NTdiQiogphcSUixWrZsiXi4uKQlZWFrl27Ij09XXYko3P69Gl06dIFjo6O2Lt3Lxo0aCA7EhFRhbG4EpGieXh4IC4uDiqVCl26dEFaWprsSEbjyJEj6Nq1K5o1a4adO3fC2dlZdiQiokphcSUixXN1dcWuXbtgb2+PwMBAnD17VnYk6fbt24egoCB07NgRsbGxsLOzkx2JiKjSWFyJyCS4uLhg9+7daNiwIQICApCcnCw7kjQxMTEICQlBYGAg1q9fDysrK9mRiIiqBIsrEZkMBwcHbN++HW3atEG3bt1w8OBB2ZFq3IYNGxAaGooBAwZg3bp10Ol0siMREVUZFlciMik2NjaIjo5Gt27d0L17d+zYsUN2pBqzcuVKDBw4EGPGjMGyZct4ZTEiMjksrkRkcnQ6HdauXYsBAwbgueeewy+//CI7UrVbuHAhRo4cibfeegvz58+HWs23dyIyPXxnIyKTpNFosGTJEowYMQJhYWGIioqSHanazJo1CxMmTMC0adMwc+ZM2XGIiKoNv0ciIpNlYWGBxYsXw87ODkOHDkVOTg7GjBkjO1aVmj59Oj755BPMnTsXkyZNkh2HiKhasbgSkeJdv34d+fn5D/35a6+9hqKiIowbNw6NGzeGl5dXtebJz89HTk4OLly4UK3PExMTg88++wxfffUV+vbt+8jns7Ozg6OjY7XmISKqbiohhJAdgoioMrp164a9e/fKjmHUXnnlFSxYsEB2DCKiyjjNGVciMgkDBgzA1KlTZccwSq+88orsCEREVYLFlYhMgouLCzp27Cg7hlGqXbu27AhERFWCZxUgIiIiIkVgcSUiIiIiRWBxJSIiIiJFYHElIiIiIkVgcSUiIiIiRWBxJSIiIiJFYHElIiIiIkVgcSUiIiIiRWBxJSIiIiJFYHElIiIiIkVgcSUiIiIiRWBxJSIiIiJFYHElIiIiIkVgcSUiIiIiRWBxJSIiIiJFYHElIiIiIkVgcSUiIiIiRWBxJSIiIiJFYHElIiIiIkVgcSUiIiIiRWBxJSIiIiJFYHElIiIiIkVgcSUiIiIiRWBxJSIiIiJFYHElIiIiIkVgcSUiIiIiRWBxJSIiIiJFYHElIiIiIkVgcSUiIiIiRWBxJSIiIiJFYHElIiIiIkVgcSUiIiIiRWBxJSIiIiJFYHElIiIiIkVgcSUiIiIiRWBxJSIiIiJFYHElIiIiIkVgcSUiIiIiRWBxJSIiIiJFYHElIiIiIkVgcSUiIiIiRWBxJSIiIiJFYHElIiIiIkVgcSUiIiIiRdDIDkBEVBVycnJw4cIF2TEAACdPnkSjRo3g4OAgOwoAID8/X3YEIqIqweJKRCYhIiICERERsmMYrSeeeEJ2BCKiSlMJIYTsEERElZGSkgK9Xi87BgCgtLQUvXr1gpubGxYvXiw7Tpl69erBzc1Ndgwioso4zRlXIlI8b29v2RHK7NixA1lZWcjOzkaDBg3QqFEj2ZGIiEwGD84iIqpCkZGRsLS0hIWFBdasWSM7DhGRSeFSASKiKlJYWAhnZ2fk5ORApVKhdevWSE5Olh2LiMhUnOaMKxFRFdm8eTNyc3MBAEIIHD9+HKmpqZJTERGZDhZXIqIqsnLlSmg0/3/ogFarRWRkpMRERESmhUsFiIiqQE5ODurWrYuCgoJ7tru5uRnN+WWJiBSOSwWIiKrCL7/8gqKiovu2X7x4EUeOHJGQiIjI9LC4EhFVgYiICKhUqvu2c7kAEVHV4VIBIqJKunnzJurXr4+SkpIH/rxu3bq4du0aLCwsajgZEZFJ4VIBIqLKioqKeuTPMzIyEBcXV0NpiIhMF4srEVElrVixAo/68srS0hKrVq2qwURERKaJSwWIiCrh8uXLcHNze2RxBQA7OztkZGRAq9XWUDIiIpPDpQJERJWxevXqfyytAKDX67Ft27YaSEREZLo440pEVAl//PFH2dWy7ho6dCiaN2+Ojz/++J7tderUQZ06dWoyHhGRKTmt+ef7EBHRw7i4uMDFxeWebVZWVrCzs4Onp6ekVEREpolLBYiIiIhIEVhciYiIiEgRWFyJiIiISBFYXImIiIhIEVhciYiIiEgRWFyJiIiISBFYXImIiIhIEVhciYiIiEgRWFyJiIiISBFYXImIiIhIEVhciYiIiEgRWFyJiIiISBFYXImIiIhIEVhciYiIiEgRWFyJiIiISBFYXImIiIhIEVhciYiIiEgRWFyJiIiISBFYXImIiIhIEVhciYiIiEgRWFyJiIiISBFYXImIiIhIEVhciYiIiEgRWFyJiIiISBFYXImIiIhIEVhciYiIiEgRWFyJiIiISBFYXImIiIhIEVhciYiIiEgRWFyJiIiISBE0sgMQEZmC0tJSZGdnAwAKCwuRl5eHzMxMqFQqODg4SE5HRGQaVEIIITsEEZExKC4uxpUrV3D+/Hlcu3YNt27duu+WkZGBW7duIScnBwCQk5OD4uLicj2+TqeDtbU1AKBOnTpwdnaGk5PTfTdnZ2c0bNgQHh4ecHV1hUqlqrZ9JiJSkNMsrkRkVu7cuYNTp04hJSUF58+fx4ULF8puV65cKSuhGo3mgaWybt26cHZ2Ru3atQEAdnZ2sLCwgFqthr29PQBAq9WipKQEJSUlEEIgKysLwH9nYu/cuQMAyMzMxM2bN3Hz5s0HFuS7b806nQ5ubm5wd3cvu3l4eKBly5Zo2bIltFptTQ8hEZEsLK5EZLrS09Nx5MgRnD59GqdOncKRI0eQmpqKkpISaLVaNGrUCJ6ennB1dUWDBg3g6elZdnN3d4daLe8wgMzMTKSlpT3wdunSJRQXF0Oj0cDLyws+Pj547LHH0L59e/j4+MDDw4OztERkilhcicg06PV6HDp0CPv378f+/fuRmJiInJwcqNVqeHp6ok2bNmjdujVat26Ntm3bwtPTU2oxrYyioiKkpKTgxIkTOH78OI4fP44TJ07gypUrAIC6deuic+fO8PPzg6+vLzp06IBatWpJTk1EVGksrkSkTFevXsWePXtw8OBBxMfH4+TJkygpKUGzZs3g6+sLX19fPP744/Dx8YGNjY3suDUiMzMTx48fx9GjR8sK/LVr16DT6dC+fXv4+vqiS5cu8Pf3h6Ojo+y4RESGYnElImUoKSnBsWPHEB0djU2bNuHXX3+FhYUF2rZtCz8/P7Rv3x7dunVDkyZNZEc1Kunp6di/fz/i4+Oxf/9+HD16FCqVCu3atUNwcDCee+45+Pr6Knb2mYjMCosrERmvS5cuISYmBrGxsdi5cydycnLg7e2NXr16ISQkBP7+/rCyspIdU1GysrKwc+dOxMbGIiYmBlevXoWLiwt69uyJkJAQ9OzZE05OTrJjEhE9CIsrERmXy5cvY/369Vi7di0OHDgAKysr+Pr6Ijg4GH379oW3t7fsiCYlLS2tbBZ73759KCkpwVNPPYVBgwbh+eefh4uLi+yIRER3sbgSkXxXr17F2rVrERUVhUOHDsHBwQH9+vVDWFgYAgMDodPpZEc0C3q9HjExMYiKikJMTAyKi4sRHByMsLAw9OvXjxdSICLZWFyJSI7c3FysXr0ay5cvx/79+1G7dm307dsXYWFh6N69O89PKllOTg6io6MRFRWF2NhYCCHQs2dPjBo1Cr1794alpaXsiERkflhciahmJSUlITw8HJGRkSgqKkJoaCiGDBmCnj17cmbVSGVnZ2PDhg2IjIzEtm3b4OLighdeeAFjx45Fs2bNZMcjIvPB4kpE1U+v12P16tVYtGgRfv31V3h7e2PUqFEYM2YMnJ2dZccjA1y9ehURERH47rvvcOHCBbRv3x7jxo3D8OHDyy5nS0RUTVhciaj6pKSkYM6cOYiIiAAAhIWF4aWXXoKvr6/kZFRZJSUliI2Nxffff4/NmzfDwcEB48aNw6uvvgpXV1fZ8YjINLG4ElHV27NnD7788kts2bIFTZs2xRtvvIFhw4bB3t5edjSqBteuXUN4eDjmz5+PrKwsDB06FJMnT0arVq1kRyMi03KaZ5wmoipRWlqK6OhodO7cGYGBgbh27RqWLl2KM2fOYMKECSytJszV1RUffvghLl26hMWLFyMxMRGtW7dGly5dEB0dDc6PEFFVYXElokopLCzEggUL4OHhgdDQUDRu3BgJCQk4fPgwRo4cCQsLC9kRqYZotVqMHDkSJ06cwKZNm6DVatGnTx888cQTWL9+PQssEVUaiysRVUhRURHCw8Ph5eWFyZMno0+fPvjtt98QFRWFjh07yo5HEqlUKjz77LPYtWsXjhw5gubNm2PQoEHo0KEDNm3aJDseESkYiysRGaS0tBRr166Fj48PJkyYgICAAJw+fRrffvstPDw8ZMcjI/PEE08gKioKx48fR9OmTdGnTx889dRTiI6Olh2NiBSIxZWIykUIgTVr1sDHxwdDhw5Fly5dkJqaiuXLl8PT01N2PDJyPj4+iIqKQmJiIhwdHdGnTx8EBARg3759sqMRkYKwuBLRP0pMTISvry+GDh2K9u3b4/Tp01iyZAlnWMlgHTp0wJYtW7B//35otVp07doVAwcORFpamuxoRKQALK5E9FDp6ekYP348OnfuDJ1OhyNHjiAiIgLNmzeXHY0UztfXFzt27MD27duRmpoKb29vTJo0CXq9XnY0IjJiLK5EdJ/CwkJ8/fXX8Pb2RkxMDJYuXYrdu3ejXbt2sqORiQkODsbRo0cxb948REZGomnTpvj6669RUlIiOxoRGSFegICI7vHzzz/jzTffxK1bt/Duu+9i8uTJqFWrluxYZAZu3bqFjz76CIsXL0a7du0wb948dOrUSXYsIjIevAABEf1Xeno6+vfvjwEDBiAgIACpqal47733WFqpxjg5OWH+/Pk4evQo7Ozs4OfnhzfeeAO5ubmyoxGRkWBxJTJzQggsX74cbdq0wbFjxxAbG4vly5ejQYMGsqORmWrVqhV27tyJyMhIrFy5Ei1atMAvv/wiOxYRGQEWVyIzlpaWhh49euDFF1/EgAEDcPz4cfTo0UN2LCIAwKBBg3Dy5Ek8/fTTCA0NRVhYGDIyMmTHIiKJWFyJzFBJSQk+//xztGrVChkZGUhISMCiRYtga2srOxrRPerVq4fly5djw4YNOHjwIHx8fLB69WrZsYhIEhZXIjNz8eJFBAUF4aOPPsKHH36IpKQkdOjQQXYsokfq06cPTp06hQEDBmDo0KEYPnw4srOzZcciohrGswoQmZF169Zh/PjxqFevHlauXInHH39cdiQig23fvh2jRo2CRqPBihUrEBAQIDsSEdUMnlWAyBzo9XqMHz8eYWFhGDhwIA4fPszSSorVvXt3HDt2DO3atUNQUBD+9a9/oaioSHYsIqoBnHElMnEJCQkYPnw49Ho9wsPD0bt3b9mRiKrM8uXLMWHCBDz22GNYuXIlr+pGZNo440pkyhYvXgx/f394enri2LFjLK1kckaOHInDhw+juLgY7du3x7p162RHIqJqxOJKZIJyc3MRFhaGiRMnYsaMGYiNjYWrq6vsWETVwtvbGwcPHsTzzz+PsLAwvPfee7xkLJGJ4lIBIhPz22+/oX///rh+/ToiIyMRHBwsOxJRjYmIiMD48ePx5JNPYs2aNahXr57sSERUdbhUgMiUREdHo2PHjtBqtUhKSmJpJbMzfPhwxMfH49KlS+jQoQMSEhJkRyKiKsTiSmQCSktL8f7776Nv374ICwvDgQMH4O7uLjsWkRSPP/44EhMT4e3tjW7duuHHH3+UHYmIqgiLK5HC5eXlYfDgwfjiiy/w/fffY9GiRdDpdLJjEUnl7OyM2NhYTJo0CaNHj8b7778ProwjUj6N7ABEVHG3bt1CaGgoTp48ia1bt6Jbt26yIxEZDQsLC8ycORPe3t4YN24czp49i+XLl8PKykp2NCKqIB6cRaRQ586dwzPPPIOioiJs3rwZLVu2lB2JyGjt3LkTAwcORMuWLbFhwwbUrVtXdiQiMhwPziJSooMHD6Jz585wcHDAwYMHWVqJ/sHTTz+N+Ph4pKeno3Pnzjh79qzsSERUASyuRAoTFRWFwMBA+Pv7Y8+ePTzdD1E5+fj44ODBg3BwcECXLl2QmJgoOxIRGYjFlUhBfvjhBwwdOhSvvPIK1q5dy7V6RAZydXXF3r170bFjRwQHB2Pv3r2yIxGRAVhciRRi4cKFGDduHKZMmYI5c+ZAreY/X6KKsLGxwS+//IJ+/fqhZ8+e2LBhg+xIRFRO/OQjUoBZs2ZhwoQJmD59OmbOnCk7DpHiaTQaLF26FMOGDUNYWBjWrVsnOxIRlQNPh0Vk5GbNmoV3330Xc+fOxaRJk2THITIZFhYWCA8Ph52dHYYMGYLw8HCMGjVKdiwiegQWVyIjJYTAm2++iXnz5mHJkiX8QCWqBiqVCnPmzIFWq8WYMWNQUFCA8ePHy45FRA/B4kpkpN5++23Mnz8fq1atQlhYmOw4RCZt1qxZsLGxwSuvvAKtVosXX3xRdiQiegAWVyIjNH36dMyZMwfLly9naSWqIR999BEKCwvx0ksvwcrKCkOGDJEdiYj+hsWVyMh8/fXX+OSTT7Bw4UIMGzZMdhwis/LZZ5+hoKAAI0eOhI2NDXr37i07EhH9BYsrkRFZsmQJ3nzzTXz++edcZ0ckyeeff46cnBwMHDgQGzZsQEhIiOxIRPQ/KiGEkB2CiIAVK1Zg1KhR+PTTT/Hee+/JjkNk1kpLSzFy5Ej8/PPPiImJQUBAgOxIRAScZnElMgLR0dEIDQ3F1KlTMWPGDNlxiAhAcXExBg0ahN27dyM+Ph6tWrWSHYnI3LG4Esl2+PBhdOvWDUOHDsXixYtlxyGivygoKECPHj1w4cIFHDp0CK6urrIjEZkzFlcima5evYqnnnoKPj4+2LRpEzQaLjsnMja3b9+Gr68vbGxssHfvXtja2sqORGSuWFyJZNHr9fD390dJSQni4+Ph4OAgOxIRPcT58+fRuXNntG/fHhs2bOAfmURynFbLTkBkjoqKijBw4EBkZGRgy5YtLK1ERs7DwwPR0dHYs2cPJk6cKDsOkdlicSWSYNy4cTh48CA2b96MJk2ayI5DROXw5JNPYtmyZQgPD8dXX30lOw6RWWJxJaphc+bMwYoVK7BmzRo8/vjjsuMQkQEGDhyImTNnYurUqdi2bZvsOERmh2tciWrQgQMH0K1bN3z66ad45513ZMchogoaNWoUoqOjkZSUBE9PT9lxiMwFD84iqinXrl1D+/bt0bFjR/z8889QqVSyIxFRBeXl5cHPzw+lpaU4cOAArK2tZUciMgc8OIuoJhQVFSEsLAy1a9fGsmXLWFqJFM7Kygrr16/HlStXeHlmohrE4kpUA15//XUcO3YM69evh729vew4RFQF3N3d8eOPP2LVqlVYtGiR7DhEZoHFlaiaLVu2DIsWLcKPP/4IHx8f2XGIqAo999xz+OCDDzBp0iQkJCTIjkNk8rjGlaganT17Fk888QQmTJiAzz//XHYcIqoGpaWlePbZZ5Gamopjx47Bzs5OdiQiU8WDs4iqS3FxMbp06YKioiIcPHgQWq1WdiQiqiYZGRlo06YNevTogWXLlsmOQ2SqeHAWUXX58MMPceLECaxatYqllcjE1a1bF0uXLsWKFSsQGRkpOw6RyeKMK1E1iIuLQ2BgIBYsWIBx48bJjkNENeTVV19FREQEkpOT4ebmJjsOkanhUgGiqpaVlYV27dqhXbt2+OWXX2THIaIalJ+fj06dOsHOzg579uyBhYWF7EhEpoRLBYiq2ssvv4zCwkKEh4fLjkJENaxWrVpYvnw5kpKSMGvWLNlxiEwOiytRFVq3bh2ioqLw448/wtnZWXYcIpKgbdu2mDFjBj7++GOcOHFCdhwik8KlAkRVJDs7Gz4+PggJCeFsK5GZKy0tRUBAAIqKinDgwAEuGSCqGlwqQFRVJk+ejJKSEsyePVt2FCKSTK1WIzw8HMnJyZg3b57sOEQmg8WVqArs2bMHS5cuxbx581CnTh3ZcYjICHh7e+Odd97Be++9h7S0NNlxiEwClwoQVVJeXh7atGkDb29vREdHy45DREaksLAQjz/+OJo0aYKYmBjZcYiUjksFiCrro48+wh9//IGFCxfKjkJERkar1eKHH37Atm3bEBERITsOkeJxxpWoEpKTk9GhQwfMmzcP48ePlx2HiIzUxIkTsXbtWqSmpnI5EVHF8QIERJXRo0cP3L59G4mJiVCr+QUGET2YXq9HixYtMHjwYMydO1d2HCKl4lIBoopav349duzYgblz57K0EtEj2dnZ4eOPP8b8+fNx6tQp2XGIFIszrkQVUFhYiFatWqFTp05YsWKF7DhEpAClpaXo2LEj6tSpg+3bt8uOQ6REnHElqogvv/wSV65cwb///W/ZUYhIIdRqNebOnYudO3fyDANEFcQZVyID3bhxA15eXpgyZQo+/PBD2XGISGEGDhyIU6dO4fjx47C0tJQdh0hJOONKZKj33nsPDg4OmDJliuwoRKRAs2fPxoULF7BgwQLZUYgUh8WVyACnT5/GsmXL8J///AdWVlay4xCRAnl4eOCNN97AZ599hpycHNlxiBSFSwWIDBAWFobTp0/j+PHjPJMAEVVYVlYWPDw8MGXKFLz//vuy4xApBZcKEJXXyZMn8dNPP+HTTz9laSWiSnFwcMCkSZPwxRdfIDMzU3YcIsXgjCtROfXr1w+XL1/G4cOHoVKpZMchIoXLzrDChcMAACAASURBVM6Gp6cnXn31VXz88cey4xApAWdcicrjyJEj2LhxIz755BOWViKqEvb29njrrbfw1VdfISMjQ3YcIkXgjCtROfTq1Qs3b95EYmIiiysRVZk7d+7A09MTo0ePxn/+8x/ZcYiMHWdcif7JwYMHERsbixkzZrC0ElGVsrGxwdtvv41vv/2Ws65E5cAZV6J/EBoaiuvXr+PgwYOyoxCRCfrzzz/h5uaGiRMnYvr06bLjEBkzzrgSPcpvv/2GjRs38mIDRFRtrK2tMWHCBHz77be4c+eO7DhERo3FlegR5syZAzc3N/Tr1092FCIyYRMnTkReXh5WrFghOwqRUWNxJXqI27dvY/ny5Zg8eTIsLCxkxyEiE+bi4oIRI0bgq6++Qmlpqew4REaLxZXoIebPnw+tVotRo0bJjkJEZuCtt97CuXPnsHHjRtlRiIwWD84ieoCCggK4u7tjzJgx+Oyzz2THISIz0adPH2RmZiIuLk52FCJjxIOziB5k1apVyMzMxMSJE2VHISIzMmXKFMTHxyMxMVF2FCKjxBlXogd46qmn0KxZM0RERMiOQkRmpl27dujQoQPCw8NlRyEyNpxxJfq748ePIyEhAS+99JLsKERkhsaOHYvVq1dDr9fLjkJkdFhcif5m8eLF8PLyQkBAgOwoRGSGRowYASEEVq9eLTsKkdFhcSX6i7y8PKxatQpjx47l5V2JSAp7e3sMGDAA33//vewoREaHxZXoL9auXYs7d+7ghRdekB2FiMzY2LFjcfjwYRw9elR2FCKjwoOziP7C398frq6uiIqKkh2FiMzcY489hqCgIMybN092FCJjwYOziO5KSUlBfHw8xo4dKzsKERFGjx6NiIgI5OXlyY5CZDRYXIn+JzIyEg0bNkRwcLDsKEREGD58OHJzc7FlyxbZUYiMBosr0f+sXbsWYWFhUKv5z4KI5Ktfvz66du2KNWvWyI5CZDT4CU0EIDk5GWfOnEFYWJjsKEREZcLCwrB582bk5ubKjkJkFFhciQBERUWhcePG6NSpk+woRERlBgwYgMLCQmzevFl2FCKjwOJKhP8uExg8eDDP3UpERsXZ2RlBQUFcLkD0PyyuZPaOHDmC3377jcsEiMgohYWFISYmhpeAJQKLKxHWrl0LDw8PdOjQQXYUIqL7hIaGoqSkBNHR0bKjEEnH4kpmb8OGDejfvz+XCRCRUXJ0dERQUBA2bNggOwqRdCyuZNYuXLiAlJQUPPvss7KjEBE9VEhICHbs2IHi4mLZUYikYnElsxYTEwNbW1v4+vrKjkJE9FC9evVCZmYmEhISZEchkorFlcxaTEwMgoODodPpZEchInqoFi1aoGnTpoiNjZUdhUgqFlcyW4WFhdi9ezdCQkJkRyEi+kc9e/ZETEyM7BhEUrG4ktnat28fcnNzWVyJSBFCQkLw66+/4tq1a7KjEEnD4kpmKzY2Fo899hjc3NxkRyEi+kdBQUHQarXYvn277ChE0rC4ktnatm0bZ1uJSDFsbGzg7++Pbdu2yY5CJA2LK5mlrKwsnDp1Cl27dpUdhYio3AICAhAfHy87BpE0LK5klg4cOAAhBDp37iw7ChFRuXXp0gUXL17E5cuXZUchkoLFlczS/v374eXlhbp168qOQkRUbh07doSlpSUOHDggOwqRFCyuZJb2798PPz8/2TGIiAxiY2ODtm3bYv/+/bKjEEnB4kpmp6ioCElJSSyuRKRIfn5+LK5ktlhcyewcPXoUf/75J4srESmSn58fkpOTkZOTIzsKUY1jcSWzc+DAATg5OcHLy0t2FCIig/n5+aGkpAQJCQmyoxDVOBZXMjtHjhxBx44doVKpZEchIjJYgwYN0LhxYxw5ckR2FKIax+JKZic5ORlt27aVHYOIqMLatGmD48ePy45BVONYXMmsFBYWIjU1Fa1bt5YdhYiowlhcyVyxuJJZOXPmDAoLC9GmTRvZUYiIKqx169ZISUlBQUGB7ChENYrFlczK8ePHodVqeWAWESla69atUVxcjJSUFNlRiGoUiyuZlRMnTqBly5bQarWyoxARVZi3tzd0Oh2XC5DZYXEls3LixAkuEyAixdNoNPD29saJEydkRyGqUSyuZFZOnDiBVq1ayY5BRFRpbdq0YXEls8PiSmYjLy8P6enpXN9KRCahWbNmOHfunOwYRDWKxZXMxoULFyCEgIeHh+woRESV5uHhgYsXL6K0tFR2FKIaw+JKZuPChQsAAHd3d6k5iIiqgru7OwoLC3Ht2jXZUYhqDIsrmY0LFy6gTp06sLe3lx2FiKjS7n57dP78eclJiGoOiyuZjQsXLnC2lYhMRoMGDaDT6cq+TSIyByyuZDbOnz/P9a1EZDLUajUaN27MGVcyKyyuZDY440pEpsbDw4MzrmRWWFzJbFy6dAlubm6yYxARVRl3d3dcvHhRdgyiGsPiSmahtLQUN2/eRL169WRHISKqMi4uLsjIyJAdg6jGsLiSWcjKykJJSQmcnJxkRyEiqjJOTk64efOm7BhENYbFlczC3Td2Z2dnyUmIiKqOs7Mzbt26JTsGUY1hcSWzcPeNnTOuRGRKnJycUFBQgNzcXNlRiGoEiyuZhbvFlTOuRGRK7r6ncdaVzAWLK5mFmzdvwtraGlZWVrKjEBFVmbvFletcyVywuJJZuHXrFmdbDRQcHAwHBwfZMSpEydmNQXh4OFQqFWJjYyv0+yEhIbC1ta3iVFWvsvtpDO4uf+KMK5kLFlcyC1lZWahTp47sGEREVcrOzg4ajQa3b9+WHYWoRrC4klnIz89HrVq1ZMdQlB07diArK8vg37ty5QpUKpXUq/lUNDuR0qhUKuh0OhQUFMiOQlQjWFzJLBQUFECn08mOYRb27NkjOwKRWdFqtSyuZDZYXMksFBYWQqvVyo5RKSEhIWjevDmSk5PRpk0b1KpVCyUlJQCAY8eOoV+/fnBycoJOp4OnpyemTJmC7Ozs+x7n22+/hZeXF3Q6HTw8PDBjxgz88ssvUKlU2LhxY9n9/r5O9Pbt23jzzTfRtGlTWFlZwcXFBc888wwSExPvyThixAgA/72G+l9nucub8VH7WV5/z/7MM8+gWbNmOH78OAIDA2Fra4s6depgxIgRyMnJwZo1a9CuXTtYW1vD09MT33zzzX2PuWvXLgQHB8POzg7W1tZo2bIlZsyY8cDCUN4xNmRcyjP+FfH111+jadOm0Gq1aNKkCd59910UFhY+8L6GvM7+rjzj17VrV9jY2ECv19/3+//5z3+gUqmwbdu2CuUxZD+VRqfTmcy+EP0jQWQGRo0aJZ555hnZMSqlT58+wtXVVfj7+4sPPvhALFy4UJSWloqkpCRhZWUlevfuLVJSUkROTo6Ijo4WLi4uomPHjqKoqKjsMRYsWCAAiMmTJ4urV6+K8+fPi6FDh4qWLVsKACImJqbsvk8//bSwt7cv++/u3buLhg0bigMHDoi8vDyRlpYm+vfvL2xtbUVqamrZ/d566y0BQJw/f75smyEZH7afhvh79r59+wp7e3vh5+cnDh06JHJycsTnn38uAIiuXbuKnj17irS0NJGZmSmGDx8uAIhDhw6V/X5cXJzQaDQiLCxMXL16VeTm5oqIiAihUqnEpEmT7nluQ8bYkHEp7/gb4rvvvhMAxDvvvCNu3Lghrl69Kj788EPRqFGjSmXt2bOnsLGxMXj8IiIiBADx3Xff3Ze1TZs2okmTJqKkpMTgPIbspxI1adJEfPHFF7JjENWEUyyuZBaGDh0q+vXrJztGpfTt21doNJr7PqD8/f1Fw4YNRX5+/j3bf/jhBwFArFy5smybp6encHd3L/vwF0KIwsJC4e7u/sjimpeXJ9RqtRg7duw9z5GdnS2cnJzEN998U7btQcXVkIwP209DPKi4AhCbNm0q21ZUVCRsbW2FpaWlSE9PL9t+4sQJAUDMmDGjbNuUKVOEra2tuHjx4j3P061bt3ueRwjDxri842LI+BuiadOm92UVQohOnTpVOKsQ9xfX8o5ffn6+cHJyEh07drznfmfOnBEAxLRp0yqUx5D9VKLmzZuLf//737JjENWEU1wqQGbBVNa4FhcXY/DgwWX/rdfrsX//fgQGBt63fyEhIQCAhISEsvumpaXB398favX//9O3tLRE//79H/m8Wq0WLi4u+OWXX/Dzzz+jqKgIwH+PaL558yZee+21h/6uIRkftp9VpUuXLmX/W6PRwNHREe7u7nB1dS3bXq9ePQDA9evXy7bNnj0bOTk5aNKkyT2P5+HhgezsbGRmZgIwbIwNGZfKjP/D/PHHHzh37hx8fX3vyQoAPXr0qHDWBynv+Ol0OowcORKJiYk4efJk2f0iIyOhUqnw4osvGpzHkP1UKq1Wy6UCZDZYXMksmMIaV+C/RxD/tWSlp6ejtLQUERERUKlU99waNmwIALh8+TKA/y9iLi4u9z1u8+bNH/m8arUa0dHRcHR0RP/+/eHg4IDg4GB88cUX/3gaHkMyPmw/q4KFhQXs7e3vex5HR8f7tgG4Z11tfn4+vvrqK/j5+cHV1RU6nQ4ajQZLly69576GjLEh41KZ8X+Yu1nr1q1738/+PvYV+f/wr8o7fgAwbtw4AMCSJUvKtq1ZswbBwcFwc3MzOI8h+6lUPKsAmRMWVzILRUVF0Gg0smNUmlqthoWFxX3bx44dCyHEA2/r168HAOTl5QH4/2L2Vw/a9ncdOnRASkoK4uLiMHnyZOj1erz99tto3rw5jh49+o+/X56M/7SfsgwePBhTpkxBjx49EB8fj9u3byM/Px+jR4++534VGePyjktlx/9hHpSrtLS0Uln/rrzjBwDe3t4ICAhAREQEiouLcfToUaSmpj7wvobkMWQ/lcbS0pIzrmQ2WFzJLFhaWqK4uFh2jCrXqFEjqNVqXLx48R/v+6hrmqelpZXr+VQqFbp06YJPP/0UiYmJOHDgAPR6PT7++OMqyWiM0tPTsXHjRgwePBjTpk1D06ZNYWNjA41Gc98+GTLGFRmXioz/w9ydgXxQ1r/Pnlbm/0NDxu+u8ePHIyMjA9u3b8eqVavg6OiI0NDQCuUxZD+VqqioyCS+USIqDxZXMgumugbM1tYW/v7+2LNnzz1rMgEgLi4Ojz32GA4fPgwAaNiwIerXr49Dhw7dc7+ioiKsW7fukc+zd+9eNGrUCMnJyfds79y5M1xdXe8pBXfXEQohDM5ojO5+Bfv3SwafOXMGe/fuBfD/+2rIGBsyLoaMf3m5urqiUaNGOHDgQFn+u7Zu3VrhrH9nyPjdNWDAADg5OSEiIgKrVq3CsGHD7lnLakgeQ/ZTqQoKClhcyWywuJJZMNXiCgCzZs2ChYUFnnvuOaSkpCA/Px979uzByJEjodPp0KpVq7L7vvLKKzhz5gzeffddZGRk4OLFixgyZMh9az//7sknn4RGo8ELL7yAhIQE5Ofn4/bt2/jqq69w+fJljBkzpuy+d9cY3r1fcXGxQRmNjZubGzw9PfHzzz/j5MmTyM/Px5YtW9C/f38MGjQIAJCUlFS2TtOQMS7vuBgy/oZ4/fXXce7cOUydOhUZGRm4cuUKpk6d+sB1sxX9/9DQ8QP+u2bzhRdewOrVq5Genv7A/TMkjyH7qUSFhYUmcfApUblU82kLiIzCqFGjxLPPPis7RqX07dtXWFhYPPBnR44cEX379hWOjo5Co9GIRo0aibfeekvcunXrnvsVFxeLd999VzRo0EDodDrh7e0t5s+fL5YuXSoAiNjY2LL7/v2UUpcuXRKjR48WjRs3FlqtVjg7O4suXbqINWvW3PMct27dEv7+/sLS0lI4OTmVnQKpvBkftZ/l9aDTYT3oMd3c3ESnTp3u2ZaRkSEAiIkTJ5ZtO3bsmOjatauwtbUVDg4OolevXiI5OVmcO3dOeHt7C41GI95//30hhGFjbMi4lHf8DVFaWio+/fRT0aRJE6HRaETDhg3FlClTxOrVqwUAsWHDhgpl/fvpsAwZv7tSUlIEAPHEE088NH958xi6n0rTpEkTMXv2bNkxiGrCKZUQf/vuhMgEjR8/Hmlpadi+fbvsKEbpyy+/xJQpU3DgwAF07txZdhyTxDE2zMmTJ9G6dWuEh4dXeEbZXLi6uuK9996r0GnRiBTmNJcKkFngJRH/a9myZRg2bBjy8/Pv2Z6UlAStVgsfHx9JyUwHx7hqzJ49G/Xr18ewYcNkRzF6pnKeaqLyUP75gYjKwZTXuBrC3t4ekZGR0Ol0mDFjBqytrbFmzRqsXbsWr7/+Ouzs7GRHVLz/a+9eg7IsEz+O/xBBBUUNO6ijIXkK5PGARgh2UFwPqWkrppKMJ2zdLU0saZqaDq6zWWFa6qaytpKmYjiSeao0VBA1rBB9wsOG4a6tIamgAoE8/xf/1WlL1wPI9TzP/f3MMPbCF195QT8urvuGz/HNu3jxosrLy7Vo0SIlJycrJSVF9evXN53l9LjjCivhxBWWUL9+/cvv2LSyoUOHau3atTp06JA6duyo22+/XXPnztXrr7+uxMRE03lXtHnz5t+8ZP5qH/fff7/pXGOfY1f7PF3J6tWr1ahRI82ZM0cffPDB5Ye3cHUOh4MTV1gKd1xhCYmJiXrnnXdc9l2iAHAlZ8+eVZMmTbRlyxa3+RW2wP/AHVdYg7+/v06dOmU6AwBq1KV3+Pr7+xsuAWoHwxWW0KxZM124cIHrAgDcyqVvyH/9Cx4Ad8VwhSVcOo3g1BWAO7n0NY0TV1gFwxWWcOmL+s38akwAcFZFRUWqV6+eGjZsaDoFqBUMV1jCpR+jceIKwJ2cOnWK01ZYCsMVltCkSRN5enpy4grArRQVFXG/FZbCcIUl1KlTR/7+/vrxxx9NpwBAjSksLOTEFZbCcIVltGrVSgUFBaYzAKDGfP/997r77rtNZwC1huEKy2jTpo3y8/NNZwBAjcnPz1ebNm1MZwC1huEKywgICNCxY8dMZwBAjXA4HCooKFBAQIDpFKDWMFxhGQxXAO7kxIkTKisr48QVlsJwhWUEBASoqKhIZ8+eNZ0CANV26RtxTlxhJQxXWMalU4nvv//ecAkAVF9+fr68vLzUokUL0ylArWG4wjLatGkjDw8PrgsAcAvHjh3T3XffLU9PT9MpQK1huMIyGjRooLvuukuHDx82nQIA1XbkyBEFBgaazgBqFcMVlhISEqLc3FzTGQBQbfv375fNZjOdAdQqhissxWazMVwBuLzKykrl5eUpJCTEdApQqxiusJSQkBDZ7XZVVFSYTgGAm3b48GGVlZVx4grLYbjCUmw2m8rLy7nnCsCl7d+/X3Xr1tW9995rOgWoVQxXWEpQUJC8vb25LgDApeXm5qpDhw6qV6+e6RSgVjFcYSne3t5q3749wxWAS+PBLFgVwxWWExISov3795vOAICbduDAAXXq1Ml0BlDrGK6wnNDQUO3du1cOh8N0CgDcsJMnT+rYsWMKDQ01nQLUOoYrLCciIkI//vijjh49ajoFAG5YRkaGPD09df/995tOAWodwxWWExoaKh8fH2VmZppOAYAblpmZqZCQEDVu3Nh0ClDrGK6wHC8vL4WGhjJcAbikzMxMRUZGms4AjGC4wpIiIiIYrgBcTmlpqb755htFRESYTgGMYLjCkiIiIpSXl6dTp06ZTgGA67Znzx79/PPPDFdYFsMVlhQRESEPDw/t3r3bdAoAXLfMzEy1bNlSrVq1Mp0CGMFwhSU1bdpUHTt21I4dO0ynAMB127lzp3r16mU6AzCG4QrL6tu3rzZv3mw6AwCuS2lpqXbs2KHf/e53plMAYxiusKwBAwYoNzdXBQUFplMA4JrS09NVVlamfv36mU4BjGG4wrIefPBB+fj46NNPPzWdAgDXtGnTJnXu3FktWrQwnQIYw3CFZdWvX18PPfQQ1wUAuIRNmzapf//+pjMAoxiusLT+/fvrs88+U0VFhekUALiq/Px8HT16VAMGDDCdAhjFcIWlPfLIIyouLlZWVpbpFAC4qg0bNsjPz0/h4eGmUwCjGK6wtMDAQLVr104bN240nQIAV7Vp0yZFRUXJy8vLdApgFMMVljdkyBCtXbvWdAYAXNGZM2e0detWDRkyxHQKYBzDFZY3YsQIHTlyRF999ZXpFAD4jXXr1kmShg4dargEMI/hCsu77777dM899yglJcV0CgD8RkpKivr166fGjRubTgGMY7gCkoYPH66UlBQ5HA7TKQBw2enTp7V161Y9/vjjplMAp8BwBfT/1wXy8/OVnZ1tOgUALktNTVWdOnU0aNAg0ymAU2C4ApK6deumdu3acV0AgFNJSUnRwIED5efnZzoFcAoMV+A/oqOjuS4AwGkUFhbqiy++0IgRI0ynAE6D4Qr8x6hRo1RQUKD09HTTKQCgDz/8UA0aNOCaAPALDFfgPzp16qSwsDAlJSWZTgEAvf/++xo1apR8fX1NpwBOg+EK/EJcXJw++ugjFRYWmk4BYGFZWVnKycnRxIkTTacAToXhCvzCyJEjVb9+fa1YscJ0CgALW7JkiWw2m3r06GE6BXAqDFfgF3x9fTVy5EgtWrSIh7QAGHHu3DmtWbNGkyZNMp0COB2GK/ArcXFxysvLU1ZWlukUABa0YsUKXbx4UaNHjzadAjgdDwfHSsBvdOvWTZ07d9b7779vOgWAxXTv3l1BQUFKTk42nQI4GzsnrsAVTJo0SatXr+YhLQC1KisrS/v27eOaAHAVDFfgCmJjY+Xr66sFCxaYTgFgIW+99ZZ69OihyMhI0ymAU2K4Alfg4+OjyZMna+HChSotLTWdA8ACvvvuO6Wlpem5554znQI4LYYrcBVPPfWUzp07xz0zALUiMTFRrVu31rBhw0ynAE6L4QpcxR133KGYmBjNmTNHVVVVpnMAuLGffvpJy5Yt07Rp01S3bl3TOYDTYrgC/8Ozzz6ro0ePav369aZTALix+fPny9vbW+PGjTOdAjg1XocFXMOgQYNUXFysHTt2mE4B4IbKysoUEBCgCRMmaNasWaZzAGfG67CAa5kxY4Z27typ9PR00ykA3NCiRYtUXFysp59+2nQK4PQ4cQWuQ58+fVReXq6MjAzTKQDcSGlpqdq2bauRI0cqMTHRdA7g7DhxBa7HzJkzlZmZqc8++8x0CgA3Mn/+fJ09e1YzZswwnQK4BE5cges0cOBAFRYWau/evfLw8DCdA8DFnTt3Tvfcc4/Gjx+vv/zlL6ZzAFfAiStwvWbOnKl9+/Zp48aNplMAuIF58+bpwoULio+PN50CuAxOXIEbMHToUB0/flzZ2dmcugK4aWfPnlVgYKCeeuopvfrqq6ZzAFfBiStwI1577TV98803Sk1NNZ0CwIXNmTNHDodD06ZNM50CuBROXIEb9MQTTygrK0t2u1316tUznQPAxRw/flwdO3bUyy+/zENZwI3hxBW4UbNnz9bJkyf19ttvm04B4IJmzJihu+66S1OnTjWdArgchitwg1q2bKkZM2Zo1qxZ+uGHH0znAHAhWVlZWr16tebMmcNPbICbwFUB4CaUlpbq3nvvVe/evbV06VLTOQBcQFVVlcLDw9WwYUNt3brVdA7girgqANyMBg0a6PXXX9eyZcv05Zdfms4B4AKWLVumffv2ae7cuaZTAJfFiStQDQ888IAqKyuVmZnJ67EAXFVJSYk6dOigYcOGacGCBaZzAFfFiStQHXPmzNGePXuUnJxsOgWAE3v55ZdVVlbGO1uBauLEFaimKVOmaMWKFbLb7brzzjtN5wBwMl9++aXCw8O1aNEiTZgwwXQO4MrsDFegms6fP6+QkBCFhYVp5cqVpnMAOJHKykrdd9998vPz0xdffMGVIqB6uCoAVJevr68WLFigVatWKS0tzXQOACcye/Zs5eXlKSkpidEK1ABOXIEaEhMTo/T0dNntdjVu3Nh0DgDDjhw5IpvNpldeeUUJCQmmcwB3wFUBoKYUFRUpKChII0aM0Lvvvms6B4BBDodDffv2VWFhobKzs+Xl5WU6CXAHXBUAaoq/v78SExO1cOFC7dixw3QOAIPee+89bd++XUuXLmW0AjWIE1eghg0dOlRff/21cnJy1KRJE9M5AGrZt99+q+7duys+Pl4zZ840nQO4E64KADXt1KlTstlsioiI0Jo1a0znAKhFFRUVioiIkMPh0K5duzhtBWoWVwWAmtasWTMtW7ZMqamp+uCDD0znAKhFL7zwgux2u1asWMFoBW4BTlyBW2TatGlKSkrSV199pXbt2pnOAXCLbd++Xb1791ZSUpLGjRtnOgdwR1wVAG6V8vJyhYWFydvbW5mZmZy+AG7s9OnT6ty5s3r06KHU1FTTOYC74qoAcKvUq1dPy5cvV25uLg9oAG7M4XBcPmFNSkoyXAO4N4YrcAt16tRJc+fO1axZs/TJJ5+YzgFwC8yePVsbN27UihUr1LRpU9M5gFvjqgBQCyZMmKC1a9fqyy+/VNu2bU3nAKghW7duVb9+/ZSYmKipU6eazgHcHXdcgdpQVlamXr16qby8XFlZWfL19TWdBKCaCgoKFBoaqqioKK1cudJ0DmAFDFegtlz6n1zfvn314Ycfms4BUA18MwoYwcNZQG1p3bq1Vq1apZSUFM2bN890DoBqeOqpp3To0CGlpKQwWoFaxHAFalGfPn302muv6bnnntO2bdtM5wC4CQsWLNDSpUu1fPlydezY0XQOYClcFQBqmcPh0MiRI/Xpp58qMzNTQUFBppMAXKcNGzbo0Ucf1SuvvKIXX3zRdA5gNdxxBUwoKytTVFSU/vWvfykrK0t33XWX6SQA1/D111/rgQceUHR0tJYuXWo6B7AihitgSlFRkXr27KlGjRpp+/bt3JMDnNiJEycUFhamtm3basuWLfL29jadBFgRwxUw6bvvvlN4eLh69OihtLQ0eXp6mk4C8CslJSXq1auXKioqlJmZqSZNmphOAqyKms67DAAADRtJREFUtwoAJgUGBmrt2rXaunWrpk+fbjoHwK9UVFRo+PDh+vHHH7Vp0yZGK2BYXdMBgNVFRERo2bJlGjVqlO644w698MILppMASKqqqtLYsWO1a9cupaenq3Xr1qaTAMtjuAJOYMSIETp37pwmTpwob29vPfvss6aTAEtzOBz64x//qI8++khpaWkKDQ01nQRADFfAaYwfP17FxcWKj4+Xn5+fJk2aZDoJsKyEhAQtXbpUqamp6t+/v+kcAP/BcAWcyDPPPKPTp09r8uTJatiwoUaPHm06CbCcl156SXPmzNHy5cs1ePBg0zkAfoHhCjiZV199VWVlZYqNjZWXl5eio6NNJwGWMXfuXM2aNUuLFi3SyJEjTecA+BWGK+CEXn/9dZ09e1ZjxoyRj4+PHnnkEdNJgNt7++23NX36dM2bN09xcXGmcwBcAa/DApyQh4eHFi5cqJiYGD322GNas2aN6STArc2aNUvTp0/Xm2++qaefftp0DoCr4MQVcFJ16tRRUlKSGjdurFGjRqmkpETjx483nQW4nZdfflkzZ87U3LlzNWXKFNM5AP4HhivgxDw8PDRnzhzdeeedmjhxokpKSjR16lTTWYBbcDgcio+P17vvvqu//e1vGjdunOkkANfAcAVcQEJCgqT/f+tAcXGxXnrpJcNFgGu7ePGiJk2apOXLl2vVqlUaPny46SQA14HhCriIhIQENWjQQM8884zKy8s1c+ZMeXh4mM4CXE5ZWZnGjBmjDRs2aN26dRowYIDpJADXieEKuJApU6aoUaNGmjRpkgoKCpSUlCRvb2/TWYDLKCoq0tChQ3XgwAFt2rRJDz74oOkkADfAw+FwOExHALgxn3/+uYYPH67g4GClpaWpWbNmppMAp/fdd99p4MCBOnfunDZs2KDOnTubTgJwY+y8DgtwQVFRUcrIyNA///lPhYeH68iRI6aTAKe2e/duhYeHq379+tqzZw+jFXBRDFfARXXq1Em7d+9W48aNFR4eroyMDNNJgFNKTU1V79691a1bN+3cuVMtW7Y0nQTgJjFcARfWvHlzpaenKywsTP369dOqVatMJwFOw+Fw6M9//rOio6MVFxenTz75RI0aNTKdBaAaGK6Ai2vYsKHS0tI0ceJEjRo1SvHx8aqsrDSdBRh19uxZDR06VK+99preeecdzZs3T56enqazAFQTD2cBbmTlypWKi4tTt27dtHr1ajVv3tx0ElDr8vLy9Nhjj+nUqVNatWqVevfubToJQM3g4SzAnYwaNUq7du3SiRMn1L17d2VlZZlOAmrVqlWr1L17d912223KyclhtAJuhuEKuBmbzaavvvpKYWFheuCBBzR79mzTScAtV1lZqeeff16jR49WTEyMtm3bxk8cADfEVQHATTkcDr3xxht64YUXNGzYMC1evFi33Xab6Sygxn3//fd64oknlJ2drYULF2rcuHGmkwDcGlwVANyVh4eHEhIStGXLFmVlZalLly7avn276SygRiUnJ8tms6mkpETZ2dmMVsDNMVwBNxcVFaWDBw8qIiJCDz/8sKZOnaqff/7ZdBZQLcXFxRozZozGjh2rsWPHas+ePQoODjadBeAW46oAYCHJycn605/+pI4dO2r58uXq0KGD6STghu3evVsxMTE6f/68li5dqoEDB5pOAlA7uCoAWElsbKyys7MlSaGhoZo/f76qqqoMVwHXp7S0VAkJCYqMjFRISIgOHDjAaAUshuEKWEyHDh20a9cuTZs2TfHx8erVq5cOHjxoOgv4n7Zt2yabzaZFixbpr3/9q9atW6dmzZqZzgJQyxiugAV5eXlp5syZ2rdvny5evKiuXbvq+eefV3l5uek04L+cOXNGTz75pKKiotSxY0fl5uYqLi7OdBYAQ7jjClhcVVWVkpKSNH36dDVv3lyLFy/WQw89ZDoL0Pr16zV58mRVVlbqjTfeUGxsrOkkAGZxxxWwujp16mjSpEnKzc1VYGCg+vTpo8mTJ+vUqVOm02BRR48e1eDBg/Xoo49qwIABysvLY7QCkMRVAQD/ERAQoM2bN+vvf/+70tLS1L59e82bN08VFRWm02ARxcXFmjFjhoKDg5Wfn69t27ZpyZIlatKkiek0AE6CqwIAfuP8+fN68803NXv2bLVu3VqJiYkaNGiQ6Sy4qaqqKi1fvlwJCQkqLy9XQkKCpk2bJm9vb9NpAJwLVwUA/Javr69eeeUVHT58WGFhYRo8eLD69u3L2wdQ4/bs2aOIiAhNmDBBQ4YM0aFDh5SQkMBoBXBFDFcAV9WqVSslJydr27ZtKiwsVNeuXfWHP/xBx48fN50GF5eTk6OhQ4fq/vvvl5+fn3JycrRo0SLdfvvtptMAODGGK4Brevjhh7Vv3z6999572rx5s9q1a6cpU6bohx9+MJ0GF2O32zVixAh17dpVx48f18aNG7VlyxYFBQWZTgPgAhiuAK6Lp6enxo8fryNHjmjx4sX65JNPFBAQoCeffJIBi2vKz8/Xk08+KZvNJrvdrtWrVys7O1sDBgwwnQbAhTBcAdwQLy8vxcbGym6364033tDHH3+s9u3b6/nnn2fA4je+/fZbjRs3Tu3bt9eOHTu0YsUK7d+/X9HR0fLw8DCdB8DF8FYBANVy4cIFLViwQImJiTpz5oxiYmIUHx+v4OBg02kwaPv27UpMTNSGDRvUtm1bvfjiixo9erQ8PT1NpwFwXbxVAED1+Pj46LnnnlNBQYEWL16sPXv2qFOnToqMjNT69evF98bWUVVVpfXr16tnz5566KGHdOLECb3//vuy2+0aM2YMoxVAtTFcAdQIb29vxcbGKjc3V+vXr5eXl5eGDBmi7t27a/ny5SorKzOdiFvkzJkzmjdvntq2bathw4apZcuW2r17t7KzsxUbG8tgBVBjuCoA4JbZt2+f3nrrLaWmpqpRo0Z64oknFBcXp06dOplOQzU5HA7t3LlTSUlJ+uijj+Tp6amxY8dq2rRpCgwMNJ0HwD3ZGa4AbrmTJ09q1apVWrJkiQ4ePKjQ0FBNmjRJo0ePVsOGDU3n4QacPn1aa9as0fz585Wbm6vQ0FCNGTNGsbGxatq0qek8AO6N4Qqg9jgcDqWnp2vJkiVau3at6tWrpxEjRmjUqFF68MEH+ZGykyotLdWmTZu0cuVKffzxx/Lx8VFMTIwmTpyoLl26mM4DYB0MVwBmFBUV6YMPPlBycrK+/vpr3XnnnRo+fLhGjBihyMhI1anDFXyTysvLtWXLFqWkpOjjjz/WhQsX1KtXL40bN07R0dFq0KCB6UQA1sNwBWDe4cOHlZKSopSUFOXm5qpFixaXR2x4eDgjtpaUl5dr69atSklJ0bp161RSUqKePXvq8ccf1+9//3s1b97cdCIAa2O4AnAu+fn5SklJ0bJly/Ttt9/K399fvXv3VlRUlAYNGqQWLVqYTnQr+fn5+uyzz/T5559ry5YtKi4uVlBQkKKjoxUbG8uDVgCcCcMVgPOy2+3auHGjNm/erIyMDFVUVKhbt27q37+/BgwYoLCwMO7F3qDS0lLt2LFDmzZt0ubNm3Xo0CE1atRIffr0Uf/+/TVw4EC1atXKdCYAXAnDFYBruHDhgnbt2qXPP/9caWlpysvLk6+vr7p06aLIyEhFREQoMjKSJ9t/pbi4WHv37lVGRoYyMzOVkZGhsrIyBQYGatCgQRo8eLB69eqlevXqmU4FgGthuAJwTXl5edqxY4cyMzOVmZmpf/zjH/L09JTNZlNERIR69uypLl26qF27dqpbt67p3FpRXl6ugwcP6ptvvlFGRoZ27dqlQ4cOqU6dOgoODlZkZKR69uyphx9+WC1btjSdCwA3iuEKwD2cPHlSe/fuvXyqmJ2drfLycnl5ealdu3YKDg5WUFCQQkNDFRwc7PJ3N0+cOCG73a6DBw9q3759stvtOnDggMrLy+Xj46OuXbsqNDRUkZGR6t27t/z9/U0nA0B1MVwBuKfy8nLZ7Xbl5uYqNzdXOTk5ys3N1b///W9Jkr+/vwICAtSmTRsFBAT813+3adPG+Ouezp49q2PHjik/P/83f+bn5+vcuXOSpICAANlsNoWEhMhms8lms6lt27aWOWUGYCkMVwDWUlhYqJycHB06dOjyGLw0CH/66afLf69p06Zq1qyZ/P39L/956aNZs2aX79LWq1dPPj4+kiQ/Pz95enrK09NTFy9elCT9/PPPOn/+vCSppKRElZWVqqqqUlFR0W8+Tp06pcLCQhUVFamkpORyS/PmzS+P60vDOigoSCEhIfLz86utTx0AmMZwBYBLiouLLw/ZEydOXHFcXvo4ffq0bvbLZ926ddW0adP/GsO/HMXNmjVTixYtLo/U+vXr1/C/FABcEsMVAKrjlyeqxcXFunjxoioqKuTp6ak6derI29tbvr6+kqRGjRrxI3wAuHkMVwAAALgEO79HEQAAAC6B4QoAAACXUFfSd6YjAAAAgGv45/8BMW77EPFoOYsAAAAASUVORK5CYII=\n"
+          },
+          "metadata": {},
+          "execution_count": 5
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Perform Computation\n",
+        "\n",
+        "output_result = compute(*result)"
+      ],
+      "metadata": {
+        "id": "u8-c4ggSeOmF"
+      },
+      "execution_count": 8,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "#cluster.close()"
+      ],
+      "metadata": {
+        "id": "2a3YI46ArcRN"
+      },
+      "execution_count": 204,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Write the meshes as vtk files\n",
+        "\n",
+        "m1 = itk.mesh_from_dict(output_result[0])\n",
+        "m2 = itk.mesh_from_dict(output_result[1])\n",
+        "\n",
+        "itk.meshwrite(m1, 'm1.vtk')\n",
+        "itk.meshwrite(m2, 'm2.vtk')"
+      ],
+      "metadata": {
+        "id": "4ZdlKUlBfKy1"
+      },
+      "execution_count": 9,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Read the meshes for viewing\n",
+        "\n",
+        "v1 = vtk.vtkPolyDataReader()\n",
+        "v1.SetFileName('m1.vtk')\n",
+        "v1.Update()\n",
+        "m1 = v1.GetOutput()\n",
+        "\n",
+        "v2 = vtk.vtkPolyDataReader()\n",
+        "v2.SetFileName('m2.vtk')\n",
+        "v2.Update()\n",
+        "m2 = v2.GetOutput()"
+      ],
+      "metadata": {
+        "id": "XQu5lxJ5fS0-"
+      },
+      "execution_count": 10,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Visualize the meshes\n",
+        "\n",
+        "from google.colab import output\n",
+        "output.enable_custom_widget_manager()\n",
+        "\n",
+        "itkwidgets.view(geometries=[m1, m2])\n"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 717,
+          "referenced_widgets": [
+            "c7aa7935d75b439d838123e4587eafc4",
+            "db828dcbb20a483ca4564508b383d739"
+          ]
+        },
+        "id": "0Yueld1HfnY1",
+        "outputId": "b7385d7a-f766-460a-8b36-955e276b949a"
+      },
+      "execution_count": 11,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "Viewer(geometries=[{'vtkClass': 'vtkPolyData', 'points': {'vtkClass': 'vtkPoints', 'name': '_points', 'numberO…"
+            ],
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "c7aa7935d75b439d838123e4587eafc4"
+            }
+          },
+          "metadata": {
+            "application/vnd.jupyter.widget-view+json": {
+              "colab": {
+                "custom_widget_manager": {
+                  "url": "https://ssl.gstatic.com/colaboratory-static/widgets/colab-cdn-widget-manager/a8874ba6619b6106/manager.min.js"
+                }
+              }
+            }
           }
-         ],
-         "vtkClass": "vtkDataSetAttributes"
-        },
-        "metadata": {
-         "name": "Geometry 0"
-        },
-        "pointData": {
-         "activeScalars": 0,
-         "arrays": [
-          {
-           "data": {
-            "dataType": "Float64Array",
-            "name": "PointScalarData",
-            "numberOfComponents": 1,
-            "size": 16588,
-            "vtkClass": "vtkDataArray"
-           }
-          }
-         ],
-         "vtkClass": "vtkDataSetAttributes"
-        },
-        "points": {
-         "dataType": "Float32Array",
-         "name": "_points",
-         "numberOfComponents": 3,
-         "size": 49761,
-         "vtkClass": "vtkPoints"
-        },
-        "polys": {
-         "dataType": "Uint32Array",
-         "name": "_polys",
-         "numberOfComponents": 1,
-         "size": 128896,
-         "vtkClass": "vtkCellArray"
-        },
-        "vtkClass": "vtkPolyData"
-       }
-      ],
-      "geometry_colors": {
-       "dtype": "float32",
-       "shape": [
-        1,
-        3
-       ]
-      },
-      "geometry_opacities": {
-       "dtype": "float32",
-       "shape": [
-        1
-       ]
-      },
-      "gradient_opacity": 0.22,
-      "interpolation": true,
-      "label_image_blend": 0.5,
-      "label_image_names": null,
-      "label_image_weights": null,
-      "layout": "IPY_MODEL_4193a5dee9b243b899733baac0bc46be",
-      "lut": "glasbey",
-      "mode": "v",
-      "opacity_gaussians": null,
-      "point_set_colors": {
-       "dtype": "float32",
-       "shape": [
-        0,
-        3
-       ]
-      },
-      "point_set_opacities": {
-       "dtype": "float32",
-       "shape": [
-        0
-       ]
-      },
-      "point_set_representations": [],
-      "point_set_sizes": {
-       "dtype": "uint8",
-       "shape": [
-        0
-       ]
-      },
-      "point_sets": [],
-      "rendered_image": null,
-      "rendered_label_image": null,
-      "roi": {
-       "dtype": "float64",
-       "shape": [
-        2,
-        3
-       ]
-      },
-      "rotate": false,
-      "sample_distance": 0.25,
-      "select_roi": false,
-      "shadow": true,
-      "slicing_planes": false,
-      "ui_collapsed": false,
-      "units": "",
-      "vmax": null,
-      "vmin": null,
-      "x_slice": null,
-      "y_slice": null,
-      "z_slice": null
-     }
-    },
-    "bf2ddee8d91e41698fda46f6fea7de6b": {
-     "model_module": "@jupyter-widgets/controls",
-     "model_module_version": "1.5.0",
-     "model_name": "ButtonModel",
-     "state": {
-      "_dom_classes": [],
-      "_model_module": "@jupyter-widgets/controls",
-      "_model_module_version": "1.5.0",
-      "_model_name": "ButtonModel",
-      "_view_count": null,
-      "_view_module": "@jupyter-widgets/controls",
-      "_view_module_version": "1.5.0",
-      "_view_name": "ButtonView",
-      "button_style": "",
-      "description": "Adapt",
-      "disabled": false,
-      "icon": "",
-      "layout": "IPY_MODEL_c9d8794770314d9f9477af9179f02cee",
-      "style": "IPY_MODEL_8230507bb71d4e8fb7f1a79cf5e31036",
-      "tooltip": ""
-     }
-    },
-    "c511b4eef0e74cd98b84c8c4e9b2cda5": {
-     "model_module": "@jupyter-widgets/base",
-     "model_module_version": "1.2.0",
-     "model_name": "LayoutModel",
-     "state": {
-      "_model_module": "@jupyter-widgets/base",
-      "_model_module_version": "1.2.0",
-      "_model_name": "LayoutModel",
-      "_view_count": null,
-      "_view_module": "@jupyter-widgets/base",
-      "_view_module_version": "1.2.0",
-      "_view_name": "LayoutView",
-      "align_content": null,
-      "align_items": null,
-      "align_self": null,
-      "border": null,
-      "bottom": null,
-      "display": null,
-      "flex": null,
-      "flex_flow": null,
-      "grid_area": null,
-      "grid_auto_columns": null,
-      "grid_auto_flow": null,
-      "grid_auto_rows": null,
-      "grid_column": null,
-      "grid_gap": null,
-      "grid_row": null,
-      "grid_template_areas": null,
-      "grid_template_columns": null,
-      "grid_template_rows": null,
-      "height": null,
-      "justify_content": null,
-      "justify_items": null,
-      "left": null,
-      "margin": null,
-      "max_height": null,
-      "max_width": null,
-      "min_height": null,
-      "min_width": null,
-      "object_fit": null,
-      "object_position": null,
-      "order": null,
-      "overflow": null,
-      "overflow_x": null,
-      "overflow_y": null,
-      "padding": null,
-      "right": null,
-      "top": null,
-      "visibility": null,
-      "width": null
-     }
-    },
-    "c9d8794770314d9f9477af9179f02cee": {
-     "model_module": "@jupyter-widgets/base",
-     "model_module_version": "1.2.0",
-     "model_name": "LayoutModel",
-     "state": {
-      "_model_module": "@jupyter-widgets/base",
-      "_model_module_version": "1.2.0",
-      "_model_name": "LayoutModel",
-      "_view_count": null,
-      "_view_module": "@jupyter-widgets/base",
-      "_view_module_version": "1.2.0",
-      "_view_name": "LayoutView",
-      "align_content": null,
-      "align_items": null,
-      "align_self": null,
-      "border": null,
-      "bottom": null,
-      "display": null,
-      "flex": null,
-      "flex_flow": null,
-      "grid_area": null,
-      "grid_auto_columns": null,
-      "grid_auto_flow": null,
-      "grid_auto_rows": null,
-      "grid_column": null,
-      "grid_gap": null,
-      "grid_row": null,
-      "grid_template_areas": null,
-      "grid_template_columns": null,
-      "grid_template_rows": null,
-      "height": null,
-      "justify_content": null,
-      "justify_items": null,
-      "left": null,
-      "margin": null,
-      "max_height": null,
-      "max_width": null,
-      "min_height": null,
-      "min_width": null,
-      "object_fit": null,
-      "object_position": null,
-      "order": null,
-      "overflow": null,
-      "overflow_x": null,
-      "overflow_y": null,
-      "padding": null,
-      "right": null,
-      "top": null,
-      "visibility": null,
-      "width": "150px"
-     }
-    },
-    "e58a8323c0b64d82a5fa75377cf46e50": {
-     "model_module": "@jupyter-widgets/controls",
-     "model_module_version": "1.5.0",
-     "model_name": "DescriptionStyleModel",
-     "state": {
-      "_model_module": "@jupyter-widgets/controls",
-      "_model_module_version": "1.5.0",
-      "_model_name": "DescriptionStyleModel",
-      "_view_count": null,
-      "_view_module": "@jupyter-widgets/base",
-      "_view_module_version": "1.2.0",
-      "_view_name": "StyleView",
-      "description_width": ""
-     }
-    },
-    "e8b95ef0e41c47a4a1144699015e17fd": {
-     "model_module": "@jupyter-widgets/controls",
-     "model_module_version": "1.5.0",
-     "model_name": "IntTextModel",
-     "state": {
-      "_dom_classes": [],
-      "_model_module": "@jupyter-widgets/controls",
-      "_model_module_version": "1.5.0",
-      "_model_name": "IntTextModel",
-      "_view_count": null,
-      "_view_module": "@jupyter-widgets/controls",
-      "_view_module_version": "1.5.0",
-      "_view_name": "IntTextView",
-      "continuous_update": false,
-      "description": "Maximum",
-      "description_tooltip": null,
-      "disabled": false,
-      "layout": "IPY_MODEL_c9d8794770314d9f9477af9179f02cee",
-      "step": 1,
-      "style": "IPY_MODEL_5c3a8f89501747de8a2d87347077af33",
-      "value": 0
-     }
-    },
-    "ef35542d83fd4a6eb38d062367658a23": {
-     "model_module": "@jupyter-widgets/controls",
-     "model_module_version": "1.5.0",
-     "model_name": "TabModel",
-     "state": {
-      "_dom_classes": [],
-      "_model_module": "@jupyter-widgets/controls",
-      "_model_module_version": "1.5.0",
-      "_model_name": "TabModel",
-      "_titles": {
-       "0": "Status",
-       "1": "Scaling"
-      },
-      "_view_count": null,
-      "_view_module": "@jupyter-widgets/controls",
-      "_view_module_version": "1.5.0",
-      "_view_name": "TabView",
-      "box_style": "",
-      "children": [
-       "IPY_MODEL_7c6a6eaedaf1455e9e4ce6e9bb2fc7b2",
-       "IPY_MODEL_35f0646f5ded451d99e92a7c74e9486e"
-      ],
-      "layout": "IPY_MODEL_04433edc426a4ba99ba1d3a937f42d15",
-      "selected_index": 0
-     }
+        }
+      ]
     }
-   }
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 1
+  ]
 }

--- a/notebooks/FullDemo.ipynb
+++ b/notebooks/FullDemo.ipynb
@@ -7,7 +7,7 @@
     "id": "view-in-github"
    },
    "source": [
-    "<a href=\"https://colab.research.google.com/github/PranjalSahu/OAI_analysis_2/blob/pranjal3/notebooks/FullDemo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/PranjalSahu/OAI_analysis_2/blob/master/notebooks/FullDemo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/notebooks/coiled_requirements.txt
+++ b/notebooks/coiled_requirements.txt
@@ -2,7 +2,7 @@ itk==5.3rc4
 vtk
 itkwidgets
 icon-registration==0.3.4
-pip install tornado==6.1
+tornado==6.1
 coiled
 torch
 jupyter

--- a/notebooks/coiled_requirements.txt
+++ b/notebooks/coiled_requirements.txt
@@ -1,0 +1,12 @@
+itk==5.3rc4
+vtk
+itkwidgets
+icon-registration==0.3.4
+pip install tornado==6.1
+coiled
+torch
+jupyter
+girder_client
+git+https://github.com/uncbiag/mermaid.git
+git+https://github.com/uncbiag/easyreg.git
+git+https://github.com/PranjalSahu/OAI_analysis_2.git#egg=oai_package

--- a/oai_analysis_2/dask_processing.py
+++ b/oai_analysis_2/dask_processing.py
@@ -1,0 +1,166 @@
+# All Imports
+
+import numpy as np
+
+import os
+os.environ["CUDA_VISIBLE_DEVICES"]=""
+
+
+import coiled
+import dask
+from dask import delayed, compute, visualize
+from dask.distributed import Client, progress, LocalCluster
+
+
+
+@delayed(nout=3)
+def register_images_delayed():
+    import boto3
+    import itk
+    import icon_registration
+    import icon_registration.itk_wrapper as itk_wrapper
+    import icon_registration.pretrained_models as pretrained_models
+    from os.path import exists
+
+    
+    image_A = 'image_preprocessed.nii.gz'
+    image_B = 'atlas_image.nii.gz'
+    if (exists(image_A) and exists(image_B)) == False:
+        s3          = boto3.resource("s3")
+        bucket_name = 'oaisample1'
+        bucket      = s3.Bucket(bucket_name)
+
+        s3.Bucket(bucket_name).download_file(image_A, image_A)
+        s3.Bucket(bucket_name).download_file(image_B, image_B)
+    
+    image_A = itk.imread(image_A, itk.D)
+    image_B = itk.imread(image_B, itk.D)
+
+    model = pretrained_models.OAI_knees_gradICON_model()
+    model.to('cpu')
+
+    # Register the images
+    phi_AB, phi_BA = itk_wrapper.register_pair(model, image_A, image_B)
+    return itk.dict_from_transform(phi_AB), itk.dict_from_image(image_A), itk.dict_from_image(image_B)
+
+
+@delayed
+def deform_probmap_delayed(phi_AB, image_A, image_B, image_type ='FC'):
+    import itk
+    import boto3
+
+    if 1:
+        s3          = boto3.resource("s3")
+        bucket_name = 'oaisample1'
+        bucket      = s3.Bucket(bucket_name)
+        fc_prob_file = str(image_type)+'_probmap.nii.gz'
+        s3.Bucket(bucket_name).download_file(fc_prob_file, fc_prob_file)
+
+    phi_AB1  = itk.transform_from_dict(phi_AB)
+    
+    def set_parameters(phi_AB, phi_AB1):
+        for i in range(len(phi_AB)-1):
+            transform1 = phi_AB1.GetNthTransform(i)
+
+            fp = phi_AB[i+1]['fixedParameters']
+            o1 = transform1.GetFixedParameters()
+            o1.SetSize(fp.shape[0])
+            for j, v in enumerate(fp):
+                o1.SetElement(j, v)
+            transform1.SetFixedParameters(o1)
+
+            p = phi_AB[i+1]['parameters']
+            o2 = transform1.GetParameters()
+            o2.SetSize(p.shape[0])
+            for j, v in enumerate(p):
+                o2.SetElement(j, v)
+            transform1.SetParameters(o2)
+
+    set_parameters(phi_AB, phi_AB1)
+    image_A = itk.image_from_dict(image_A)
+    image_B = itk.image_from_dict(image_B)
+
+    interpolator = itk.LinearInterpolateImageFunction.New(image_A)
+    
+    prob_file = str(image_type)+'_probmap.nii.gz'
+    prob = itk.imread(prob_file, itk.D)
+
+    warped_image = itk.resample_image_filter(prob, 
+       transform=phi_AB1, 
+       interpolator=interpolator,
+       size=itk.size(image_B),
+       output_spacing=itk.spacing(image_B),
+       output_direction=image_B.GetDirection(),
+       output_origin=image_B.GetOrigin()
+    )
+
+    output_dict = itk.dict_from_image(warped_image)
+    return output_dict
+
+@delayed(nout=1)
+def get_thickness(warped_image, mesh_type):
+    import itk
+    import vtk
+    import numpy as np
+    from oai_analysis_2 import mesh_processing as mp
+
+    def get_itk_mesh(vtk_mesh):
+        Dimension = 3
+        PixelType = itk.D
+        
+        # Get points array from VTK mesh
+        points = vtk_mesh.GetPoints().GetData()
+        points_numpy = np.array(points).flatten()#.astype('float32')
+            
+        polys = vtk_mesh.GetPolys().GetData()
+        polys_numpy = np.array(polys).flatten()
+
+        # Triangle Mesh
+        vtk_cells_count = vtk_mesh.GetNumberOfPolys()
+        polys_numpy = np.reshape(polys_numpy, [vtk_cells_count, Dimension+1])
+
+        # Extracting only the points by removing first column that denotes the VTK cell type
+        polys_numpy = polys_numpy[:, 1:]
+        polys_numpy = polys_numpy.flatten().astype(np.uint64)
+
+        # Get point data from VTK mesh to insert in ITK Mesh
+        point_data_numpy = np.array(vtk_mesh.GetPointData().GetScalars())#.astype('float64')
+        
+        # Get cell data from VTK mesh to insert in ITK Mesh
+        cell_data_numpy = np.array(vtk_mesh.GetCellData().GetScalars())#.astype('float64')
+        
+        MeshType = itk.Mesh[PixelType, Dimension]
+        itk_mesh = MeshType.New()
+        
+        itk_mesh.SetPoints(itk.vector_container_from_array(points_numpy))
+        itk_mesh.SetCellsArray(itk.vector_container_from_array(polys_numpy), itk.CommonEnums.CellGeometry_TRIANGLE_CELL)
+        itk_mesh.SetPointData(itk.vector_container_from_array(point_data_numpy))
+        itk_mesh.SetCellData(itk.vector_container_from_array(cell_data_numpy))    
+        return itk_mesh
+
+    warped_image = itk.image_from_dict(warped_image)
+    distance_inner, distance_outer = mp.get_thickness_mesh(warped_image, mesh_type=mesh_type)
+    distance_inner_itk = get_itk_mesh(distance_inner)
+    distance_inner_itk_dict = itk.dict_from_mesh(distance_inner_itk)
+
+    return distance_inner_itk_dict
+
+@delayed(nout=2)
+def segment_image_delayed():
+    from os.path import exists
+    import boto3
+    import itk
+    import oai_analysis_2
+
+    image_A = 'image_preprocessed.nii.gz'
+    if exists(image_A) ==  False:
+        s3          = boto3.resource("s3")
+        bucket_name = 'oaisample1'
+        bucket      = s3.Bucket(bucket_name)
+        s3.Bucket(bucket_name).download_file(image_A, image_A)
+
+    test_volume = itk.imread(image_A)
+    obj = oai_analysis_2.AnalysisObject()
+    FC_prob, TC_prob = obj.segment(test_volume)
+
+    return itk.dict_from_image(FC_prob), itk.dict_from_image(TC_prob)

--- a/oai_analysis_2/utils.py
+++ b/oai_analysis_2/utils.py
@@ -1,5 +1,5 @@
 import pathlib
 def get_data_dir():
-    return str(pathlib.Path(__file__).parents[1] / "data")
+    return "/media/OAI_analysis_2/data"
 
 

--- a/oai_analysis_2/utils.py
+++ b/oai_analysis_2/utils.py
@@ -1,5 +1,5 @@
 import pathlib
 def get_data_dir():
-    return "/media/OAI_analysis_2/data"
+    return str(pathlib.Path(__file__).parents[1] / "data")
 
 


### PR DESCRIPTION
Moved the dask-related methods to the dask_processing module for better readability.
Adding coiled_requirements.txt for future reference.

Two commits have code related to using the segmentation model however, it is removed in later commits as without GPU it is taking around 20 minutes to segment. That code will act as a reference once the GPU cluster is ready. Currently reading the segmented probability map from S3.