### PR TITLE
Pin icon_registration version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ jupyter
 itk
 itkwidgets
 girder_client
-icon_registration
+icon_registration==0.3.4
 git+https://github.com/uncbiag/mermaid.git
 git+https://github.com/uncbiag/easyreg.git


### PR DESCRIPTION
I'm about to push the 1.0.0 release of icon_registration which has breaking changes. Once I do that, I can unpin the version here + make the code compatible with the new version in a second pull request